### PR TITLE
fix(GH-824): normalize quality and software categories

### DIFF
--- a/_posts/2025-12-31-testing-times.md
+++ b/_posts/2025-12-31-testing-times.md
@@ -3,7 +3,7 @@ layout: post
 title: "Testing times: why AI conquered QA without improving it"
 date: 2025-12-31
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/testing-times-renovation.png
 image_alt: "Warm sepia editorial illustration of robots holding QA dashboards while human testers observe from the sidelines, vintage newspaper engraving style"
 description: "80% of software teams will use AI testing tools by 2025. Vendors raised $2.3 billion. Yet defect rates remain unchanged. An examination of the gap."

--- a/_posts/2026-01-18-ai-assisted-development-the-new-industrial-revolut.md
+++ b/_posts/2026-01-18-ai-assisted-development-the-new-industrial-revolut.md
@@ -3,7 +3,7 @@ layout: post
 title: "Code Generators: The Brilliant Interns Nobody Supervises"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["software-engineering"]
+categories: ["Software Engineering"]
 image: /assets/images/ai-assisted-code-generation.png
 image_alt: "Whimsical watercolour scene of unsupervised intern robots typing furiously at keyboards in an empty open-plan office, pastel tones with loose brushwork"
 description: "AI code generators boost typing speed but degrade code quality — METR found developers are 19% slower on tasks, while GitClear shows 41% higher code churn."

--- a/_posts/2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md
+++ b/_posts/2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md
@@ -3,7 +3,7 @@ layout: post
 title: "Testing Theatre: The QA Metrics That Fool Everyone"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/testing-theatre-vanity-metrics.png
 image_alt: "Theatrical stage-set editorial illustration with green-light QA dashboards as painted scenery props while actors perform quality rituals for an unseen audience"
 description: "Volkswagen's tests hit 94% pass rates — then a two-year launch delay exposed the gap. Most QA dashboards measure activity, not outcomes."

--- a/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
+++ b/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
@@ -3,7 +3,7 @@ layout: post
 title: "Digital transformation's dirty secret: the 70% that never deliver"
 date: 2026-01-18
 author: "Ouray Viney"
-categories: ["software-engineering"]
+categories: ["Software Engineering"]
 image: /assets/images/digital-transformation-secret.png
 image_alt: "Monochrome architectural rendering of a half-built digital bridge crumbling on the far side, rendered with precise pencil-sketch crosshatching in pewter and ivory"
 description: "McKinsey's data shows 70% of digital transformations fail their stated objectives. Why the failure rate persists despite a decade of accumulated wisdom."

--- a/_posts/2026-04-05-building-a-test-strategy-that-works.md
+++ b/_posts/2026-04-05-building-a-test-strategy-that-works.md
@@ -3,7 +3,7 @@ layout: post
 title: "The test strategy trap: why quality plans fail"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/test-strategy-trap.png
 image_alt: "Cold technical blueprint of a test pyramid collapsing under its own weight, rendered in blueprint drafting style with crisp white lines on navy blue"
 description: "88% of organisations have a documented test strategy. Only 23% believe it works. An examination of why quality plans fail before the first test runs."

--- a/_posts/2026-04-05-copq-in-software-engineering-and-how-quality-engin.md
+++ b/_posts/2026-04-05-copq-in-software-engineering-and-how-quality-engin.md
@@ -3,7 +3,7 @@ layout: post
 title: "Software's Trillion-Dollar Tax: The Cost Nobody Itemises"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/copq-software-engineering.png
 image_alt: "Cool photorealistic newspaper front page displaying a trillion-dollar bill for software bugs, broadsheet layout with formal serif typography on aged newsprint"
 description: "CISQ estimates poor software quality costs the US $2.41 trillion a year. CrowdStrike's single untested update destroyed $500 million in one afternoon."

--- a/_posts/2026-04-05-cost-of-poor-quality-copq.md
+++ b/_posts/2026-04-05-cost-of-poor-quality-copq.md
@@ -3,7 +3,7 @@ layout: post
 title: "Quality's Second Act: What Software Can Steal from Factories"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/copq-cross-industry.png
 image_alt: "Split-panel editorial illustration contrasting a precise factory assembly line on the left with a chaotic software deployment pipeline on the right, risograph print texture"
 description: "Boeing's $31 billion quality failure mirrors software's inverted cost structure. US firms spend 3.4× more fixing defects than preventing them."

--- a/_posts/2026-04-05-practical-applications-of-ai-in-software-development.md
+++ b/_posts/2026-04-05-practical-applications-of-ai-in-software-development.md
@@ -3,7 +3,7 @@ layout: post
 title: "The coder's crutch: AI-assisted development's hidden costs"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["software-engineering"]
+categories: ["Software Engineering"]
 image: /assets/images/ai-coders-crutch.png
 image_alt: "Stark black-and-white editorial cartoon of a developer leaning on a giant crutch shaped like a glowing microchip, symbolising AI dependency"
 description: "AI tools like Copilot now write 46% of code on GitHub. Developers ship faster—but understand less, creating compounding technical debt."

--- a/_posts/2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md
+++ b/_posts/2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md
@@ -3,7 +3,7 @@ layout: post
 title: "Manual QA's Last Stand: The Machines Have Already Won"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/the-end-of-manual-qa.png
 image_alt: "Dramatic duotone illustration of a lone human tester at a desk surrounded by advancing robotic assembly lines, film noir lighting in deep teal and amber"
 description: "89% of enterprises are piloting AI in QA, yet only 16% have adopted it. The 59-point gap is closing fast — and manual QA's economics have collapsed."

--- a/_posts/2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md
+++ b/_posts/2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md
@@ -3,7 +3,7 @@ layout: post
 title: "The maintenance myth: what AI test generation costs"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 image: /assets/images/why-recent-ai-test-generation-tools-are-overpromising-on-mai.png
 image_alt: "Stark black-and-white bar chart infographic placing vendor-promised savings alongside IEEE-measured actuals, data-journalism style with minimal colour"
 description: "AI testing vendors promise 80% reductions in maintenance effort. IEEE research across 400 teams finds 62% see no meaningful savings."

--- a/_posts/2026-04-12-platform-engineering-adoption-crisis.md
+++ b/_posts/2026-04-12-platform-engineering-adoption-crisis.md
@@ -3,7 +3,7 @@ layout: post
 title: "Platform Engineering's Adoption Crisis: Why Potential Goes Unrealised"
 date: 2026-04-12
 author: "Ouray Viney"
-categories: ["software-engineering"]
+categories: ["Software Engineering"]
 description: "Most platform engineering initiatives stall before delivering value. Here is why cultural inertia, poor tooling, and misaligned expectations derail the promise."
 tags: [platform-engineering, developer-experience, devops, adoption]
 image: /assets/images/platform-engineering-adoption-crisis.png

--- a/_posts/2026-04-12-platform-engineering-developer-portals.md
+++ b/_posts/2026-04-12-platform-engineering-developer-portals.md
@@ -3,7 +3,7 @@ layout: post
 title: "The Golden Path: Platform Engineering's Quiet Revolution"
 date: 2026-04-12
 author: "Ouray Viney"
-categories: ["software-engineering"]
+categories: ["Software Engineering"]
 tags: [platform-engineering, developer-portals, backstage, developer-experience, internal-developer-platform]
 image: /assets/images/platform-engineering-developer-portals.png
 image_alt: "Abstract illustration of interconnected developer tools forming a unified platform"

--- a/_posts/2026-04-12-understanding-qa-qc-and-quality-engineering.md
+++ b/_posts/2026-04-12-understanding-qa-qc-and-quality-engineering.md
@@ -3,7 +3,7 @@ layout: post
 title: "The quality confusion tax: when QA, QC and QE blur"
 date: 2026-04-12
 author: "Ouray Viney"
-categories: ["quality-engineering"]
+categories: ["Quality Engineering"]
 tags: [quality-assurance, quality-control, quality-engineering, quality-management]
 image: /assets/images/understanding-qa-qc-quality-engineering.png
 image_alt: "Crisp infographic diagram showing three distinct quality disciplines — QA, QC and QE — converging into a unified quality strategy, rendered in a clean editorial style with navy, grey and red accents"


### PR DESCRIPTION
## Summary
Normalize historical post categories for the Quality Engineering and Software Engineering slices.

## Changes
- update 13 published posts from lowercase/hyphenated categories to canonical editorial values
- keep the PR under the repo's 15-file scope gate
- leave the remaining Test Automation posts for the follow-up mainline PR

## Testing
- [x] `bundle exec jekyll build` passes
- [ ] `bash scripts/validate-post-quality.sh` passes on this PR alone (remaining test-automation posts are fixed in the follow-up)
- [ ] Manually verified at target viewports (not applicable)

## Screenshots
Not applicable.

Part 1 of #824