### PR TITLE
docs: strengthen security debt post

### DIFF
--- a/_posts/2026-04-12-the-hidden-economics-of-security-debt.md
+++ b/_posts/2026-04-12-the-hidden-economics-of-security-debt.md
@@ -1,54 +1,53 @@
 ---
 layout: post
-title: "The Financial Toll of Security Debt: A Growing Concern"
+title: "The Financial Toll of Security Debt"
 date: 2026-04-12
 author: "Ouray Viney"
 categories: ["Security"]
-description: "Exploring the financial implications and challenges of managing security debt within organizations."
+tags: [security-debt, vulnerability-management, cyber-risk, remediation]
+description: "Security debt compounds on the balance sheet through slower remediation, higher breach exposure and more expensive recovery."
 image: /assets/images/the-hidden-economics-of-security-debt.png
+image_alt: "Abstract illustration of financial ledgers overlaid with vulnerability alerts and security icons"
 ---
 
-Global security debt is projected to cost organisations an average of $9 million annually by 2026 due to unpatched vulnerabilities, according to a report by Cybersecurity Ventures. As cyber threats grow in complexity and frequency, the economic implications of failing to patch known vulnerabilities have become undeniably significant. Despite their knowledge of the financial risks, many organisations remain vulnerable, highlighting a critical issue: the escalating costs associated with poor vulnerability management and the struggle to implement effective security strategies.
+Security debt rarely looks dramatic on the day it is incurred. A critical patch is deferred because a release is due. An unsupported library survives another quarter because replacing it would slow delivery. Yet the bill keeps accumulating. IBM's *Cost of a Data Breach Report 2025* puts the global average breach cost at $4.4 million, while Veracode's 2025 public-sector research found that 78% of organisations still carried significant security debt: flaws left unresolved for more than a year. What begins as engineering delay ends, sooner or later, as a financial liability.
 
-## Rising Costs of Security Breaches
+## When the backlog becomes a balance-sheet problem
 
-Unpatched vulnerabilities are a ticking time bomb, accounting for up to 60% of cyber breaches. Even as the average cost of a data breach reached $4.35 million in 2025, the urgency of addressing these vulnerabilities has not been matched by action within many companies. Analysts from the IBM Cost of a Data Breach Report affirm that these breaches are not merely costly incidents but symptomatic of deeper systemic issues within organisations' approaches to cybersecurity.
+Security debt is the stock of known weaknesses an organisation has chosen not to fix yet. Like financial debt, it can be rational in small doses. A business may accept temporary risk to ship a product, complete a migration or avoid disrupting a critical system. The problem is not the existence of debt; it is the habit of refinancing it indefinitely.
 
-Companies that delay patching critical vulnerabilities often see their potential breach costs rise by as much as 50%, according to FTI Consulting. This daunting increase demonstrates not only the latent financial risks but also the reactive approach many organisations have towards cybersecurity. Rather than proactively managing vulnerabilities, businesses frequently find themselves in a cycle of firefighting—addressing issues only after they escalate into breaches.
+The public sector offers one of the clearest benchmarks. Veracode found that government organisations took an average of 315 days to fix half their software vulnerabilities, 63 days longer than the cross-industry average. Even after two years, one-third of those flaws remained unresolved, and 15% lingered for more than five years. At that point the backlog is no longer a queue of routine fixes. It is a portfolio of open invitations to attackers, auditors and insurers.
 
-## Security Debt Management
+## Attackers move faster than budget cycles
 
-The increase in security debt management costs over the past few years clearly illustrates the growing fiscal burden of unaddressed cybersecurity weaknesses. As evidenced by the data, there has been a significant rise in these costs, moving from $5 million in 2024 to a projected $9 million by 2026.
+The economic case for faster remediation becomes sharper when one looks at attacker behaviour. CISA notes that fewer than 4% of all CVEs have been publicly exploited in the wild. That sounds reassuring until the timing is considered: among those exploited vulnerabilities, 42% were used on day zero of disclosure, 50% within two days and 75% within 28 days.
 
-![Trend in Security Debt Management Costs](/assets/charts/the-hidden-economics-of-security-debt.png)
+That is the central asymmetry of security debt. Most finance and planning processes run in quarters. Exploitation runs in days. An organisation that needs ten months to clear half its backlog is not merely behind schedule. It is operating on a timescale fundamentally misaligned with the threat landscape.
 
-As the chart shows, this steady rise reflects not only the increasing frequency of cyber threats but also the growing necessity for organisations to invest more significantly in security measures aimed at reducing their security debt.
+This mismatch also explains why security debt is so often mispriced internally. The cost of remediation is immediate and visible: engineer time, testing effort, maintenance windows and temporary disruption. The cost of delay feels hypothetical right up until the moment it is not. Then the invoice arrives as incident response, legal fees, regulatory scrutiny and customer distrust.
 
-## Challenges in Addressing Security Debt
+## Why the debt keeps compounding
 
-Addressing security debt is not just a technical challenge but a financial and managerial one. A majority, 60% of Chief Information Security Officers (CISOs), cite budget constraints as the primary hurdle in addressing security debt effectively. The McKinsey Cybersecurity Survey underscores this reality, highlighting how severely limited budgets inhibit the ability to undertake comprehensive vulnerability management.
+Security debt persists not because leaders are indifferent, but because it is embedded in the way many organisations operate. Asset inventories are incomplete. Ownership of remediation is split across infrastructure, application and product teams. Legacy systems remain in service long after vendor support has weakened, because the business process sitting behind them is still considered too important to interrupt.
 
-These constraints lead organisations to spend an average of 10% more on security tools due to inadequate vulnerability management. Essentially, limited budgetary allocations force many companies into a reactive, rather than proactive, stance on cybersecurity, leaving them vulnerable to constant threats and the associated high costs.
+In its guidance on known exploited vulnerabilities, CISA makes the trade-off plain: if an affected asset cannot be updated within the required timeframe, it may need to be removed from the network. That is an operationally painful conclusion, but also an economically revealing one. Unsupported technology is not just a technical nuisance. It is a stranded asset whose risk profile worsens with age.
 
-## The Contrarian Viewpoint
+This is why visibility matters so much. Organisations cannot prioritise what they cannot see, and they cannot reduce risk if every business unit carries its own private backlog. Security debt looks manageable when it is distributed across dozens of teams and dashboards. It looks far more expensive when measured as the age, severity and business criticality of unresolved flaws across the estate.
 
-Despite the rising consensus on the escalating costs of security debt, a contrarian viewpoint suggests that strategic investments in security tools and automation could mitigate these projected costs significantly. Proponents argue that, when integrated with robust management practices, such investments could provide a more stable financial impact than expected, allowing organisations to maintain operational efficiency without succumbing to rising cybersecurity costs.
+## The cheaper path is usually the earlier one
 
-This perspective emphasises the need for organisations to not only focus on immediate vulnerabilities but also implement structured, long-term cybersecurity strategies that make use of emerging technologies, such as AI and machine learning, to predict and prevent threats more efficiently.
+There is, however, a more constructive reading of the data. Faster, better-targeted security investment does appear to pay. IBM found that organisations making extensive use of AI and automation in security saved an average of $1.9 million compared with those that did not. That does not mean every shiny tool deserves a budget line. It means the economics improve when organisations shorten detection and containment cycles, prioritise the flaws that are actually being exploited, and stop asking humans to triage everything manually.
 
-## Implications for the Future
+That is also where security debt intersects with operating model. The best programmes are not simply buying more products; they are improving the machinery of remediation. They maintain current inventories, separate known exploited vulnerabilities from background noise, and route urgent fixes quickly enough to match the threat window. For teams thinking through that automation question, the case for smarter detection is explored further in [AI-Driven Threat Detection in Enterprise Networks](/2026/04/12/ai-threat-detection-enterprise/).
 
-The financial dynamics of security debt will continue to evolve as organisations strive to keep pace with a rapidly changing cyber threat landscape. The continuous increase in breach costs and security debt management expenses indicates a clear requirement for a strategic overhaul. Organisations must move towards integrating proactive measures into their cybersecurity frameworks.
+## A better way to account for cyber risk
 
-A real-world example can be seen in the strategic approach taken by major financial institutions. These institutions have incorporated AI-driven threat detection tools, which not only identify potential breaches before they occur but also provide predictive insights that enable more effective resource allocation. These tools represent a forward-thinking strategy that organisations across sectors can emulate to balance their budgets against the need for robust security measures.
+The practical implication is straightforward. Leaders should treat security debt less like a technical backlog and more like working capital under pressure. Measure how old the backlog is, not just how large it is. Track how quickly known exploited vulnerabilities are remediated. Put a cost against unsupported systems that remain online for convenience. And distinguish between investment that reduces exposure and spending that merely adds another dashboard.
 
-Furthermore, organisations adopting comprehensive cyber hygiene practices will be better positioned to manage security debt effectively. By revisiting their security policies and keeping abreast of emerging threat landscapes, they ensure their investments in cybersecurity yield tangible returns. The key lies in transforming cybersecurity from a reactive to a proactive posture, ensuring robust defence mechanisms are in place long before threats materialise.
-
-Ultimately, organisations that strategically invest in advanced security practices and tools today will safeguard their operations and finances against the increasing threat of cyber vulnerabilities tomorrow.
+For boards, the question is no longer whether security debt exists. It is whether the organisation is pricing it honestly. A deferred patch may preserve this quarter's delivery targets, but it can just as easily raise next quarter's breach costs. In cybersecurity, as in finance, compounding works in both directions. The organisations that pay down debt early preserve optionality. The ones that wait discover that interest, once it starts to accrue, is rarely cheap.
 
 ## References
 
-1. Federal News Network, "Visibility is the Only Way to Fix the Public's Growing Security Debt", *Federal News Network*, 2026, [Accessed online](https://federalnewsnetwork.com/commentary/2026/04/visibility-is-the-only-way-to-fix-the-publics-growing-security-debt/).
-2. IBM Cost of a Data Breach Report, "Data Breach Costs", *IBM*, 2025, [Accessed online](https://www.ibm.com/reports/cost-of-a-data-breach-2025).
-3. FTI Consulting, "2026: Make-or-Break Year for Economy", *FTI Consulting*, 2026, [Accessed online](https://www.fticonsulting.com/insights/articles/2026-sets-up-make-break-year-economy).
-4. McKinsey Cybersecurity Survey, "Cybersecurity 2026", *McKinsey*, 2026, [Accessed online](https://www.mckinsey.com/business-functions/risk-and-resilience/our-insights/the-numbers-behind-cybersecurity-2026).
+1. IBM Security, ["Cost of a Data Breach Report 2025"](https://www.ibm.com/reports/data-breach), *IBM*, 2025.
+2. Help Net Security, ["78% of public sector organisations are operating with significant security debt"](https://www.helpnetsecurity.com/2025/06/13/public-sector-software-vulnerabilities/), *Help Net Security*, 2025.
+3. CISA, ["Binding Operational Directive 22-01: Reducing the Significant Risk of Known Exploited Vulnerabilities"](https://www.cisa.gov/news-events/directives/bod-22-01-reducing-significant-risk-known-exploited-vulnerabilities), *Cybersecurity and Infrastructure Security Agency*, updated 2025.


### PR DESCRIPTION
## Summary

Strengthen the existing Security post on security debt with a sharper opening, tighter structure, and cleaner SEO metadata.

## Changes

- rewrite the introduction around the financial cost of deferred remediation
- replace weaker or unverified claims with sourced IBM, CISA, and public-sector security debt data
- tighten the title, description, tags, and image alt text, and add a relevant internal link

## Testing

- [x] `bundle exec jekyll build` passes
- [x] `bash scripts/validate-posts.sh --all` passes
- [x] `scripts/check-pr-scope.sh` passes

Closes #848