### PR TITLE
fix(GH-818): pin basic-ftp to 5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,9 +2368,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "overrides": {
     "lodash": "^4.18.1",
     "tmp": ">=0.2.3",
-    "basic-ftp": ">=5.2.1"
+    "basic-ftp": "5.3.0"
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
## Summary

Pin the transitive `basic-ftp` override to a patched release so the security audit passes again.

## Changes

- tighten the npm override from a vulnerable range to `5.3.0`
- regenerate `package-lock.json` with no unrelated dependency churn
- restore `npm audit --audit-level=moderate` to green

## Testing

- [x] `npm audit --audit-level=moderate` passes
- [x] `bundle exec jekyll build` passes
- [ ] Playwright tests pass (if applicable)
- [ ] Manually verified at target viewports (320 px, 768 px, 1024 px)

## Screenshots

Not applicable — dependency-only remediation.

Closes #818