### PR TITLE
docs: clarify Copilot cloud agent instruction flow

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -4,10 +4,18 @@ For direct/local agent work in this repo, the upstream `agent-skills` lifecycle
 is the working backbone, with viney.ca blog skills layered on top where
 repo-specific guidance is helpful.
 
-Issue-assigned cloud agents still follow `.github/copilot-instructions.md`.
-The upstream-aligned files in this directory are reference guides; the callable
-skills in this environment are the local lifecycle skills such as `spec`,
-`planning-and-task-breakdown`, `build`, `test`, `review`, and `ship`.
+Issue-assigned **Copilot cloud agents** still follow repo instructions in
+`.github/copilot-instructions.md`, then any matching path instructions in
+`.github/instructions/`.
+
+Use `AGENTS.md` for persona boundaries, ownership, and handoffs, and use
+`CLAUDE.md` for the local/direct lifecycle backbone. The upstream-aligned files in
+this directory are reference guides; the callable skills in this environment are the
+local lifecycle skills such as `spec`, `planning-and-task-breakdown`, `build`,
+`test`, `review`, and `ship`.
+
+Custom agents and MCP/tool integrations are runtime-dependent. Treat them as
+optional execution aids when available, not as guarantees across every runtime.
 
 ## Lifecycle Backbone
 

--- a/.github/skills/using-agent-skills/SKILL.md
+++ b/.github/skills/using-agent-skills/SKILL.md
@@ -18,7 +18,17 @@ The upstream-aligned guides live in `.github/skills/spec-driven-development/`,
 reference docs backing the callable local skills such as `spec`, `build`, `test`,
 `review`, and `ship`.
 
-Issue-assigned cloud agents still follow `.github/copilot-instructions.md`.
+For issue-assigned **Copilot cloud agent** work, stay inside this repo-authored
+instruction envelope:
+
+1. Start with repo instructions in `.github/copilot-instructions.md`
+2. Apply any matching path instructions from `.github/instructions/`
+3. Use `AGENTS.md` and the relevant skill files as supporting repo context
+
+This meta-skill helps choose the right lifecycle skill inside that envelope; it does
+not replace the repo or path instructions. Runtime features such as custom agents or
+MCP/tool integrations are useful when available, but they are runtime-dependent and
+should not be documented as guaranteed everywhere.
 
 ## Skill Discovery Flowchart
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,20 @@ callable local lifecycle skills first, then use the upstream-aligned reference
 guides in `.github/skills/` plus any viney.ca blog skill needed for repo-specific
 constraints and conventions.
 
-Issue-assigned cloud agents still follow the label-first routing in
+Issue-assigned **Copilot cloud agents** still follow the label-first routing in
 `.github/copilot-instructions.md`; this file describes the lifecycle backbone for
 local/direct execution and command-driven workflows in the repo.
+
+## Repo Instruction Layers
+
+Use the repo's instruction sources as complementary layers:
+
+1. `.github/copilot-instructions.md` — repo-wide instructions and hard boundaries for issue-assigned Copilot cloud agent work
+2. `.github/instructions/` — path instructions that add file- or directory-specific rules when a touched path matches
+3. `AGENTS.md` — shared memory for personas, scope boundaries, ownership, and handoffs; it adds repo context but does not override repo or path instructions
+4. `CLAUDE.md` — local/direct execution guidance for lifecycle skill order and command-layer workflows
+
+Runtime features such as custom agents or MCP/tool integrations can vary by execution environment. Use them when available, but do not imply every runtime exposes the same surface area.
 
 ## Persona Layers
 
@@ -46,7 +57,7 @@ For non-trivial work on oviney/blog, prefer tracked GitHub Issues:
 2. Create or identify the GitHub issue
 3. Apply the correct agent label (see table below)
 4. Assign to `@copilot`: `gh issue edit <N> --repo oviney/blog --add-assignee "@copilot"`
-5. The cloud agent picks it up, reads the relevant skill files, and opens a PR
+5. The Copilot cloud agent picks it up, reads the relevant skill files, and opens a PR
 6. Admin-merge when appropriate: `gh pr merge <N> --repo oviney/blog --admin --squash --delete-branch`
 
 **Reserve direct work for:** triage, orchestration, admin-merges, pipeline debugging,


### PR DESCRIPTION
## Summary

Refresh repo docs to use current Copilot cloud agent terminology and clarify how repo instructions, path instructions, AGENTS.md, and local lifecycle docs fit together.

## Changes

- align CLAUDE.md with Copilot cloud agent terminology
- document the repo instruction layering across repo instructions, path instructions, and AGENTS.md
- note that custom agents and MCP/tool integrations are runtime-dependent
- update the skills index and the using-agent-skills guide to match the same wording

## Testing

- [x] `bundle exec jekyll build` passes
- [x] `PR_LABELS='governance-update,documentation,enhancement,P2:medium' bash scripts/check-pr-scope.sh` passes
- [ ] Playwright tests pass (not applicable)
- [ ] Manually verified at target viewports (not applicable)

## Screenshots

Not applicable — docs-only change.

Closes #845
