### PR TITLE
fix(deps): bump basic-ftp override to 5.3.1 (closes #928)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,9 +2382,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4315,9 +4315,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "overrides": {
     "lodash": "^4.18.1",
     "tmp": ">=0.2.3",
-    "basic-ftp": "5.3.0",
+    "basic-ftp": "5.3.1",
     "@lhci/cli": {
       "uuid": "npm:@smithy/uuid@^1.1.2"
     }


### PR DESCRIPTION
## Summary

- Bump the exact `basic-ftp` override from `5.3.0` → `5.3.1` to clear **GHSA-rpmf-866q-6p89** (high, `<=5.3.0`).
- Regenerated `package-lock.json` — `ip-address` rolls 10.1.0 → 10.2.0 as a side effect, clearing **GHSA-v2v4-37r5-5v8g** (moderate, transitive via `@lhci/cli` → `socks`).
- `npm run test:security` (`npm audit --audit-level=moderate`) now reports **0 vulnerabilities**.

## Why this happened

The override was pinned to exactly `5.3.0` in #819 to remediate the earlier **GHSA-rp42-5vxx-qpwr** advisory against `<=5.2.2`. A newer advisory has since extended the vulnerable range up to and including `5.3.0`, so the same pin that fixed #818 has been failing the audit on every \`main\` run since 2026-05-06 and breaking all dependabot PR CI.

## Test plan

- [x] \`npm run test:security\` exits 0 locally
- [x] \`npm ls basic-ftp\` resolves to \`5.3.1\` (transitive via \`@lhci/cli\` → \`proxy-agent\` → \`get-uri\`)
- [x] Diff scoped to \`package.json\` + \`package-lock.json\` only (no unrelated churn)
- [ ] CI \`🔒 Security Audit\` job passes on this PR

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)