### PR TITLE
ci: fix orchestrator phantom failures on push to main (closes #650)

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -13,6 +13,8 @@ name: 🤖 CI Orchestrator
 on:
   schedule:
     - cron: '*/15 * * * *'   # every 15 minutes
+  push:
+    branches: [main]          # run on every merge to main; idempotent if nothing to act on
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Problem\nPR #645 (Node.js 24 fix) modified `orchestrator.yml`, causing GitHub to register it as a push-event workflow. Every subsequent push to main triggered it with the `push` event → 0 jobs ran → failure.\n\nSchedule runs (every 15 min) continued working correctly.\n\n## Fix\nAdd explicit `push: branches: [main]` trigger. The orchestrator script is idempotent — if there's nothing to act on it logs "(none)" and exits 0.\n\nCloses #650