### PR TITLE
fix(GH-804): validate image dimensions in validate-posts.sh

### DIFF
--- a/scripts/validate-posts.sh
+++ b/scripts/validate-posts.sh
@@ -101,6 +101,29 @@ for post in $POSTS; do
       echo "❌  $rel — image path does not exist: '$image_val'"
       ERRORS=$((ERRORS + 1))
       post_errors=$((post_errors + 1))
+    else
+      # Check image is not a stub (must be at least 100×100 px)
+      if command -v python3 &>/dev/null; then
+        dim_check=$(python3 - "$image_abs" <<'PYEOF'
+import sys
+try:
+    from PIL import Image
+    with Image.open(sys.argv[1]) as img:
+        w, h = img.size
+        if w < 100 or h < 100:
+            print(f"STUB:{w}x{h}")
+except ImportError:
+    pass  # Pillow not available — skip dimension check
+except Exception:
+    pass
+PYEOF
+)
+        if [[ "$dim_check" == STUB:* ]]; then
+          echo "❌  $rel — featured image is a stub (${dim_check#STUB:}): '$image_val'"
+          ERRORS=$((ERRORS + 1))
+          post_errors=$((post_errors + 1))
+        fi
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

Closes #804

Adds a Pillow-based dimension check to `validate-posts.sh`. Images smaller than 100x100 px are now rejected as stubs, catching the placeholder pattern that allowed a 1x1 PNG to reach production.

## Root cause this fixes

A 1x1 pixel stub was deployed in the QA/QC/QE post (see #802). Every existing gate validated file existence but not dimensions.

## Change

After the existing file-existence check in `scripts/validate-posts.sh`, use Python/Pillow to verify minimum dimensions (100x100 px). Gracefully degrades if Pillow is unavailable — check is skipped rather than erroring.

## Test output

All 22 valid posts pass. The stub image fails:

```
XX  _posts/2026-04-12-understanding-qa-qc-and-quality-engineering.md — featured image is a stub (1x1): '/assets/images/understanding-qa-qc-quality-engineering.png'
validate-posts: FAILED — 1 error(s) found.
```

## Notes
- 100px threshold catches stubs without false-positiving on small intentional images
- Pillow already present in CI via economist-agents pipeline