### PR TITLE
fix: healing monitor artifact path regression from #692

### DIFF
--- a/.github/workflows/healing-monitor.yml
+++ b/.github/workflows/healing-monitor.yml
@@ -237,7 +237,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: playwright-results-chromium
-        path: test-results/
+        path: .
+      continue-on-error: true
 
     - name: 🎯 Run comprehensive healing monitoring
       id: monitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,9 +2368,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem
Healing monitor has been reporting 0% success rate and failing on every push to `main` since #692 merged.

**Root cause:** artifact `playwright-results-chromium` stores files at path `test-results/results.json` internally. Downloading with `path: test-results/` caused double nesting → `test-results/test-results/results.json`. `healing-monitor.js` couldn't find `test-results/results.json`, defaulted to 0/126, and exited 1.

All 3 browser test jobs (chromium, firefox, webkit) were actually passing — this was a **false failure**.

## Fix
- Change `path: test-results/` → `path: .` so the artifact extracts to workspace root
- Add `continue-on-error: true` as defensive measure

## Verification
All 3 healing monitor failures (runs #601–603) had identical log pattern:
```
⚠️ Playwright results file not found, attempting to parse from reporter output
⚠️ No Playwright results available, using defaults
✅ Monitoring complete: 0/126 tests passed (0%)
❌ Critical: Success rate below minimum threshold
```

Closes #704