### PR TITLE
fix(GH-824): normalize remaining test automation categories

### DIFF
--- a/_posts/2026-01-02-self-healing-tests-myth-vs-reality.md
+++ b/_posts/2026-01-02-self-healing-tests-myth-vs-reality.md
@@ -3,7 +3,7 @@ layout: post
 title: "Self-healing tests: the promise that keeps breaking"
 date: 2026-01-02
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/self-healing-broken-promise.png
 image_alt: "High-contrast photorealistic close-up of a cracked mechanical arm attempting to reassemble itself mid-fracture, industrial photography with stark studio lighting"
 description: "Vendors promise 80% reductions in test maintenance. Independent data tells a different story: only 30% of teams achieve meaningful autonomy."

--- a/_posts/2026-01-18-the-hidden-technical-debt-of-test-automation.md
+++ b/_posts/2026-01-18-the-hidden-technical-debt-of-test-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "Test Automation's Dirty Secret: The Debt Nobody Budgets For"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/test-automation-technical-debt.png
 image_alt: "Stark data-visualisation style chart showing compounding technical debt curves in crimson on white, inspired by financial charting with annotated inflection points"
 description: "Flaky tests caused 57% of Slack's CI failures. Test suites now consume 40% of QA capacity in maintenance — becoming the debt they were built to prevent."

--- a/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
+++ b/_posts/2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md
@@ -3,7 +3,7 @@ layout: post
 title: "Coverage Obsession: The Metric That Ate Quality Engineering"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/test-coverage-paradox.png
 image_alt: "Cold infographic showing a coverage meter pegged at 100% while a cartoon bug slips through an unchecked gap, technical diagram style in slate grey and white"
 description: "Research shows coverage has low correlation with fault detection after controlling for suite size. Google enforces no coverage target — here is why."

--- a/_posts/2026-01-19-the-surprising-economics-of-test-automation-roi.md
+++ b/_posts/2026-01-19-the-surprising-economics-of-test-automation-roi.md
@@ -3,7 +3,7 @@ layout: post
 title: "The automation accountant: what test ROI looks like"
 date: 2026-01-19
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/the-surprising-economics-of-test-automation-roi.png
 image_alt: "Warm editorial illustration of an accountant examining an oversized ledger where automation costs spill off the page, muted amber and cream palette with fine pen hatching"
 description: "Forrester tracked 15 enterprise test automation programmes. Median ROI reached 143%, but payback took 23 months—and 4 programmes never broke even."

--- a/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
+++ b/_posts/2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md
@@ -3,7 +3,7 @@ layout: post
 title: "Test automation's hidden ledger: costs nobody budgets"
 date: 2026-04-04
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/automation-hidden-ledger.png
 image_alt: "Close-up editorial photomontage of an oversized accountant's ledger where red-ink automation costs sprawl beyond the margins onto the surrounding desk"
 description: "Test automation now consumes 42% of QA budgets—up from 31% in 2020. The rise isn't from expanded coverage; it's from the cost of keeping automation alive."

--- a/_posts/2026-04-05-ai-quality-testing-automation.md
+++ b/_posts/2026-04-05-ai-quality-testing-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "AI Testing Tools: The Adoption Chasm Nobody Discusses"
 date: 2026-04-05
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/ai-quality-testing-adoption.png
 image_alt: "Bold infographic showing a yawning chasm separating 'pilot' enterprises from 'deployed at scale', rendered in vivid burnt-orange and electric-blue block-print style"
 description: "89% of enterprises are piloting AI in QA, but only 15% have deployed it at scale — the gap is organisational inertia, not technology readiness."

--- a/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
+++ b/_posts/2026-04-06-the-concealed-price-tag-of-test-automation.md
@@ -3,7 +3,7 @@ layout: post
 title: "The Concealed Price Tag of Test Automation"
 date: 2026-04-06
 author: "Ouray Viney"
-categories: ["test-automation"]
+categories: ["Test Automation"]
 image: /assets/images/testing-tax-shifted-costs.png
 image_alt: "Cold technical blueprint of automation machinery with price-tag labels attached to every component and subsystem, engineering schematic style in white lines on deep navy"
 description: "Only 25% of test automation programmes hit their projected ROI. Licensing, maintenance, and hidden integration costs inflate budgets by 20-30%."


### PR DESCRIPTION
## Summary
Normalize the remaining historical Test Automation post categories after #826 landed the first batch.

## Changes
- update 7 published posts from lowercase/hyphenated categories to the canonical `Test Automation` value
- complete the repo-wide category normalization baseline
- unblock unrelated PRs from the historical content-validation failure

## Testing
- [x] `bundle exec jekyll build` passes
- [x] `bash scripts/validate-post-quality.sh` passes (warnings only)
- [ ] Manually verified at target viewports (not applicable)

## Screenshots
Not applicable.

Closes #824