### PR TITLE
fix: content-review pipeline — labels, write permissions, commit results JSON

### DIFF
--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -39,3 +39,11 @@ jobs:
         run: |
           node scripts/content-review.js --json
           echo "Review complete. JSON results saved to content-review-results.json"
+
+      - name: Commit results JSON
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add content-review-results.json
+          git diff --staged --quiet || git commit -m "chore: update content-review-results.json [skip ci]"
+          git push origin main


### PR DESCRIPTION
## Root Cause

Smoke test (manual `workflow_dispatch`) revealed two bugs causing `content-review.yml` to always exit 1:

### Bug 1: Missing GitHub labels
`scripts/content-review.js` calls `gh issue create --label "content-review"` but that label didn't exist in the repo. This caused `process.exit(1)`, failing the workflow before any issue was created.

**Fix:** Created both missing labels directly in the repo:
- `content-review` — weekly editorial quality report  
- `editorial-improvement` — post flagged for editorial improvement

### Bug 2: `contents: read` permission + no commit step
The workflow couldn't write `content-review-results.json` back to `main`. The `content-remediation.yml` workflow (triggered via `workflow_run`) reads this file — without it, the remediation pipeline has nothing to process.

**Fix:**
- Bumped `permissions.contents` to `write`
- Added a `Commit results JSON` step that commits and pushes `content-review-results.json` with `[skip ci]`

## Impact

Without this fix, `content-remediation.yml` could never trigger (depends on `content-review` succeeding), and `remediation-sync.yml` in economist-agents would always read a stale queue.