### PR TITLE
fix: correct agent dashboard data quality issues

### DIFF
--- a/.github/workflows/agent-activity-report.yml
+++ b/.github/workflows/agent-activity-report.yml
@@ -17,7 +17,6 @@ on:
         type: string
 
 env:
-  COPILOT_LOGIN: 'copilot-swe-agent[bot]'
   DEPENDABOT_LOGIN: 'dependabot[bot]'
 
 jobs:
@@ -43,7 +42,6 @@ jobs:
           const reportDate = new Date().toISOString().slice(0, 10);
 
           // ── PRs merged in the window ──────────────────────────────────────
-          const copilotLogin    = process.env.COPILOT_LOGIN;
           const dependabotLogin = process.env.DEPENDABOT_LOGIN;
 
           let page = 1;
@@ -77,7 +75,12 @@ jobs:
             page++;
           }
 
-          const prCopilot    = mergedPRs.filter(pr => pr.user.login === copilotLogin).length;
+          // Bug fix: use case-insensitive login check + branch-prefix detection.
+          // The Copilot coding agent login is 'Copilot' (capital C), not 'copilot-swe-agent[bot]'.
+          const prCopilot    = mergedPRs.filter(pr =>
+            pr.user.login.toLowerCase().includes('copilot') ||
+            (pr.head?.ref || '').startsWith('copilot/')
+          ).length;
           const prDependabot = mergedPRs.filter(pr => pr.user.login === dependabotLogin).length;
           const prHuman      = mergedPRs.length - prCopilot - prDependabot;
 
@@ -107,8 +110,10 @@ jobs:
           const evalFail   = evalRuns.data.workflow_runs.filter(r =>
             r.conclusion === 'failure' || r.conclusion === 'timed_out'
           ).length;
-          const evalPassPct = evalTotal > 0
-            ? ((evalPass / evalTotal) * 100).toFixed(1)
+          // Bug fix: only count runs with a definitive outcome (success/failure).
+          // Using evalTotal (all runs) inflates the denominator with queued/in-progress runs.
+          const evalPassPct = (evalPass + evalFail) > 0
+            ? ((evalPass / (evalPass + evalFail)) * 100).toFixed(1)
             : 'N/A';
 
           // ── Build success rate (jekyll.yml) ───────────────────────────────
@@ -124,8 +129,11 @@ jobs:
           const buildFail    = buildRuns.data.workflow_runs.filter(r =>
             r.conclusion === 'failure' || r.conclusion === 'timed_out'
           ).length;
-          const buildPct = buildTotal > 0
-            ? ((buildSuccess / buildTotal) * 100).toFixed(1)
+          // Bug fix: only count runs with a definitive outcome (success/failure).
+          // Using buildTotal inflates the denominator with queued/cancelled/skipped runs,
+          // causing artificially low success rates when 0 builds have actually failed.
+          const buildPct = (buildSuccess + buildFail) > 0
+            ? ((buildSuccess / (buildSuccess + buildFail)) * 100).toFixed(1)
             : 'N/A';
 
           core.setOutput('report_date',    reportDate);

--- a/dashboard/agents-data.json
+++ b/dashboard/agents-data.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-06T12:55:54.867Z",
+  "generatedAt": "2026-04-06T13:21:51.243Z",
   "kpis": {
-    "agentPRsMerged30d": 13,
+    "agentPRsMerged30d": 11,
     "evalPassRate": 33,
     "contentAvgScore": 87,
-    "openBacklog": 1,
+    "openBacklog": 0,
     "openPRCount": 0,
     "evalCount": 3,
     "remediationQueueDepth": 8,
@@ -101,9 +101,25 @@
       "coverage": 0,
       "freshness": 3
     },
-    "generatedAt": "2026-04-06T12:55:51.548Z"
+    "generatedAt": "2026-04-06T13:21:47.810Z"
   },
   "recentPRs": [
+    {
+      "number": 598,
+      "title": "fix: bump service worker cache version to v2 (mobile nav regression)",
+      "author": "oviney",
+      "mergedAt": "2026-04-06T13:04:35Z",
+      "labels": [],
+      "isAgent": false
+    },
+    {
+      "number": 597,
+      "title": "feat(editorial): content remediation layer",
+      "author": "oviney",
+      "mergedAt": "2026-04-06T12:58:20Z",
+      "labels": [],
+      "isAgent": false
+    },
     {
       "number": 595,
       "title": "feat(observability): agent observability dashboard",
@@ -267,37 +283,11 @@
       "mergedAt": "2026-04-05T04:51:18Z",
       "labels": [],
       "isAgent": false
-    },
-    {
-      "number": 551,
-      "title": "feat: Enhanced analytics — Plausible + Google Search Console support",
-      "author": "Copilot",
-      "mergedAt": "2026-04-05T04:32:37Z",
-      "labels": [
-        "risk:high"
-      ],
-      "isAgent": true
-    },
-    {
-      "number": 550,
-      "title": "Add interactive elements to blog posts: ToC, progress bar, copy code, back-to-top, share buttons, print styles",
-      "author": "Copilot",
-      "mergedAt": "2026-04-05T04:32:34Z",
-      "labels": [
-        "risk:high"
-      ],
-      "isAgent": true
     }
   ],
   "openIssuesByLabel": {
     "agent:creative-director": [],
-    "agent:qa-gatekeeper": [
-      {
-        "number": 596,
-        "title": "Content remediation layer: translate review scores into actionable improvement inputs for the editorial pipeline",
-        "age": 0
-      }
-    ],
+    "agent:qa-gatekeeper": [],
     "agent:editorial-chief": [],
     "agent:editorial-manager": []
   },

--- a/scripts/agent-dashboard-data.js
+++ b/scripts/agent-dashboard-data.js
@@ -79,8 +79,12 @@ function aggregateEvals() {
     .filter(Boolean)
     .sort((a, b) => new Date(b.evaluated_at) - new Date(a.evaluated_at));
 
-  const passRate = evals.length
-    ? Math.round((evals.filter(e => e.all_pass).length / evals.length) * 100)
+  const passed = evals.filter(e => e.all_pass === true).length;
+  const failed = evals.filter(e => e.all_pass === false).length;
+  // Bug fix: use passed+failed as denominator (runs with outcomes), not total evals.
+  // Evals where all_pass is undefined/null (e.g. not yet evaluated) should not dilute the rate.
+  const passRate = (passed + failed) > 0
+    ? Math.round((passed / (passed + failed)) * 100)
     : null;
 
   // Per-dimension pass rates
@@ -242,7 +246,7 @@ function main() {
       openBacklog:          totalBacklog,
       openPRCount:          liveData.openPRCount,
       evalCount:            evals.length,
-      remediationQueueDepth: remediationData?.postsInQueue ?? null,
+      remediationQueueDepth: remediationData?.postsInQueue ?? remediationData?.queue?.length ?? null,
       remediationThreshold:  remediationData?.threshold ?? 85,
     },
     evalDimensions: {


### PR DESCRIPTION
## Summary

Fixes four data quality bugs in the agent observability pipeline reported in #585.

## Bugs Fixed

### Bug 1 — Copilot PR count showed 0 (`agent-activity-report.yml`)
`COPILOT_LOGIN` was set to `'copilot-swe-agent[bot]'` but the actual Copilot coding agent login is `'Copilot'` (capital C). The filter never matched any PRs.

**Fix:** Replace exact-match with case-insensitive `.toLowerCase().includes('copilot')` AND branch-prefix check `head.ref.startsWith('copilot/')`.

### Bug 2 — Eval pass rate showed 24.5% instead of ~85% (`agent-activity-report.yml` + `agent-dashboard-data.js`)
Pass rate used **total runs** (49) as denominator, including queued/in-progress/cancelled runs with no outcome. 12 passed out of 49 = 24.5% — but 35 runs had no conclusion.

**Fix:** Denominator is now `passed + failed` (runs with definitive outcomes), so 12/14 = 85.7%.

### Bug 3 — Build success rate showed 56% with 0 failed (`agent-activity-report.yml`)
Build success rate used **total workflow runs** (100) as denominator, including 44 cancelled/skipped runs. 56 successful / 100 total = 56% — flagged 🔴 despite no actual failures.

**Fix:** Denominator is now `success + failed` only, so 56/56 = 100% when no builds have failed.

### Bug 4 — Remediation queue depth resilience (`scripts/agent-dashboard-data.js`)
The queue depth read `postsInQueue` key exclusively. If that key is absent (e.g. older queue file format), the count silently becomes `null`.

**Fix:** Added fallback to `queue.length` so the count is always derived from the actual array when `postsInQueue` is missing.

## Testing
- `node scripts/agent-dashboard-data.js` runs without errors; KPIs are accurate
- `bundle exec jekyll build` passes ✅
- Pre-commit hooks pass ✅

Closes #585