### PR TITLE
test(GH-846): add Playwright ARIA smoke coverage

### DIFF
--- a/tests/playwright-agents/homepage.spec.ts
+++ b/tests/playwright-agents/homepage.spec.ts
@@ -174,6 +174,32 @@ test.describe('@content @navigation Homepage Redesign @REQ-CONTENT-01 @REQ-VISUA
     expect(currentUrl).not.toBe('http://localhost:4000/');
   });
 
+  test('Homepage main landmark matches ARIA smoke snapshot', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('main').first()).toMatchAriaSnapshot(`
+      - main:
+        - heading /Latest post:.+/ [level=1]
+        - region "Focus Areas":
+          - heading "Focus Areas" [level=2]
+        - region "From the Blog":
+          - heading "From the Blog" [level=2]
+          - article
+          - article
+          - article
+        - region "About the author":
+          - heading [level=2]
+          - link "About me"
+          - link /LinkedIn/
+          - link /GitHub/
+          - link "RSS Feed"
+        - complementary:
+          - heading "Stay informed" [level=3]
+          - link "Subscribe via RSS →"
+    `);
+  });
+
 });
 
 test.describe('@visual @navigation Homepage Responsive Layout @REQ-VISUAL-01 @REQ-CONTENT-01', () => {

--- a/tests/playwright-agents/navigation.spec.ts
+++ b/tests/playwright-agents/navigation.spec.ts
@@ -239,6 +239,29 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
     }
   });
 
+  test('Representative post article matches ARIA smoke snapshot', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const representativePostLink = page.locator('.hero-post-title a, .hero-post-cta').first();
+    await expect(representativePostLink).toBeVisible();
+    await representativePostLink.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('main article').first()).toMatchAriaSnapshot(`
+      - article:
+        - link /.+/
+        - heading /.+/ [level=1]
+        - button "Copy link to this article"
+        - figure "ILLUSTRATION"
+        - time
+        - navigation "Table of contents"
+        - heading "References" [level=2]
+        - list
+        - heading "Explore more" [level=3]
+    `);
+  });
+
   test('Main navigation accessibility and keyboard support', async ({ page }) => {
     await page.goto('/');
 
@@ -451,6 +474,34 @@ test.describe('@navigation Mobile Navigation Specific Tests @REQ-NAV-01 @REQ-NAV
     await toggle.click();
     await expect(nav).toBeHidden();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('Mobile navigation landmark matches ARIA smoke snapshot', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const toggle = page.getByRole('button', { name: /open navigation menu/i });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    await expect(page.locator('#site-navigation')).toMatchAriaSnapshot(`
+      - navigation:
+        - list:
+          - listitem:
+            - link "Home"
+          - listitem:
+            - link "Blog"
+          - listitem:
+            - link "Software Engineering"
+          - listitem:
+            - link "Test Automation"
+          - listitem:
+            - link "About"
+          - listitem:
+            - link "Search"
+          - listitem:
+            - link "RSS"
+    `);
   });
 
   test('Nav link tap closes the hamburger menu', async ({ page }) => {


### PR DESCRIPTION
## Summary

Add lightweight Playwright ARIA snapshot smoke coverage for key page structure on the homepage, mobile navigation, and a representative post.

## Changes

- add a scoped homepage main landmark ARIA smoke snapshot
- add a scoped mobile navigation landmark ARIA smoke snapshot
- add a representative post article ARIA smoke snapshot via the homepage hero link
- keep coverage inside the existing Playwright spec files with no unrelated test churn

## Testing

- [x] bundle exec jekyll build
- [x] npx playwright test tests/playwright-agents/homepage.spec.ts tests/playwright-agents/navigation.spec.ts --project=Mobile Chrome --project=Tablet Chrome --project=Desktop Chrome --grep ARIA smoke snapshot
- [x] Manually verified the snapshot scopes against the local Jekyll site structure

Closes #846