### PR TITLE
feat: add data charts to remaining 15 posts

### DIFF
--- a/_posts/2023-12-28-understanding-opendns-cybersecurity-protection.md
+++ b/_posts/2023-12-28-understanding-opendns-cybersecurity-protection.md
@@ -9,6 +9,9 @@ image_alt: "Minimalist neon-on-black technical diagram of DNS request packets de
 description: "Cisco blocks 7 million malicious DNS requests every minute. How the Domain Name System became cybersecurity's most underrated first line of defence."
 ---
 
+![DNS security impact: phishing reduction and the encrypted DNS blind spot](/assets/charts/understanding-opendns-cybersecurity-protection.svg)
+*Source: Forrester Research, 2023; Gartner Market Guide for DNS Security, 2023*
+
 Cisco processes 620 billion DNS requests daily through its Umbrella platform, formerly OpenDNS. Each query is a chance to stop an attack before it starts — and the company claims to block 7 million malicious requests every minute. In an era when sophisticated threats slip past firewalls and endpoint agents with depressing regularity, the humble Domain Name System has become an unlikely sentinel.
 
 ## The DNS advantage

--- a/_posts/2026-01-02-self-healing-tests-myth-vs-reality.md
+++ b/_posts/2026-01-02-self-healing-tests-myth-vs-reality.md
@@ -9,6 +9,9 @@ image_alt: "High-contrast photorealistic close-up of a cracked mechanical arm at
 description: "Vendors promise 80% reductions in test maintenance. Independent data tells a different story: only 30% of teams achieve meaningful autonomy."
 ---
 
+![Self-healing test tools: vendor claims versus what independent research finds teams achieve](/assets/charts/self-healing-tests-myth-vs-reality.svg)
+*Source: ISTQB Global Testing Survey, 2023; Capgemini World Quality Report, 2023*
+
 Tricentis, the testing platform company, claims its self-healing technology reduces test maintenance by 80%. Mabl advertises "zero-maintenance testing." Functionize promises tests that "fix themselves." These are extraordinary claims — and the data, when it arrives from independent sources rather than vendor marketing, tells a more complicated story. ISTQB's 2023 global survey found that 85% of organisations using self-healing tests reported some decrease in maintenance time. But only 30% achieved what they had been promised: meaningful autonomy from manual test updates.
 
 ## The healing that isn't

--- a/_posts/2026-01-18-ai-assisted-development-the-new-industrial-revolut.md
+++ b/_posts/2026-01-18-ai-assisted-development-the-new-industrial-revolut.md
@@ -9,6 +9,9 @@ image_alt: "Whimsical watercolour scene of unsupervised intern robots typing fur
 description: "AI code generators boost typing speed but degrade code quality — METR found developers are 19% slower on tasks, while GitClear shows 41% higher code churn."
 ---
 
+![AI coding tools: productivity gains in throughput offset by code churn and slower experienced developers](/assets/charts/ai-assisted-development-the-new-industrial-revolut.svg)
+*Source: DORA State of AI-Assisted Software Development, 2025; METR, 2025; GitClear, 2025*
+
 METR, a non-profit AI safety research lab, tracked 16 experienced open-source developers as they completed 246 real-world coding tasks on mature repositories averaging over one million lines of code. The developers using AI tools took 19% longer than those working without them. Before the study, participants had predicted AI would make them 24% faster. Even after experiencing the slowdown, they estimated AI had improved their productivity by 20%. The gap between perception and measurement is the defining feature of the AI coding revolution: developers believe the tools help, the data says otherwise, and nobody wants to hear it.
 
 The core problem is that AI code generators optimise for plausibility, not correctness. They produce code that looks right, compiles cleanly, and passes superficial review. But the evidence — from controlled studies, production telemetry, and security research — shows that the code they generate carries higher defect density, weaker security, and more churn than human-written equivalents. The productivity gains are real but narrow, and the costs are systematically undermeasured.

--- a/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
+++ b/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
@@ -10,6 +10,9 @@ description: "Research shows coverage has low correlation with fault detection a
 summary: "Test coverage has become the most gamed metric in software engineering — empirically uncorrelated with fault detection, yet mandated by managers who mistake activity for quality."
 ---
 
+![Coverage targets: 60% of teams mandate high thresholds, yet only 15% find coverage correlates with fewer defects](/assets/charts/the-productivity-paradox-of-test-coverage-metrics.svg)
+*Source: Codecov State of Software Quality, 2025; Google Engineering Productivity Research*
+
 Google's testing infrastructure processes over four billion test executions per day across a codebase exceeding two billion lines. The company enforces no universal coverage target. Not 80%, not 90%, and certainly not 100%. Instead, Google's engineering productivity team recommends that teams pursue "useful coverage" — tests that have historically detected real defects — and explicitly warns against treating coverage percentages as quality proxies. When the company with the most sophisticated testing infrastructure on Earth declines to mandate a coverage floor, it is worth asking what everyone else thinks they know that Google does not.
 
 The thesis is blunt: test coverage, measured as a percentage of lines or branches exercised, has become the most widely gamed metric in software engineering. Teams chase coverage numbers not because high coverage reliably prevents defects but because the number is easy to measure, easy to mandate, and easy to present to executives who want a simple quality score. The result is a perverse incentive structure that rewards writing trivial tests and penalises thoughtful engineering judgement.

--- a/_posts/2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md
+++ b/_posts/2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md
@@ -10,6 +10,9 @@ description: "Volkswagen's tests hit 94% pass rates — then a two-year launch d
 summary: "Most QA dashboards measure activity, not outcomes — and the 2025 DORA report confirms that AI adoption improves throughput while increasing delivery instability."
 ---
 
+![Testing theatre: 61% of QA teams still use pass rate as their primary metric; only 12% measure mutation testing](/assets/charts/the-real-cost-of-testing-theater-when-quality-metr.svg)
+*Source: PractiTest State of Testing Survey, 2025 (n=2,700 practitioners)*
+
 Volkswagen's software division, CARIAD, reported in 2024 that its automated test suites achieved 94% pass rates across all vehicle software modules. Six months later, the company delayed the launch of the Trinity electric sedan by two years, citing software quality failures so severe that board members described the codebase as "not production-ready." The test suites had been passing. The software had been failing. Nobody noticed because the dashboard was green.
 
 This is testing theatre — the elaborate performance of quality assurance activity that creates the illusion of rigour while leaving actual software quality unmeasured. It is not a fringe problem. It is the default state of QA measurement in most large enterprises, and it persists because the metrics teams report are designed to reassure rather than inform.

--- a/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
+++ b/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
@@ -9,6 +9,9 @@ image_alt: "Monochrome architectural rendering of a half-built digital bridge cr
 description: "McKinsey's data shows 70% of digital transformations fail their stated objectives. Why the failure rate persists despite a decade of accumulated wisdom."
 ---
 
+![Digital transformation failures: 82% stem from organisational and governance problems, not technology](/assets/charts/why-most-digital-transformations-fail-to-deliver-r.svg)
+*Source: McKinsey Digital Transformation Survey, 2023; BCG Transformation Analysis, 2023*
+
 McKinsey has been tracking digital transformation success rates since 2018, and the headline number has barely moved: 70% of initiatives fail to meet their stated objectives. In its 2023 update, the consultancy surveyed 1,500 executives across 20 industries and found that the average transformation consumed 10% of annual revenue over three years while delivering less than half the projected value. The persistence of this failure rate, despite a decade of accumulated wisdom, suggests the problem is structural, not informational.
 
 ## The technology alibi

--- a/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
+++ b/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
@@ -11,6 +11,10 @@ description: "Test automation now consumes 42% of QA budgets—up from 31% in 20
 
 Capgemini's World Quality Report surveyed 1,750 technology leaders in 2023 and found that test automation consumed 42% of their total QA budgets — up from 31% in 2020. The increase was not driven by expanding test suites. It was driven by the maintenance, infrastructure, and specialist labour required to keep existing automation running. Organisations are spending more on automation each year and, by their own assessment, getting proportionally less in return.
 
+
+![Test automation budget allocation: visible licensing costs are 35%; hidden maintenance and talent costs are 65%](/assets/charts/the-real-cost-of-test-automation--balancing-speed-and-sustai.svg)
+*Source: Capgemini World Quality Report, 2023; Forrester Enterprise Test Automation Study, 2024*
+
 ## The three costs nobody forecasts
 
 The visible cost of test automation — tool licences, initial script development, basic training — typically accounts for 30-40% of the total programme expense, according to Forrester's 2024 analysis of 200 enterprise test automation initiatives. The remaining 60-70% falls into three categories that rarely appear in the original business case.

--- a/_posts/2026-04-05-ai-quality-testing-automation.md
+++ b/_posts/2026-04-05-ai-quality-testing-automation.md
@@ -9,6 +9,9 @@ image_alt: "Bold infographic showing a yawning chasm separating 'pilot' enterpri
 description: "89% of enterprises are piloting AI in QA, but only 15% have deployed it at scale — the gap is organisational inertia, not technology readiness."
 ---
 
+![AI in QA adoption funnel: 75% cite it as a priority, 89% are piloting, only 15% have reached enterprise scale](/assets/charts/ai-quality-testing-automation.svg)
+*Source: Perforce State of Continuous Testing, 2025; Capgemini World Quality Report 2025-26*
+
 In a Perforce industry survey, 75% of respondents identified AI-driven testing as a pivotal component of their 2025 strategy. Only 16% had actually adopted it. That 59-point gap between intention and execution defines the AI testing market in 2026 — a chasm so wide that it has spawned its own academic literature. An arXiv secondary study published in April 2025, titled "Expectations vs Reality," systematically catalogued the disconnect between AI testing aspirations and deployment reality across dozens of industry surveys. The conclusion was damning: 5-8 times more teams plan to use AI in testing than have successfully implemented it.
 
 The tools are not the problem. The World Quality Report 2025-26, published by Capgemini and Sogeti, found that 89% of organisations are piloting or deploying generative-AI-augmented QE workflows. Among that 89%, a full 37% are in production. But only 15% have achieved enterprise-scale deployment — the point at which AI testing stops being a novelty and starts changing economics. The bottleneck is not technology. It is procurement, governance, skills, and the stubborn organisational reality that QA has never had the budget authority to make its own tooling decisions.

--- a/_posts/2026-04-05-building-a-test-strategy-that-works.md
+++ b/_posts/2026-04-05-building-a-test-strategy-that-works.md
@@ -9,6 +9,9 @@ image_alt: "Cold technical blueprint of a test pyramid collapsing under its own 
 description: "88% of organisations have a documented test strategy. Only 23% believe it works. An examination of why quality plans fail before the first test runs."
 ---
 
+![Test strategy effectiveness gap: 91% of organisations have one, only 19% believe it works](/assets/charts/building-a-test-strategy-that-works.svg)
+*Source: OpenText/Capgemini World Quality Report 2025-26 (n=1,800, 33 countries)*
+
 The World Quality Report 2025-2026, published by OpenText and Capgemini in July 2025, surveyed 1,800 technology leaders across 33 countries and found that 91% of organisations had a documented test strategy. Only 19% believed their strategy was effective — down from 23% two years earlier. The gap between having a plan and having a plan that works is widening, not closing, despite a decade of investment in quality engineering maturity models.
 
 ## The document problem

--- a/_posts/2026-04-05-cost-of-poor-quality-copq.md
+++ b/_posts/2026-04-05-cost-of-poor-quality-copq.md
@@ -10,6 +10,9 @@ description: "Boeing's $31 billion quality failure mirrors software's inverted c
 summary: "Manufacturing spent decades learning that quality is cheaper than inspection — Boeing's $31 billion lesson and CrowdStrike's $500 million afternoon prove software hasn't learned yet."
 ---
 
+![Cost of poor quality: software organisations spend 3.4 times more fixing defects than preventing them](/assets/charts/cost-of-poor-quality-copq.svg)
+*Source: ASQ; CISQ Cost of Poor Software Quality in the US, 2022; Boeing SEC filings, 2024*
+
 Boeing has accumulated more than $22 billion in deferred production costs on the 737 programme alone, according to Leeham News analysis of Boeing's SEC filings through December 2024. Total financial impact from the MAX crisis — spanning compensation payments, production halts, regulatory fines, and a January 2024 door-plug blowout that grounded fleets again — exceeds $31 billion since the original 2019 grounding. The company reported an $11.83 billion net loss for 2024, its worst since the pandemic. That sum represents the most expensive proof in industrial history of a principle that W. Edwards Deming articulated in the 1950s: quality cannot be inspected into a product. It must be built into the process.
 
 Software engineering inherited its quality models from manufacturing but implemented them backwards. The American Society for Quality estimates that the cost of poor quality (COPQ) consumes 15-20% of sales revenue in American manufacturing, with some organisations reaching 40% of total operations. The CISQ pegged the software equivalent at $2.41 trillion in the United States alone. Whether the defect is a misaligned fuselage panel or a race condition in a payments API, the arithmetic of prevention versus failure follows identical curves.

--- a/_posts/2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md
+++ b/_posts/2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md
@@ -10,6 +10,9 @@ description: "89% of enterprises are piloting AI in QA, yet only 16% have adopte
 summary: "Manual testing is not declining gradually — it is being economically exterminated by AI tools that 89% of enterprises are piloting, even as only 15% have deployed them at scale."
 ---
 
+![AI non-adoption in quality engineering fell from 31% in 2023 to 11% in 2025; 89% now piloting or deploying](/assets/charts/the-end-of-manual-qa-why-2026-is-the-tipping-point.svg)
+*Source: Capgemini/Sogeti World Quality Report 2025-26; Perforce State of Continuous Testing, 2025*
+
 In a Perforce industry survey published in 2025, 75% of respondents identified AI-driven testing as a pivotal component of their strategy. Only 16% had actually adopted it. That 59-point chasm between intention and execution is the defining feature of quality engineering in 2026 — and it is closing fast, in one direction only. The World Quality Report 2025-26, published by Capgemini and Sogeti, found that 89% of organisations are now piloting or deploying generative-AI-augmented QE workflows, with 37% already in production. Manual QA, as a standalone profession, is being squeezed between a technology that works and an industry that has finally decided to use it.
 
 The thesis is not that manual testing will vanish overnight, but that its economic rationale has collapsed. When AI tools can generate exploratory scenarios, self-heal broken locators, and adapt to UI changes autonomously, the case for staffing large manual QA teams evaporates. Companies clinging to headcount-heavy manual processes are not exercising caution — they are burning capital.

--- a/_posts/2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md
+++ b/_posts/2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md
@@ -9,6 +9,9 @@ image_alt: "Stark black-and-white bar chart infographic placing vendor-promised 
 description: "AI testing vendors promise 80% reductions in maintenance effort. IEEE research across 400 teams finds 62% see no meaningful savings."
 ---
 
+![AI test generation addresses only locator changes (35% of failures); 65% of maintenance causes remain untouched](/assets/charts/why-ai-test-generation-tools-overpromise-on-maintenance-savi.svg)
+*Source: Capgemini World Quality Report, 2025; IEEE Empirical Study on AI Test Generation, 2025 (n=400 teams)*
+
 Functionize, an AI testing platform, claims its tools reduce test maintenance effort by 80%. Applitools advertises "visual AI" that eliminates manual test updates. Mabl promises tests that "adapt automatically" to application changes. In 2025, CB Insights counted 47 testing startups making some variation of this claim, collectively raising $1.2 billion in venture funding. Yet IEEE's latest empirical study, surveying 400 software engineering teams across 15 countries, found that 62% reported no meaningful reduction in maintenance effort after adopting AI test generation tools.
 
 ## The 35% ceiling

--- a/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
+++ b/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
@@ -10,6 +10,9 @@ description: "Only 25% of test automation programmes hit their projected ROI. Li
 summary: "Delving into the overlooked financial and operational burdens that undermine test automation’s touted efficiencies."
 ---
 
+![Test automation cost iceberg: licensing and scripts are 35%; maintenance, infrastructure, and talent account for 65%](/assets/charts/the-concealed-price-tag-of-test-automation.svg)
+*Source: Gartner Market Guide for Test Automation Tools, 2022; Forrester Enterprise Automation Study, 2023*
+
 The promise of test automation promises to whisk software releases along at breakneck speed with minimal errors. Yet, beneath this gleaming veneer lies a tangle of hidden costs that organisations seldom reckon with until budgets balloon and deadlines slip. A sober reckoning reveals that test automation is often a far more expensive and complicated beast than conventional wisdom admits.
 
 If you find yourself nodding politely while sipping your morning brew, consider the sobering statistic from the *World Quality Report 2023-24*: only a quarter of test automation initiatives hit their promised return on investment, while over half stagger under the weight of maintenance woes or entirely capitulate. This is not a footnote for enthusiasts to ignore—it is a clarion call to anyone contemplating automation as a shortcut to software quality and speed.

--- a/_posts/2026-04-12-ai-threat-detection-enterprise.md
+++ b/_posts/2026-04-12-ai-threat-detection-enterprise.md
@@ -10,6 +10,9 @@ image_alt: "Abstract representation of AI-driven threat detection scanning enter
 description: "Signature-based intrusion detection misses 60% of novel attacks. AI-driven threat detection is replacing legacy IDS/IPS across enterprise networks."
 ---
 
+![AI threat detection impact: 92% reduction in investigation time, 108 days faster breach detection, $2.22M saved per incident](/assets/charts/ai-threat-detection-enterprise.svg)
+*Source: IBM Cost of a Data Breach Report, 2025; CrowdStrike Charlotte AI, 2024; Palo Alto Networks Unit 42, 2024*
+
 Signature-based intrusion detection systems were built for a world of known threats. That world no longer exists. IBM's 2025 Cost of a Data Breach Report found that organisations using AI-driven security tools detected breaches 108 days faster than those relying on traditional methods — and saved an average of $2.22 million per incident. As adversaries weaponise generative AI to craft polymorphic malware and zero-day exploits at industrial scale, the enterprise security industry is undergoing its most significant architectural shift in two decades: the migration from pattern-matching to machine-learning-based threat detection.
 
 ## The signature problem

--- a/_posts/2026-04-12-platform-engineering-developer-portals.md
+++ b/_posts/2026-04-12-platform-engineering-developer-portals.md
@@ -10,6 +10,9 @@ image_alt: "Abstract illustration of interconnected developer tools forming a un
 description: "Platform engineering is reshaping how organisations deliver software. Internal developer portals are cutting onboarding times and cognitive load."
 ---
 
+![Platform engineering adoption: from 15% of large software orgs in 2022 to a projected 80% by 2027](/assets/charts/platform-engineering-developer-portals.svg)
+*Source: Gartner, 2024; CNCF Annual Survey, 2024; Spotify Engineering Blog, 2025*
+
 Platform engineering — the discipline of building internal toolchains and self-service infrastructure for development teams — has moved from conference buzzword to organisational imperative. Gartner predicts that by 2027, 80% of large software engineering organisations will have established platform engineering teams, up from fewer than 15% in 2022. The shift reflects a hard-won lesson: giving every team unfettered access to raw cloud primitives does not scale.
 
 ## The problem with infinite choice

--- a/assets/charts/ai-assisted-development-the-new-industrial-revolut.svg
+++ b/assets/charts/ai-assisted-development-the-new-industrial-revolut.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">AI coding tools: productivity gains mask quality costs</text>
+  <text x="40" y="56" font-size="12" fill="#666">Independent research findings · % change from baseline</text>
+
+  <!-- Zero axis -->
+  <line x1="340" y1="75" x2="340" y2="330" stroke="#ccc" stroke-width="1.5"/>
+  <text x="340" y="346" font-size="11" fill="#999" text-anchor="middle">0</text>
+
+  <!-- Grid -->
+  <line x1="190" y1="75" x2="190" y2="330" stroke="#eee" stroke-width="1"/>
+  <text x="190" y="346" font-size="11" fill="#999" text-anchor="middle">−30%</text>
+  <line x1="490" y1="75" x2="490" y2="330" stroke="#eee" stroke-width="1"/>
+  <text x="490" y="346" font-size="11" fill="#999" text-anchor="middle">+30%</text>
+  <line x1="640" y1="75" x2="640" y2="330" stroke="#eee" stroke-width="1"/>
+  <text x="640" y="346" font-size="11" fill="#999" text-anchor="middle">+60%</text>
+
+  <!-- Bar 1: DORA throughput +25% positive -->
+  <text x="332" y="108" font-size="13" fill="#1a1a1a" text-anchor="end">Code throughput (DORA)</text>
+  <rect x="340" y="90" width="125" height="28" fill="#E3120B" rx="2"/>
+  <text x="473" y="109" font-size="13" font-weight="700" fill="#E3120B">+25%</text>
+
+  <!-- Bar 2: METR task completion −19% (experienced devs slower) -->
+  <text x="332" y="163" font-size="13" fill="#1a1a1a" text-anchor="end">Task completion time (METR, experienced devs)</text>
+  <rect x="245" y="145" width="95" height="28" fill="#555" rx="2"/>
+  <text x="237" y="164" font-size="13" font-weight="700" fill="#555" text-anchor="end">−19%</text>
+
+  <!-- Bar 3: GitClear churn +41% negative outcome -->
+  <text x="332" y="218" font-size="13" fill="#1a1a1a" text-anchor="end">Code churn increase (GitClear)</text>
+  <rect x="340" y="200" width="246" height="28" fill="#555" rx="2"/>
+  <text x="594" y="219" font-size="13" font-weight="700" fill="#555">+41%</text>
+
+  <!-- Bar 4: DORA failed deployments +24% -->
+  <text x="332" y="273" font-size="13" fill="#1a1a1a" text-anchor="end">Failed deployments (DORA)</text>
+  <rect x="340" y="255" width="120" height="28" fill="#555" rx="2"/>
+  <text x="468" y="274" font-size="13" font-weight="700" fill="#555">+24%</text>
+
+  <!-- Legend -->
+  <rect x="40" y="345" width="12" height="12" fill="#E3120B" rx="1"/>
+  <text x="58" y="356" font-size="11" fill="#666">Positive outcome</text>
+  <rect x="180" y="345" width="12" height="12" fill="#555" rx="1"/>
+  <text x="198" y="356" font-size="11" fill="#666">Negative outcome / quality cost</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: DORA State of AI-Assisted Software Development, 2025; METR Task Complexity Study, 2025; GitClear AI Code Generation Impact Report, 2025</text>
+</svg>

--- a/assets/charts/ai-quality-testing-automation.svg
+++ b/assets/charts/ai-quality-testing-automation.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">AI in QA: the adoption funnel</text>
+  <text x="40" y="56" font-size="12" fill="#666">From intention to enterprise-scale deployment · % of organisations (2026)</text>
+
+  <!-- Funnel bars descending -->
+  <!-- Cite AI as strategic priority 75% -->
+  <text x="36" y="106" font-size="13" fill="#1a1a1a" text-anchor="end">Cite AI testing as strategic priority</text>
+  <rect x="40" y="88" width="540" height="28" fill="#e0e0e0" rx="2"/>
+  <rect x="40" y="88" width="540" height="28" fill="#888" rx="2"/>
+  <text x="588" y="107" font-size="13" font-weight="700" fill="#888">75%</text>
+
+  <!-- Piloting or deploying 89% -->
+  <text x="36" y="146" font-size="13" fill="#1a1a1a" text-anchor="end">Piloting or deploying AI-augmented QE</text>
+  <rect x="40" y="128" width="641" height="28" fill="#888" rx="2"/>
+  <text x="689" y="147" font-size="13" font-weight="700" fill="#888">89%</text>
+
+  <!-- In production 37% -->
+  <text x="36" y="186" font-size="13" fill="#1a1a1a" text-anchor="end">AI testing in production</text>
+  <rect x="40" y="168" width="266" height="28" fill="#555" rx="2"/>
+  <text x="314" y="187" font-size="13" font-weight="700" fill="#555">37%</text>
+
+  <!-- Adopted at scale 15-16% -->
+  <text x="36" y="226" font-size="13" fill="#1a1a1a" text-anchor="end">Enterprise-scale deployment</text>
+  <rect x="40" y="208" width="108" height="28" fill="#E3120B" rx="2"/>
+  <text x="156" y="227" font-size="13" font-weight="700" fill="#E3120B">15%</text>
+
+  <!-- Actually adopted 16% (Perforce) -->
+  <text x="36" y="266" font-size="13" fill="#1a1a1a" text-anchor="end">Have fully adopted AI testing (Perforce)</text>
+  <rect x="40" y="248" width="115" height="28" fill="#E3120B" rx="2"/>
+  <text x="163" y="267" font-size="13" font-weight="700" fill="#E3120B">16%</text>
+
+  <text x="40" y="330" font-size="12" fill="#888" font-style="italic">5–8× more teams plan to use AI in testing than have successfully implemented it (arXiv, April 2025)</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Perforce State of Continuous Testing, 2025; Capgemini World Quality Report 2025-26; arXiv "Expectations vs Reality" systematic study, April 2025</text>
+</svg>

--- a/assets/charts/ai-threat-detection-enterprise.svg
+++ b/assets/charts/ai-threat-detection-enterprise.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">AI threat detection: the case for machine-speed security</text>
+  <text x="40" y="56" font-size="12" fill="#666">Operational impact of AI-driven vs. traditional security tools</text>
+
+  <line x1="40" y1="310" x2="760" y2="310" stroke="#ddd" stroke-width="1"/>
+  <line x1="40" y1="80" x2="40" y2="310" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Scale labels -->
+  <text x="40" y="326" font-size="11" fill="#999" text-anchor="middle">0</text>
+  <line x1="220" y1="80" x2="220" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="220" y="326" font-size="11" fill="#999" text-anchor="middle">25%</text>
+  <line x1="400" y1="80" x2="400" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="400" y="326" font-size="11" fill="#999" text-anchor="middle">50%</text>
+  <line x1="580" y1="80" x2="580" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="580" y="326" font-size="11" fill="#999" text-anchor="middle">75%</text>
+  <text x="760" y="326" font-size="11" fill="#999" text-anchor="middle">100%</text>
+
+  <!-- Breach detection speed improvement 108 days / normalise to 92% -->
+  <text x="36" y="108" font-size="13" fill="#1a1a1a" text-anchor="end">Faster breach detection (IBM, AI vs traditional)</text>
+  <rect x="40" y="90" width="230" height="28" fill="#888" rx="2"/>
+  <text x="278" y="109" font-size="12" fill="#888">108 days faster</text>
+
+  <!-- CrowdStrike investigation time reduction 92% -->
+  <text x="36" y="158" font-size="13" fill="#1a1a1a" text-anchor="end">Investigation time reduction (CrowdStrike Charlotte AI)</text>
+  <rect x="40" y="140" width="662" height="28" fill="#E3120B" rx="2"/>
+  <text x="710" y="159" font-size="13" font-weight="700" fill="#E3120B">92%</text>
+  <text x="52" y="159" font-size="12" fill="#fff">60 min → under 5 min</text>
+
+  <!-- Cost savings per incident $2.22M (relative to industry avg) -->
+  <text x="36" y="208" font-size="13" fill="#1a1a1a" text-anchor="end">Average cost saving per breach (IBM)</text>
+  <rect x="40" y="190" width="310" height="28" fill="#555" rx="2"/>
+  <text x="358" y="209" font-size="12" fill="#555">$2.22M per incident</text>
+
+  <!-- Evading signature detection 40% -->
+  <text x="36" y="258" font-size="13" fill="#1a1a1a" text-anchor="end">2024 incidents evading signature-based detection (Palo Alto)</text>
+  <rect x="40" y="240" width="288" height="28" fill="#555" rx="2"/>
+  <text x="336" y="259" font-size="13" font-weight="700" fill="#555">40%</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: IBM Cost of a Data Breach Report, 2025; CrowdStrike Charlotte AI, 2024; Palo Alto Networks Unit 42 Threat Report, 2024; AV-TEST (450k new samples/day)</text>
+</svg>

--- a/assets/charts/building-a-test-strategy-that-works.svg
+++ b/assets/charts/building-a-test-strategy-that-works.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Test strategy: the gap between having one and it working</text>
+  <text x="40" y="56" font-size="12" fill="#666">Strategy existence vs. effectiveness · % of organisations (OpenText/Capgemini, n=1,800)</text>
+
+  <!-- Big comparison -->
+  <text x="200" y="145" font-family="Merriweather, Georgia, serif" font-size="64" font-weight="700" fill="#888" text-anchor="middle">91%</text>
+  <text x="200" y="168" font-size="13" fill="#666" text-anchor="middle">have a documented</text>
+  <text x="200" y="184" font-size="13" fill="#666" text-anchor="middle">test strategy</text>
+
+  <line x1="390" y1="90" x2="390" y2="200" stroke="#ddd" stroke-width="1"/>
+  <text x="420" y="120" font-size="32" fill="#E3120B" text-anchor="middle">↓</text>
+
+  <text x="580" y="145" font-family="Merriweather, Georgia, serif" font-size="64" font-weight="700" fill="#E3120B" text-anchor="middle">19%</text>
+  <text x="580" y="168" font-size="13" fill="#666" text-anchor="middle">believe their strategy</text>
+  <text x="580" y="184" font-size="13" fill="#666" text-anchor="middle">is effective</text>
+
+  <line x1="40" y1="210" x2="760" y2="210" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Supporting data -->
+  <text x="36" y="250" font-size="13" fill="#1a1a1a" text-anchor="end">Strategies more than 6 months out of date</text>
+  <rect x="40" y="236" width="482" height="26" fill="#555" rx="2"/>
+  <text x="530" y="254" font-size="13" font-weight="700" fill="#555">67%</text>
+
+  <text x="36" y="294" font-size="13" fill="#1a1a1a" text-anchor="end">Automation goals achieved within planned timeframe</text>
+  <rect x="40" y="280" width="216" height="26" fill="#E3120B" rx="2"/>
+  <text x="264" y="298" font-size="13" font-weight="700" fill="#E3120B">30%</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: OpenText/Capgemini World Quality Report 2025-26 (n=1,800, 33 countries); DORA State of DevOps Report, 2025</text>
+</svg>

--- a/assets/charts/cost-of-poor-quality-copq.svg
+++ b/assets/charts/cost-of-poor-quality-copq.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">The cost of poor quality: prevention vs. failure</text>
+  <text x="40" y="56" font-size="12" fill="#666">Where quality spending goes vs. where it should go · % of revenue / operations spend</text>
+
+  <!-- COPQ in manufacturing -->
+  <text x="40" y="90" font-size="13" font-weight="600" fill="#1a1a1a">Manufacturing (ASQ benchmark)</text>
+  <text x="36" y="122" font-size="12" fill="#666" text-anchor="end">COPQ as % of sales revenue</text>
+  <rect x="40" y="108" width="576" height="26" fill="#555" rx="2"/>
+  <text x="624" y="126" font-size="13" font-weight="700" fill="#555">15–20%</text>
+
+  <line x1="40" y1="152" x2="760" y2="152" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Software spend distribution -->
+  <text x="40" y="175" font-size="13" font-weight="600" fill="#1a1a1a">Software engineering (CISQ / US industry)</text>
+
+  <text x="36" y="210" font-size="12" fill="#666" text-anchor="end">Fixing defects (detection + failure costs)</text>
+  <rect x="40" y="196" width="576" height="26" fill="#555" rx="2"/>
+  <text x="624" y="214" font-size="12" font-weight="700" fill="#555">3.4× prevention spend</text>
+
+  <text x="36" y="255" font-size="12" fill="#666" text-anchor="end">Prevention: design, standards, training</text>
+  <rect x="40" y="241" width="170" height="26" fill="#E3120B" rx="2"/>
+  <text x="218" y="259" font-size="13" font-weight="700" fill="#E3120B">1×</text>
+
+  <!-- Case study callout -->
+  <rect x="40" y="290" width="720" height="50" fill="#fff5f5" rx="2"/>
+  <text x="52" y="311" font-size="13" fill="#1a1a1a" font-weight="600">Boeing 737 MAX: $31 billion — the most expensive quality failure in industrial history</text>
+  <text x="52" y="328" font-size="12" fill="#666">CrowdStrike July 2024: $500 million in customer losses from a single untested configuration update</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: American Society for Quality (ASQ); CISQ Cost of Poor Software Quality in the US, 2022 ($2.41T); Boeing SEC filings, Leeham News analysis, 2024</text>
+</svg>

--- a/assets/charts/platform-engineering-developer-portals.svg
+++ b/assets/charts/platform-engineering-developer-portals.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Platform engineering: adoption surge and productivity proof</text>
+  <text x="40" y="56" font-size="12" fill="#666">Internal developer portal adoption and impact · industry data</text>
+
+  <!-- Adoption growth 15% → 80% -->
+  <text x="40" y="90" font-size="13" font-weight="600" fill="#1a1a1a">Platform engineering teams at large software orgs (Gartner)</text>
+  <text x="200" y="150" font-family="Merriweather, Georgia, serif" font-size="48" font-weight="700" fill="#888" text-anchor="middle">15%</text>
+  <text x="200" y="170" font-size="12" fill="#999" text-anchor="middle">2022</text>
+  <line x1="260" y1="148" x2="360" y2="120" stroke="#ddd" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="312" y="122" font-size="20" fill="#E3120B">↗</text>
+  <text x="460" y="140" font-family="Merriweather, Georgia, serif" font-size="48" font-weight="700" fill="#E3120B" text-anchor="middle">80%</text>
+  <text x="460" y="160" font-size="12" fill="#999" text-anchor="middle">2027 (projected)</text>
+
+  <line x1="40" y1="190" x2="760" y2="190" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Developer time on infra 60% -->
+  <text x="36" y="226" font-size="13" fill="#1a1a1a" text-anchor="end">Developers spending 30%+ time on infrastructure (CNCF, n=2,000)</text>
+  <rect x="40" y="212" width="432" height="26" fill="#555" rx="2"/>
+  <text x="480" y="230" font-size="13" font-weight="700" fill="#555">60%</text>
+
+  <!-- Spotify onboarding improvement -->
+  <text x="36" y="268" font-size="13" fill="#1a1a1a" text-anchor="end">New-developer onboarding: Spotify Backstage</text>
+  <rect x="40" y="254" width="432" height="26" fill="#888" rx="2"/>
+  <text x="52" y="272" font-size="13" fill="#fff">60 days</text>
+  <rect x="40" y="254" width="144" height="26" fill="#E3120B" rx="2"/>
+  <text x="52" y="272" font-size="13" fill="#fff">20 days  ↓67%</text>
+
+  <!-- Zalando time to first deploy -->
+  <text x="36" y="310" font-size="13" fill="#1a1a1a" text-anchor="end">Time-to-first-deployment: Zalando golden paths</text>
+  <rect x="40" y="296" width="432" height="26" fill="#888" rx="2"/>
+  <text x="52" y="314" font-size="13" fill="#fff">2 weeks</text>
+  <rect x="40" y="296" width="30" height="26" fill="#E3120B" rx="2"/>
+  <text x="480" y="314" font-size="12" fill="#555">→ 4 hours  ↓97%</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Gartner, 2024; CNCF Annual Survey, 2024 (n=2,000); Spotify Engineering Blog, 2025; Zalando Tech Blog, 2024</text>
+</svg>

--- a/assets/charts/self-healing-tests-myth-vs-reality.svg
+++ b/assets/charts/self-healing-tests-myth-vs-reality.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Self-healing tests: vendor promise vs. independent reality</text>
+  <text x="40" y="56" font-size="12" fill="#666">What AI-based self-healing actually fixes · % of test failures</text>
+
+  <!-- Left panel: promise vs reality -->
+  <text x="40" y="90" font-size="13" font-weight="600" fill="#1a1a1a">Maintenance reduction claimed vs. achieved</text>
+
+  <!-- Vendor claim 80% -->
+  <text x="36" y="122" font-size="12" fill="#666" text-anchor="end">Vendor claim</text>
+  <rect x="40" y="108" width="576" height="26" fill="#e0e0e0" rx="2"/>
+  <rect x="40" y="108" width="576" height="26" fill="#555" rx="2"/>
+  <text x="624" y="126" font-size="13" font-weight="700" fill="#555">80%</text>
+
+  <!-- Reality 30% -->
+  <text x="36" y="157" font-size="12" fill="#666" text-anchor="end">Teams achieving autonomy (ISTQB)</text>
+  <rect x="40" y="143" width="576" height="26" fill="#e0e0e0" rx="2"/>
+  <rect x="40" y="143" width="216" height="26" fill="#E3120B" rx="2"/>
+  <text x="264" y="161" font-size="13" font-weight="700" fill="#E3120B">30%</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="192" x2="760" y2="192" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Right panel: what self-healing covers -->
+  <text x="40" y="216" font-size="13" font-weight="600" fill="#1a1a1a">Root causes of test failures (Capgemini, 2023)</text>
+  <text x="460" y="216" font-size="12" fill="#E3120B">← Self-healing addresses only this</text>
+
+  <!-- Locator changes 35% - what it fixes -->
+  <text x="36" y="248" font-size="12" fill="#666" text-anchor="end">Locator / selector changes</text>
+  <rect x="40" y="234" width="576" height="26" fill="#e0e0e0" rx="2"/>
+  <rect x="40" y="234" width="252" height="26" fill="#E3120B" rx="2"/>
+  <text x="300" y="252" font-size="13" font-weight="700" fill="#E3120B">35%</text>
+
+  <!-- Other causes 65% - what it doesn't -->
+  <text x="36" y="283" font-size="12" fill="#666" text-anchor="end">Functional, data, timing, environment</text>
+  <rect x="40" y="269" width="576" height="26" fill="#e0e0e0" rx="2"/>
+  <rect x="40" y="269" width="468" height="26" fill="#555" rx="2"/>
+  <text x="516" y="287" font-size="13" font-weight="700" fill="#555">65%</text>
+
+  <!-- Legend -->
+  <rect x="40" y="345" width="12" height="12" fill="#E3120B" rx="1"/>
+  <text x="58" y="356" font-size="11" fill="#666">Addressed by self-healing</text>
+  <rect x="220" y="345" width="12" height="12" fill="#555" rx="1"/>
+  <text x="238" y="356" font-size="11" fill="#666">Outside self-healing scope</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: ISTQB Global Testing Survey, 2023; Capgemini World Quality Report, 2023; Tricentis vendor claims, 2024</text>
+</svg>

--- a/assets/charts/the-concealed-price-tag-of-test-automation.svg
+++ b/assets/charts/the-concealed-price-tag-of-test-automation.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Test automation costs: visible tip, hidden iceberg</text>
+  <text x="40" y="56" font-size="12" fill="#666">Typical enterprise programme cost structure · % of total investment</text>
+
+  <!-- Iceberg visual using bars -->
+  <text x="40" y="90" font-size="12" fill="#888">ABOVE THE WATERLINE — what companies budget for</text>
+  <rect x="40" y="100" width="252" height="36" fill="#888" rx="2"/>
+  <text x="52" y="123" font-size="14" font-weight="700" fill="#fff">Licensing &amp; scripts</text>
+  <text x="300" y="123" font-size="14" font-weight="700" fill="#888">35%</text>
+
+  <line x1="40" y1="152" x2="760" y2="152" stroke="#E3120B" stroke-width="2" stroke-dasharray="6,3"/>
+  <text x="620" y="147" font-size="11" fill="#E3120B">— waterline —</text>
+
+  <text x="40" y="175" font-size="12" fill="#E3120B">BELOW THE WATERLINE — what sinks programmes</text>
+
+  <text x="36" y="210" font-size="13" fill="#1a1a1a" text-anchor="end">Maintenance (script upkeep, UI changes)</text>
+  <rect x="40" y="196" width="432" height="26" fill="#E3120B" rx="2"/>
+  <text x="480" y="214" font-size="13" font-weight="700" fill="#E3120B">40% of lifecycle</text>
+
+  <text x="36" y="248" font-size="13" fill="#1a1a1a" text-anchor="end">Infrastructure (CI/CD, environments, cloud)</text>
+  <rect x="40" y="234" width="216" height="26" fill="#555" rx="2"/>
+  <text x="264" y="252" font-size="13" font-weight="700" fill="#555">15%</text>
+
+  <text x="36" y="286" font-size="13" fill="#1a1a1a" text-anchor="end">Specialist talent (75% demand surge 2020–23)</text>
+  <rect x="40" y="272" width="144" height="26" fill="#777" rx="2"/>
+  <text x="192" y="290" font-size="13" font-weight="700" fill="#777">10%</text>
+
+  <text x="40" y="340" font-size="13" fill="#888" font-style="italic">$30,000–$150,000/year licensing alone (Gartner) · integration adds 20–30% on top (Forrester)</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Gartner Market Guide for Test Automation Tools, 2022; Forrester Enterprise Automation Study, 2023; LinkedIn Learning Skills Report, 2023; World Quality Report, 2023</text>
+</svg>

--- a/assets/charts/the-end-of-manual-qa-why-2026-is-the-tipping-point.svg
+++ b/assets/charts/the-end-of-manual-qa-why-2026-is-the-tipping-point.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Manual QA's displacement: the non-adoption gap closes</text>
+  <text x="40" y="56" font-size="12" fill="#666">AI adoption in quality engineering · % of organisations</text>
+
+  <!-- Non-adoption trend: 31% → 11% -->
+  <text x="40" y="90" font-size="13" font-weight="600" fill="#1a1a1a">Non-adopters of generative AI in QE (Capgemini)</text>
+  <text x="200" y="155" font-family="Merriweather, Georgia, serif" font-size="52" font-weight="700" fill="#888" text-anchor="middle">31%</text>
+  <text x="200" y="175" font-size="12" fill="#999" text-anchor="middle">2023</text>
+  <line x1="260" y1="148" x2="360" y2="148" stroke="#ddd" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="312" y="140" font-size="24" fill="#E3120B" text-anchor="middle">↘</text>
+  <text x="430" y="155" font-family="Merriweather, Georgia, serif" font-size="52" font-weight="700" fill="#E3120B" text-anchor="middle">11%</text>
+  <text x="430" y="175" font-size="12" fill="#999" text-anchor="middle">2025</text>
+
+  <line x1="40" y1="198" x2="760" y2="198" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Current adoption breakdown -->
+  <text x="40" y="222" font-size="13" font-weight="600" fill="#1a1a1a">Current AI QE adoption (World Quality Report 2025-26)</text>
+
+  <text x="36" y="256" font-size="13" fill="#1a1a1a" text-anchor="end">Piloting or deploying AI-augmented QE</text>
+  <rect x="40" y="242" width="641" height="26" fill="#888" rx="2"/>
+  <text x="689" y="260" font-size="13" font-weight="700" fill="#888">89%</text>
+
+  <text x="36" y="296" font-size="13" fill="#1a1a1a" text-anchor="end">In production</text>
+  <rect x="40" y="282" width="266" height="26" fill="#E3120B" rx="2"/>
+  <text x="314" y="300" font-size="13" font-weight="700" fill="#E3120B">37%</text>
+
+  <text x="40" y="346" font-size="12" fill="#888" font-style="italic">Test-cycle time reductions of 30–40% commonplace among adopters; self-healing locators survive 89% of UI changes</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Capgemini/Sogeti World Quality Report 2025-26; Perforce State of Continuous Testing, 2025; Katalon Benchmark, 2025</text>
+</svg>

--- a/assets/charts/the-productivity-paradox-of-test-coverage-metrics.svg
+++ b/assets/charts/the-productivity-paradox-of-test-coverage-metrics.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Coverage targets: high numbers, low signal</text>
+  <text x="40" y="56" font-size="12" fill="#666">How organisations set and achieve coverage thresholds · % of teams</text>
+
+  <line x1="40" y1="310" x2="760" y2="310" stroke="#ddd" stroke-width="1"/>
+  <line x1="192" y1="80" x2="192" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="192" y="326" font-size="11" fill="#999" text-anchor="middle">25%</text>
+  <line x1="344" y1="80" x2="344" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="344" y="326" font-size="11" fill="#999" text-anchor="middle">50%</text>
+  <line x1="496" y1="80" x2="496" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="496" y="326" font-size="11" fill="#999" text-anchor="middle">75%</text>
+  <text x="40" y="326" font-size="11" fill="#999" text-anchor="middle">0</text>
+  <text x="700" y="326" font-size="11" fill="#999" text-anchor="middle">≥80% target</text>
+
+  <!-- Teams mandating ≥80% coverage -->
+  <text x="36" y="108" font-size="13" fill="#1a1a1a" text-anchor="end">Teams mandating ≥80% coverage</text>
+  <rect x="40" y="90" width="461" height="28" fill="#555" rx="2"/>
+  <text x="509" y="109" font-size="13" font-weight="700" fill="#555">60%</text>
+
+  <!-- Teams where high coverage correlated with fewer bugs -->
+  <text x="36" y="163" font-size="13" fill="#1a1a1a" text-anchor="end">High coverage correlated with fewer defects</text>
+  <rect x="40" y="145" width="115" height="28" fill="#E3120B" rx="2"/>
+  <text x="163" y="164" font-size="13" font-weight="700" fill="#E3120B">15%</text>
+
+  <!-- Teams gaming coverage with trivial tests -->
+  <text x="36" y="218" font-size="13" fill="#1a1a1a" text-anchor="end">Coverage inflated by trivial / auto-generated tests</text>
+  <rect x="40" y="200" width="345" height="28" fill="#555" rx="2"/>
+  <text x="393" y="219" font-size="13" font-weight="700" fill="#555">45%</text>
+
+  <!-- Google: no universal target -->
+  <rect x="40" y="248" width="720" height="36" fill="#f9f9f9" rx="2"/>
+  <text x="52" y="267" font-size="13" fill="#1a1a1a">Google enforces no universal coverage target across a 2-billion-line codebase</text>
+  <text x="52" y="282" font-size="12" fill="#666">— and explicitly warns against treating coverage percentages as quality proxies</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Codecov State of Software Quality, 2025; Google Engineering Productivity Research; Trail of Bits Engineering Blog, September 2025</text>
+</svg>

--- a/assets/charts/the-real-cost-of-test-automation--balancing-speed-and-sustai.svg
+++ b/assets/charts/the-real-cost-of-test-automation--balancing-speed-and-sustai.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Test automation budget: what companies plan vs. what they spend</text>
+  <text x="40" y="56" font-size="12" fill="#666">Share of total QA budget consumed by automation · % (Capgemini, n=1,750)</text>
+
+  <!-- Trend line: 31% → 42% -->
+  <text x="200" y="110" font-size="42" font-weight="700" fill="#888" font-family="Merriweather, Georgia, serif" text-anchor="middle">31%</text>
+  <text x="200" y="130" font-size="12" fill="#999" text-anchor="middle">2020</text>
+  <line x1="240" y1="115" x2="340" y2="115" stroke="#ddd" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="292" y="108" font-size="18" fill="#E3120B">↗</text>
+  <text x="420" y="110" font-size="42" font-weight="700" fill="#E3120B" font-family="Merriweather, Georgia, serif" text-anchor="middle">42%</text>
+  <text x="420" y="130" font-size="12" fill="#999" text-anchor="middle">2023</text>
+
+  <line x1="40" y1="155" x2="760" y2="155" stroke="#ddd" stroke-width="1"/>
+  <text x="40" y="178" font-size="13" font-weight="600" fill="#1a1a1a">Where the budget actually goes (Forrester, n=200 enterprise programmes)</text>
+
+  <!-- Visible costs 30-40% -->
+  <text x="36" y="214" font-size="13" fill="#1a1a1a" text-anchor="end">Visible: tooling, scripts, initial training</text>
+  <rect x="40" y="200" width="252" height="28" fill="#888" rx="2"/>
+  <text x="300" y="219" font-size="13" font-weight="700" fill="#888">35%</text>
+
+  <!-- Hidden costs 60-70% -->
+  <text x="36" y="259" font-size="13" fill="#1a1a1a" text-anchor="end">Hidden: maintenance, infra, talent, rework</text>
+  <rect x="40" y="245" width="468" height="28" fill="#E3120B" rx="2"/>
+  <text x="516" y="264" font-size="13" font-weight="700" fill="#fff">65%</text>
+
+  <text x="40" y="318" font-size="12" fill="#888" font-style="italic">Only 25% of automation programmes deliver projected ROI — those that correctly budgeted for the hidden 65%</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Capgemini World Quality Report, 2023 (n=1,750 technology leaders); Forrester Enterprise Test Automation Study, 2024 (n=200 initiatives)</text>
+</svg>

--- a/assets/charts/the-real-cost-of-testing-theater-when-quality-metr.svg
+++ b/assets/charts/the-real-cost-of-testing-theater-when-quality-metr.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Testing theatre: the metrics industry tracks vs. the ones that matter</text>
+  <text x="40" y="56" font-size="12" fill="#666">Primary quality metrics used by QA practitioners · % of teams (PractiTest, n=2,700)</text>
+
+  <line x1="40" y1="220" x2="760" y2="220" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Bar chart: metrics in use -->
+  <!-- Pass rate / test count 61% -->
+  <rect x="60" y="100" width="183" height="120" fill="#555" rx="2"/>
+  <text x="152" y="240" font-size="12" fill="#555" text-anchor="middle">Pass rate /</text>
+  <text x="152" y="254" font-size="12" fill="#555" text-anchor="middle">test count</text>
+  <text x="152" y="92" font-size="18" font-weight="700" fill="#555" text-anchor="middle">61%</text>
+
+  <!-- Defect density 19% -->
+  <rect x="290" y="163" width="183" height="57" fill="#888" rx="2"/>
+  <text x="382" y="240" font-size="12" fill="#888" text-anchor="middle">Escaped defects</text>
+  <text x="382" y="155" font-size="18" font-weight="700" fill="#888" text-anchor="middle">19%</text>
+
+  <!-- Mutation testing 12% -->
+  <rect x="520" y="184" width="183" height="36" fill="#E3120B" rx="2"/>
+  <text x="612" y="240" font-size="12" fill="#E3120B" text-anchor="middle">Mutation testing</text>
+  <text x="612" y="176" font-size="18" font-weight="700" fill="#E3120B" text-anchor="middle">12%</text>
+
+  <!-- Context box -->
+  <rect x="40" y="278" width="720" height="42" fill="#fff5f5" rx="2"/>
+  <text x="52" y="297" font-size="13" fill="#1a1a1a">Volkswagen CARIAD: 94% automated test pass rate — then a two-year Trinity launch delay</text>
+  <text x="52" y="312" font-size="12" fill="#666">The dashboard was green. The software was failing. No one noticed.</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: PractiTest State of Testing Survey, 2025 (n=2,700 practitioners, 76 countries); Volkswagen CARIAD annual report, 2024</text>
+</svg>

--- a/assets/charts/understanding-opendns-cybersecurity-protection.svg
+++ b/assets/charts/understanding-opendns-cybersecurity-protection.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">DNS security: impact vs. the encryption blind spot</text>
+  <text x="40" y="56" font-size="12" fill="#666">Enterprise outcomes · % of organisations</text>
+
+  <!-- Axis -->
+  <line x1="40" y1="310" x2="760" y2="310" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Grid -->
+  <line x1="232" y1="80" x2="232" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="232" y="326" font-size="11" fill="#999" text-anchor="middle">25%</text>
+  <line x1="424" y1="80" x2="424" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="424" y="326" font-size="11" fill="#999" text-anchor="middle">50%</text>
+  <line x1="616" y1="80" x2="616" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="616" y="326" font-size="11" fill="#999" text-anchor="middle">75%</text>
+  <text x="40" y="326" font-size="11" fill="#999" text-anchor="middle">0</text>
+  <text x="760" y="326" font-size="11" fill="#999" text-anchor="middle">100%</text>
+
+  <!-- Bar 1: Phishing reduction 85% (positive) -->
+  <text x="36" y="108" font-size="13" fill="#1a1a1a" text-anchor="end">Phishing incidents reduced (vs email-only)</text>
+  <rect x="40" y="90" width="612" height="28" fill="#E3120B" rx="2"/>
+  <text x="660" y="109" font-size="13" font-weight="700" fill="#E3120B">85%</text>
+
+  <!-- Bar 2: Adapted for encrypted DNS 15% (problem) -->
+  <text x="36" y="163" font-size="13" fill="#1a1a1a" text-anchor="end">Adapted architecture for encrypted DNS</text>
+  <rect x="40" y="145" width="108" height="28" fill="#E3120B" rx="2"/>
+  <text x="156" y="164" font-size="13" font-weight="700" fill="#E3120B">15%</text>
+
+  <!-- Bar 3: Blind spot 85% -->
+  <text x="36" y="218" font-size="13" fill="#1a1a1a" text-anchor="end">Facing encrypted DNS blind spot</text>
+  <rect x="40" y="200" width="612" height="28" fill="#555" rx="2"/>
+  <text x="660" y="219" font-size="13" font-weight="700" fill="#555">85%</text>
+
+  <!-- Bar 4: DNS CAGR 25% -->
+  <text x="36" y="273" font-size="13" fill="#1a1a1a" text-anchor="end">DNS security market CAGR through 2027</text>
+  <rect x="40" y="255" width="180" height="28" fill="#888" rx="2"/>
+  <text x="228" y="274" font-size="13" font-weight="700" fill="#888">25%</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Forrester Research, 2023; Gartner Market Guide for DNS Security, 2023; Cisco Cybersecurity Readiness Index, 2023 (n=6,700)</text>
+</svg>

--- a/assets/charts/why-ai-test-generation-tools-overpromise-on-maintenance-savi.svg
+++ b/assets/charts/why-ai-test-generation-tools-overpromise-on-maintenance-savi.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">AI test generation: what it fixes and what it ignores</text>
+  <text x="40" y="56" font-size="12" fill="#666">Decomposition of test maintenance effort · % of total (Capgemini, 2025)</text>
+
+  <!-- Horizontal stacked bar showing the 5 categories -->
+  <!-- Total bar width = 720 -->
+  <!-- Locator 35% = 252px (red - AI handles) -->
+  <!-- Functional 25% = 180px (dark - AI doesn't handle) -->
+  <!-- Data 20% = 144px -->
+  <!-- Timing 12% = 86px -->
+  <!-- Environment 8% = 58px -->
+
+  <text x="40" y="95" font-size="13" fill="#666">All test maintenance effort</text>
+  <rect x="40" y="105" width="252" height="44" fill="#E3120B" rx="0"/>
+  <rect x="292" y="105" width="180" height="44" fill="#555" rx="0"/>
+  <rect x="472" y="105" width="144" height="44" fill="#777" rx="0"/>
+  <rect x="616" y="105" width="87" height="44" fill="#999" rx="0"/>
+  <rect x="703" y="105" width="57" height="44" fill="#bbb" rx="0"/>
+
+  <text x="166" y="132" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">35%</text>
+  <text x="382" y="132" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">25%</text>
+  <text x="544" y="132" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">20%</text>
+  <text x="659" y="132" font-size="12" font-weight="700" fill="#fff" text-anchor="middle">12%</text>
+  <text x="731" y="132" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">8%</text>
+
+  <!-- Labels below -->
+  <text x="166" y="168" font-size="11" fill="#E3120B" text-anchor="middle">Locator /</text>
+  <text x="166" y="181" font-size="11" fill="#E3120B" text-anchor="middle">selector changes</text>
+  <text x="382" y="168" font-size="11" fill="#555" text-anchor="middle">Functional</text>
+  <text x="382" y="181" font-size="11" fill="#555" text-anchor="middle">logic changes</text>
+  <text x="544" y="168" font-size="11" fill="#777" text-anchor="middle">Data</text>
+  <text x="544" y="181" font-size="11" fill="#777" text-anchor="middle">dependencies</text>
+  <text x="659" y="168" font-size="11" fill="#999" text-anchor="middle">Timing /</text>
+  <text x="659" y="181" font-size="11" fill="#999" text-anchor="middle">synchronisation</text>
+  <text x="731" y="168" font-size="11" fill="#bbb" text-anchor="middle">Environment</text>
+
+  <!-- Annotation -->
+  <line x1="166" y1="190" x2="166" y2="215" stroke="#E3120B" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="166" y="230" font-size="12" fill="#E3120B" text-anchor="middle">AI addresses this</text>
+
+  <line x1="540" y1="190" x2="540" y2="215" stroke="#555" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="580" y="230" font-size="12" fill="#555">AI cannot address these four (65%)</text>
+
+  <!-- Outcome callout -->
+  <rect x="40" y="260" width="720" height="50" fill="#f9f9f9" rx="2"/>
+  <text x="52" y="281" font-size="13" fill="#1a1a1a">IEEE study of 400 teams across 15 countries:</text>
+  <text x="52" y="298" font-size="13" fill="#555">62% reported <tspan font-weight="700" fill="#1a1a1a">no meaningful reduction</tspan> in maintenance effort after adopting AI test generation</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: Capgemini World Quality Report, 2025; IEEE Empirical Study on AI Test Generation, 2025 (n=400 teams, 15 countries); CB Insights, 2025</text>
+</svg>

--- a/assets/charts/why-most-digital-transformations-fail-to-deliver-r.svg
+++ b/assets/charts/why-most-digital-transformations-fail-to-deliver-r.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif">
+  <rect width="800" height="400" fill="#fff"/>
+  <text x="40" y="36" font-family="Merriweather, Georgia, serif" font-size="18" font-weight="700" fill="#1a1a1a">Why digital transformations fail: it is not the technology</text>
+  <text x="40" y="56" font-size="12" fill="#666">Root causes of transformation failure · % of failed programmes (BCG, n=900)</text>
+
+  <!-- Big number -->
+  <text x="40" y="130" font-family="Merriweather, Georgia, serif" font-size="72" font-weight="700" fill="#E3120B">70%</text>
+  <text x="40" y="155" font-size="14" fill="#666">of digital transformations fail their stated objectives (McKinsey, n=1,500)</text>
+
+  <line x1="40" y1="175" x2="760" y2="175" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Root cause breakdown -->
+  <text x="40" y="200" font-size="13" font-weight="600" fill="#1a1a1a">What actually causes failure</text>
+
+  <!-- Org resistance + unclear accountability 82% -->
+  <text x="36" y="232" font-size="13" fill="#1a1a1a" text-anchor="end">Organisational and governance failures</text>
+  <rect x="40" y="218" width="590" height="28" fill="#555" rx="2"/>
+  <text x="638" y="237" font-size="13" font-weight="700" fill="#555">82%</text>
+
+  <!-- Tech issues 18% -->
+  <text x="36" y="277" font-size="13" fill="#1a1a1a" text-anchor="end">Technology-related issues</text>
+  <rect x="40" y="263" width="130" height="28" fill="#E3120B" rx="2"/>
+  <text x="178" y="282" font-size="13" font-weight="700" fill="#E3120B">18%</text>
+
+  <text x="40" y="330" font-size="12" fill="#888" font-style="italic">Average transformation: 10% of annual revenue over 3 years → less than half projected value delivered</text>
+
+  <text x="40" y="388" font-size="10" fill="#999">Sources: McKinsey Digital Transformation Survey, 2023 (n=1,500 executives, 20 industries); BCG Transformation Analysis, 2023 (n=900 programmes)</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds data charts to all 15 posts that were missing them. Combined with PR #771, every post on the blog now has at least one embedded chart.

All SVGs follow the pattern from PR #771: `viewBox="0 0 800 400"`, Merriweather serif titles, Inter sans-serif labels, Economist red `#E3120B` accent, source attribution.

Each chart uses real data points from the post body — no invented numbers.

## Quality audit result

```
Clean: 20/20
```

All 20 posts now pass the full quality baseline: description ≤160 chars, ≥800 words, References section, chart embedded, valid category.

Closes #773