### PR TITLE
fix: remediate LHCI audit baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -512,6 +512,20 @@
         "tldts-core": "^6.1.86"
       }
     },
+    "node_modules/@lhci/cli/node_modules/uuid": {
+      "name": "@smithy/uuid",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@lhci/cli/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -6946,16 +6960,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
   "overrides": {
     "lodash": "^4.18.1",
     "tmp": ">=0.2.3",
-    "basic-ftp": "5.3.0"
+    "basic-ftp": "5.3.0",
+    "@lhci/cli": {
+      "uuid": "npm:@smithy/uuid@^1.1.2"
+    }
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
## Summary

Remediate the failing npm security audit baseline by replacing `@lhci/cli`'s vulnerable `uuid` dependency with a scoped, CommonJS-compatible override.

## Changes

- add an npm override so only `@lhci/cli` resolves `uuid` to `@smithy/uuid`
- refresh `package-lock.json` for the targeted Lighthouse dependency change
- keep the existing `@lhci/cli` version and Lighthouse workflow unchanged

## Testing

- [x] `npm run test:security`
- [x] `bundle exec jekyll build`
- [x] `npm run test:lighthouse`

Closes #839
