### PR TITLE
docs: improve digital transformation post SEO

### DIFF
--- a/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
+++ b/_posts/2026-01-18-why-most-digital-transformations-fail-to-deliver-r.md
@@ -1,48 +1,53 @@
 ---
 layout: post
-title: "Digital transformation's dirty secret: the 70% that never deliver"
+title: "Why 70% of Digital Transformations Still Fail"
 date: 2026-01-18
 author: "Ouray Viney"
 categories: ["Software Engineering"]
+tags: [digital-transformation, software-engineering, change-management, engineering-leadership]
 image: /assets/images/digital-transformation-secret.png
 image_alt: "Monochrome architectural rendering of a half-built digital bridge crumbling on the far side, rendered with precise pencil-sketch crosshatching in pewter and ivory"
-description: "McKinsey's data shows 70% of digital transformations fail their stated objectives. Why the failure rate persists despite a decade of accumulated wisdom."
+description: "Why digital transformations fail: most programmes still miss targets because governance, talent and operating-model problems overwhelm the technology."
 ---
 
 ![Digital transformation failures: 82% stem from organisational and governance problems, not technology](/assets/charts/why-most-digital-transformations-fail-to-deliver-r.svg)
 *Source: McKinsey Digital Transformation Survey, 2023; BCG Transformation Analysis, 2023*
 
-McKinsey has been tracking digital transformation success rates since 2018, and the headline number has barely moved: 70% of initiatives fail to meet their stated objectives. In its 2023 update, the consultancy surveyed 1,500 executives across 20 industries and found that the average transformation consumed 10% of annual revenue over three years while delivering less than half the projected value. The persistence of this failure rate, despite a decade of accumulated wisdom, suggests the problem is structural, not informational.
+Seven in ten digital transformations still miss their targets. In its 2023 update, McKinsey surveyed 1,500 executives across 20 industries and found that the average programme consumed 10% of annual revenue over three years while delivering less than half its projected value. After a decade of accumulated wisdom, that persistence looks less like bad luck than a management design flaw.
 
-## The technology alibi
+The evidence points to four recurring failure modes: diffuse accountability, weak customer focus, unrealistic integration plans, and chronic underinvestment in skills. Technology appears in each of them, but rarely as the decisive constraint.
+
+## Why technology gets blamed first
 
 The instinct to blame technology is understandable and almost always wrong. BCG's 2023 analysis of 900 transformation programmes found that technology-related issues accounted for only 18% of failures. The remaining 82% stemmed from organisational resistance, unclear accountability, and what BCG diplomatically termed "ambiguity in the operating model" — the corporate equivalent of nobody knowing who is supposed to do what.
 
 Bain & Company's research tells a complementary story. Among transformations that the firm classified as successful, 85% had a single executive with clear authority over the programme's scope, budget, and timeline. Among failures, that figure dropped to 29%. The technology was often identical in both groups. The difference was whether someone could make decisions without convening a steering committee.
 
-## The customer exception
+## Why customer-led transformations outperform
 
 Not all transformations fail at the same rate, and the exceptions are instructive. BCG found that initiatives explicitly designed around customer experience improvements succeeded 2.5 times more frequently than those aimed at operational efficiency or cost reduction. The explanation is prosaic: customer-facing changes produce visible, measurable results quickly — a redesigned checkout flow, a faster mobile application, a streamlined onboarding process. These quick wins sustain executive commitment and team morale through the difficult middle phase where most transformations stall.
 
 Walmart's grocery delivery platform, rebuilt between 2021 and 2023, exemplifies this pattern. The company framed the transformation not as a technology migration but as a customer promise: order by midnight, receive by 8am. Every engineering decision was evaluated against that commitment. The result, documented in Walmart's 2023 investor presentations, was a 35% increase in digital grocery revenue and a platform that processed 2 million daily orders — outcomes that justified the investment before the programme was officially complete.
 
-## Why timelines always expand
+The same logic appears in {% post_url 2026-04-12-platform-engineering-adoption-crisis %}, where internal platforms succeed only when teams treat adoption as a customer problem rather than an infrastructure one.
+
+## Why digital transformation timelines slip
 
 More than 75% of transformation leaders report that their initiatives exceeded planned timelines, according to Deloitte's 2023 Digital Transformation Survey. The delay pattern is consistent: the first 30% of the work takes 40% of the planned time, creating a false sense of progress. The next 40% — the integration phase, where new systems must coexist with legacy infrastructure — consumes 80% of the remaining time and most of the unplanned budget.
 
 The integration problem is particularly acute in regulated industries. At a major European bank that Deloitte studied, a core banking platform migration planned for 18 months took 42 months because each regulatory approval cycle added 4-6 months that the project plan had not anticipated. The technology worked. The organisation could not move at the speed the technology permitted.
 
-## The talent gap nobody budgets for
+## The talent gap transformation budgets ignore
 
 Technology failures account for only 18% of transformation breakdowns, but a closely related cause — the shortage of people who understand both the technology and the business domain — rarely appears in post-mortems. McKinsey's 2023 survey found that 64% of transformation leaders cited talent gaps as a "significant barrier," yet only 22% had allocated dedicated budget for upskilling or external hiring as part of the programme's costs. The talent deficit was treated as an HR problem, not a transformation risk.
 
 The consequences are predictable. AWS's 2024 Global Digital Skills Study estimated that organisations which invested in workforce training alongside technology change achieved 2.6 times higher ROI on their digital initiatives than those that did not. The World Economic Forum's 2023 Future of Jobs Report projected that 44% of workers' core skills would need updating by 2027 — a timeline that overlaps with most active transformation programmes. Ignoring the skills component does not save money; it defers costs into the integration phase where they compound.
 
-## The uncomfortable prescription
+## What successful transformations do differently
 
 The 30% of transformations that succeed share a characteristic that most organisations find culturally unbearable: they start small. Rather than launching an enterprise-wide programme with a three-year roadmap, successful transformations pick a single business process, transform it completely, measure the result, and then decide whether to continue. This approach is slower to announce but faster to deliver, and it produces the evidence that sustains funding through inevitable setbacks.
 
-The organisations still planning their next comprehensive digital transformation should consider a different question: what is the smallest change that would produce a measurable improvement in how a customer experiences your product? The answer to that question is worth more than any transformation roadmap.
+For engineering leaders, the practical question is not whether transformation matters but where to begin. What is the smallest change that would produce a measurable improvement in how a customer experiences your product, reduce a known operational bottleneck, and force one accountable executive to own the result? The answer to that question is worth more than any transformation roadmap.
 
 ## References
 


### PR DESCRIPTION
## Summary
Improve the Software Engineering post on digital transformation failure rates for stronger SEO clarity and a sharper opening argument.

## Changes
- strengthen the opening hook with a clearer lead and management-focused framing
- tighten the SEO title and meta description around digital transformation failure intent
- rename section headings for clearer scanability and add one directly related internal link

## Testing
- [x] `bundle exec jekyll build` passes
- [x] `bash scripts/validate-posts.sh --all` passes
- [ ] Playwright tests pass (not applicable for this post-only change)
- [ ] Manually verified at target viewports (not applicable for this post-only change)

Closes #849