### PR TITLE
ci: opt into Node.js 24 for orchestrator (deadline June 2 2026)

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Run orchestrator
         uses: actions/github-script@v7
+        # TODO: upgrade to @v8 when released; FORCE flag below opts into Node 24 ahead of the
+        # June 2 2026 forced migration and silences the deprecation warning.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         env:
           DRY_RUN: ${{ env.DRY_RUN }}
           ORCHESTRATOR_TOKEN: ${{ env.ORCHESTRATOR_TOKEN }}


### PR DESCRIPTION
## Problem
`actions/github-script@v7` runs on Node 20, which GitHub is deprecating on June 2 2026. Every orchestrator run currently logs a warning.

## Fix
Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var on the step to opt in now.

## Notes
- No behaviour change — this is a runtime version bump only
- TODO comment left to upgrade to `@v8` when released

No issue — preventive maintenance.