### PR TITLE
fix: normalise 8 posts to single category per editorial convention

### DIFF
--- a/_posts/2026-01-18-the-hidden-technical-debt-of-test-automation.md
+++ b/_posts/2026-01-18-the-hidden-technical-debt-of-test-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "Test Automation's Dirty Secret: The Debt Nobody Budgets For"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/test-automation-technical-debt.png
 image_alt: "Stark data-visualisation style chart showing compounding technical debt curves in crimson on white, inspired by financial charting with annotated inflection points"
 description: "Flaky tests caused 57% of Slack's CI failures. Test suites now consume 40% of QA capacity in maintenance — becoming the debt they were built to prevent."

--- a/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
+++ b/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
@@ -3,7 +3,7 @@ layout: post
 title: "Coverage Obsession: The Metric That Ate Quality Engineering"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/test-coverage-paradox.png
 image_alt: "Cold infographic showing a coverage meter pegged at 100% while a cartoon bug slips through an unchecked gap, technical diagram style in slate grey and white"
 description: "Research shows coverage has low correlation with fault detection after controlling for suite size. Google enforces no coverage target — here is why."

--- a/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
+++ b/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
@@ -3,7 +3,7 @@ layout: post
 title: "Digital transformation's dirty secret: the 70% that never deliver"
 date: 2026-01-18
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Software Engineering"]
+categories: ["Software Engineering"]
 image: /assets/images/digital-transformation-secret.png
 image_alt: "Monochrome architectural rendering of a half-built digital bridge crumbling on the far side, rendered with precise pencil-sketch crosshatching in pewter and ivory"
 description: "McKinsey's data shows 70% of digital transformations fail their stated objectives. Why the failure rate persists despite a decade of accumulated wisdom."

--- a/_posts/2026-01-19-the-surprising-economics-of-test-automation-roi.md
+++ b/_posts/2026-01-19-the-surprising-economics-of-test-automation-roi.md
@@ -3,7 +3,7 @@ layout: post
 title: "The automation accountant: what test ROI looks like"
 date: 2026-01-19
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/the-surprising-economics-of-test-automation-roi.png
 image_alt: "Warm editorial illustration of an accountant examining an oversized ledger where automation costs spill off the page, muted amber and cream palette with fine pen hatching"
 description: "Forrester tracked 15 enterprise test automation programmes. Median ROI reached 143%, but payback took 23 months—and 4 programmes never broke even."

--- a/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
+++ b/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
@@ -3,7 +3,7 @@ layout: post
 title: "Test automation's hidden ledger: costs nobody budgets"
 date: 2026-04-04
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/automation-hidden-ledger.png
 image_alt: "Close-up editorial photomontage of an oversized accountant's ledger where red-ink automation costs sprawl beyond the margins onto the surrounding desk"
 description: "Test automation now consumes 42% of QA budgets—up from 31% in 2020. The rise isn't from expanded coverage; it's from the cost of keeping automation alive."

--- a/_posts/2026-04-05-ai-quality-testing-automation.md
+++ b/_posts/2026-04-05-ai-quality-testing-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "AI Testing Tools: The Adoption Chasm Nobody Discusses"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/ai-quality-testing-adoption.png
 image_alt: "Bold infographic showing a yawning chasm separating 'pilot' enterprises from 'deployed at scale', rendered in vivid burnt-orange and electric-blue block-print style"
 description: "89% of enterprises are piloting AI in QA, but only 15% have deployed it at scale — the gap is organisational inertia, not technology readiness."

--- a/_posts/2026-04-05-copq-in-software-engineering-and-how-quality-engin.md
+++ b/_posts/2026-04-05-copq-in-software-engineering-and-how-quality-engin.md
@@ -3,7 +3,7 @@ layout: post
 title: "Software's Trillion-Dollar Tax: The Cost Nobody Itemises"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Software Engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/copq-software-engineering.png
 image_alt: "Cool photorealistic newspaper front page displaying a trillion-dollar bill for software bugs, broadsheet layout with formal serif typography on aged newsprint"
 description: "CISQ estimates poor software quality costs the US $2.41 trillion a year. CrowdStrike's single untested update destroyed $500 million in one afternoon."

--- a/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
+++ b/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "The Concealed Price Tag of Test Automation"
 date: 2026-04-06
 author: "Ouray Viney"
-categories: ["Quality Engineering", "Test Automation"]
+categories: ["Test Automation"]
 image: /assets/images/testing-tax-shifted-costs.png
 image_alt: "Cold technical blueprint of automation machinery with price-tag labels attached to every component and subsystem, engineering schematic style in white lines on deep navy"
 description: "Only 25% of test automation programmes hit their projected ROI. Licensing, maintenance, and hidden integration costs inflate budgets by 20-30%."


### PR DESCRIPTION
## Summary

8 posts were using two categories (e.g., `["Quality Engineering", "Test Automation"]`). The editorial convention (SKILL.md) requires exactly one category per post.

## Changes

| File | Old | New |
|------|-----|-----|
| the-hidden-technical-debt-of-test-automation | Quality Engineering + Test Automation | Test Automation |
| the-productivity-paradox-of-test-coverage-metrics | Quality Engineering + Test Automation | Test Automation |
| the-surprising-economics-of-test-automation-roi | Quality Engineering + Test Automation | Test Automation |
| the-real-cost-of-test-automation | Quality Engineering + Test Automation | Test Automation |
| ai-quality-testing-automation | Quality Engineering + Test Automation | Test Automation |
| the-concealed-price-tag-of-test-automation | Quality Engineering + Test Automation | Test Automation |
| why-most-digital-transformations-fail | Quality Engineering + Software Engineering | Software Engineering |
| copq-in-software-engineering | Quality Engineering + Software Engineering | Quality Engineering |

## Category distribution after fix

- Quality Engineering: 8
- Test Automation: 7
- Software Engineering: 4
- Security: 2

## Validation

- `bundle exec jekyll build` ✅
- All front matter audit: 0 invalid categories, 0 multi-category posts ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>