### PR TITLE
fix: replace non-existent image in concealed-price-tag post (43 HTML-Proofer failures)

### DIFF
--- a/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
+++ b/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
@@ -4,7 +4,7 @@ title: "The Concealed Price Tag of Test Automation"
 date: 2026-04-06
 author: "The Economist"
 categories: ["Quality Engineering", "Test Automation"]
-image: /assets/images/concealed-price-tag-test-automation.png
+image: /assets/images/testing-tax-shifted-costs.png
 image_alt: "Cold technical blueprint of automation machinery with price-tag labels attached to every component and subsystem, engineering schematic style in white lines on deep navy"
 summary: "Delving into the overlooked financial and operational burdens that undermine test automation’s touted efficiencies."
 ---


### PR DESCRIPTION
## Problem

PR #649 set `image: /assets/images/concealed-price-tag-test-automation.png` in the concealed-price-tag post, but that file was **never created**. The image appears in shared layout components (recent posts sidebar) on every page, causing **43 HTML-Proofer image failures** across the site and blocking CI on main.

## Fix

Replace with `testing-tax-shifted-costs.png` — an existing asset that is thematically appropriate for a post about the hidden costs of test automation.

## Validation
- `bundle exec jekyll build` passes ✅
- Pre-commit hook passes ✅

Closes #658