### PR TITLE
feat(GH-810): add .claude/commands/ slash commands

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,15 @@
+---
+description: Build incrementally — start the Jekyll dev server and implement one slice at a time
+---
+
+Invoke the jekyll-development skill, then the relevant domain skill (economist-theme, editorial, or jekyll-qa).
+
+Follow the incremental implementation pattern:
+1. Start the Jekyll dev server: `bundle exec jekyll serve --config _config_dev.yml`
+2. Implement the smallest possible working slice
+3. Verify visually at http://localhost:4000 before committing
+4. Commit with a descriptive message referencing the issue
+5. Move to the next slice
+
+Always test at 320px, 768px, and 1024px before marking a visual slice done.
+Never commit without a passing `bundle exec jekyll build`.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,14 @@
+---
+description: Plan how to build it — break a GitHub Issue into small, atomic tasks before writing any code
+---
+
+Invoke the planning skill.
+
+Read the GitHub Issue number the user provides (or ask for it). Then:
+1. Fetch the issue with `gh issue view <N> --repo oviney/blog`
+2. Identify which agent label applies and which skill file to read
+3. Break the work into atomic tasks (each task = one logical change, one commit)
+4. Present the task list with estimated effort (S/M/L) before starting
+5. Insert tasks into the session SQL todos table for tracking
+
+Do NOT write any code until the user confirms the plan.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,18 @@
+---
+description: Review before merge — evaluate a PR or diff across correctness, style, security, and accessibility
+---
+
+Invoke the code-review skill, then adopt the code-reviewer agent persona from .claude/agents/code-reviewer.md.
+
+For a given PR number or diff:
+1. Fetch the diff: `gh pr diff <N> --repo oviney/blog`
+2. Evaluate across five dimensions:
+   - **Correctness** — does it do what the issue requires?
+   - **Style** — SCSS variables only, no hardcoded values, follows economist-theme conventions
+   - **Architecture** — does it follow existing patterns? No scope creep.
+   - **Security** — no secrets, no unsafe Liquid, no new unreviewed dependencies
+   - **Accessibility** — WCAG AA contrast, semantic HTML, keyboard navigable
+3. Categorise findings as MUST FIX / SHOULD FIX / CONSIDER
+4. Post review comment on the PR or summarise findings
+
+Always check: does `bundle exec jekyll build` pass on the branch?

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,17 @@
+---
+description: Ship to production — commit, push, open a PR, and verify deployment on viney.ca
+---
+
+Invoke the git-operations skill.
+
+Follow the shipping checklist:
+1. Confirm `bundle exec jekyll build` passes on the branch
+2. Confirm all acceptance criteria from the issue are met
+3. Create a PR: `gh pr create --repo oviney/blog --title "..." --body "Closes #N"`
+4. Wait for GitHub Actions to go green (CI Orchestrator + Deploy Jekyll)
+5. Verify on production: `curl -sI https://www.viney.ca/ | grep HTTP`
+6. Navigate to the affected URL on viney.ca and visually confirm the fix
+7. Comment on the issue with production verification notes
+
+Never merge a PR with a red CI check.
+Admin-merge when needed: `gh pr merge <N> --repo oviney/blog --admin --squash --delete-branch`

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,0 +1,19 @@
+---
+description: Start spec-driven development — write a well-formed GitHub Issue before writing code
+---
+
+Invoke the github-issues-workflow skill.
+
+Begin by understanding what the user wants to build or fix. Ask clarifying questions about:
+1. Is this a bug or a feature?
+2. Which agent domain does it fall under? (design/content/QA/general)
+3. What are the acceptance criteria?
+4. What priority — P1/P2/P3?
+
+Then create a well-formed GitHub Issue on oviney/blog with:
+- Descriptive title using feat:/fix:/chore: prefix
+- Clear problem statement and desired behaviour
+- Testable acceptance criteria checklist
+- Correct labels (bug/enhancement + agent label + priority)
+
+Confirm with the user before filing the issue.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,18 @@
+---
+description: Prove it works — run the full test suite (Playwright, pa11y, Lighthouse, Jekyll build)
+---
+
+Invoke the jekyll-qa skill.
+
+Run the test suite in this order:
+1. `bundle exec jekyll build` — must pass before anything else
+2. Start dev server: `bundle exec jekyll serve --config _config_dev.yml`
+3. `npx playwright test` — all projects (Mobile/Tablet/Desktop)
+4. Check for visual regressions, accessibility failures, and performance issues
+
+Report results as:
+- ✅ Passed / ❌ Failed / ⚠️ Warning
+- For failures: include the exact error, file, and line number
+- For warnings: explain the impact and whether it blocks merge
+
+If any test fails, stop and diagnose before continuing.


### PR DESCRIPTION
Adds 6 lifecycle slash commands to `.claude/commands/`, mirroring the `addyosmani/agent-skills` pattern.

| Command | Activates |
|---------|-----------|
| `/spec` | github-issues-workflow — file a well-formed issue |
| `/plan` | planning skill — break into atomic tasks |
| `/build` | jekyll-development + domain skill |
| `/test` | jekyll-qa — full test suite |
| `/review` | code-review + code-reviewer persona |
| `/ship` | git-operations — PR, CI, production verify |

Closes #810