### PR TITLE
feat(validators): broken internal-link detection (#904, #905, #923)

### DIFF
--- a/.github/skills/audience-research/SKILL.md
+++ b/.github/skills/audience-research/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: audience-research
+description: 'Audience and UX research for viney.ca. Use when evaluating reader journey, navigation, scanability, usability, or audience fit before handing implementation to design, editorial, or QA.'
+version: 1.0.0
+triggers:
+  - Need reader-journey or audience-fit research
+  - Investigating navigation, scanability, or usability friction
+  - Research sweep finds UX or content-discovery questions
+  - Need evidence-backed recommendations before design or content changes
+---
+
+## Context
+
+This skill exists because UX, usability, and audience-fit work should not be
+left as an informal overlap between design, editorial, and QA. The Audience
+Researcher evaluates how the blog serves readers, captures evidence, and turns
+ambiguous "make it more appealing" requests into concrete follow-up work for the
+right implementation agent.
+
+**Production URL**: https://www.viney.ca
+
+**Primary research surfaces**:
+- `/` - first impression, positioning, and content discovery
+- `/blog/` - topic scanning, card hierarchy, and archive usability
+- representative post pages - readability, structure, and trust signals
+- `/search/` - findability and query refinement
+- mobile navigation - tap targets, hierarchy, and reading comfort
+
+## Step-by-Step Instructions
+
+1. **Define the audience question**
+   - State the audience segment or usability concern being investigated.
+   - Write the current hypothesis in one sentence.
+   - Example: "Readers interested in QE strategy can find the topic, but the path
+     from homepage to deeper articles is harder than it should be."
+
+2. **Review the reader journey end-to-end**
+   - Inspect homepage, blog index, search, and at least one representative post.
+   - Check mobile and desktop behaviour.
+   - Focus on information scent, scanability, navigation clarity, reading rhythm,
+     trust cues, and next-step discovery.
+
+3. **Collect evidence instead of taste-based opinions**
+   - Reuse repo standards where possible:
+     - `references/accessibility-checklist.md`
+     - Playwright navigation/responsive checks
+     - existing SEO/content conventions
+   - Record what the reader sees, where friction appears, and why it matters.
+   - Distinguish evidence from preference.
+
+4. **Write findings in a reusable format**
+   - Capture each finding with:
+     - the affected surface
+     - the reader problem
+     - the likely impact
+     - the recommended owner
+   - Use this template:
+
+   ```markdown
+   ## Finding: [short title]
+   - **Surface:** homepage | blog index | post page | search | mobile nav
+   - **Reader problem:** what feels unclear, slow, noisy, or unconvincing
+   - **Evidence:** concrete observation or test signal
+   - **Impact:** discovery | comprehension | trust | conversion | return visits
+   - **Route to:** `agent:creative-director` | `agent:editorial-chief` | `agent:qa-gatekeeper`
+   - **Recommended change:** concise, testable next step
+   ```
+
+5. **Route implementation to the correct agent**
+   - Visual hierarchy, layout, spacing, component behaviour → Creative Director
+   - Clarity, tone, headlines, summaries, internal linking, SEO → Editorial Chief
+   - Accessibility, interaction regressions, test coverage, measurable quality gates → QA Gatekeeper
+   - If the work is still exploratory and not yet implementation-ready, keep it as
+     an Audience Researcher issue until the findings are clear.
+
+## Common Pitfalls
+
+### Pitfall 1: Turning research into unscoped redesign
+**Problem**: "Improve appeal" becomes broad design churn with no evidence.
+**Solution**: Start with a specific reader journey or usability question and
+route implementation in small, testable follow-up issues.
+
+### Pitfall 2: Confusing taste with evidence
+**Problem**: Recommendations reflect personal preference rather than reader
+friction.
+**Solution**: Tie every finding to a concrete observation, checklist item, or
+behavioural risk.
+
+### Pitfall 3: Implementing fixes inside the research issue
+**Problem**: Research findings and implementation changes get mixed together.
+**Solution**: Keep research synthesis separate. Open follow-up issues for design,
+editorial, or QA execution.
+
+## Related Files
+
+- `AGENTS.md` - persona boundaries and handoffs
+- `CLAUDE.md` - local/direct lifecycle and label guidance
+- `.github/workflows/research-sweep.yml` - recurring research intake
+- `references/accessibility-checklist.md` - baseline usability/a11y heuristics
+- `tests/playwright-agents/interactive-elements.spec.ts` - interaction and target-size checks
+- `tests/playwright-agents/responsive.spec.ts` - responsive navigation behaviour checks
+- `.github/skills/economist-theme/SKILL.md` - design follow-up destination
+- `.github/skills/editorial/SKILL.md` - content follow-up destination
+- `.github/skills/jekyll-qa/SKILL.md` - QA follow-up destination
+
+## Success Criteria
+
+- [ ] Research scope is framed as a reader problem, not a vague redesign request
+- [ ] Findings cite concrete evidence from the live site or repo standards
+- [ ] Every recommendation names the implementation owner explicitly
+- [ ] Research issues end with actionable follow-up work instead of open-ended commentary
+
+## Version History
+
+- **1.0.0** (2026-04-26): Initial audience and UX research skill

--- a/.github/skills/jekyll-qa/SKILL.md
+++ b/.github/skills/jekyll-qa/SKILL.md
@@ -853,6 +853,15 @@ echo "Link check complete. Errors: ${ERRORS}"
 
 **Target:** Zero broken links. Any broken URL → `type:functional` / `severity:S2:major` bug.
 
+#### 6.2a Pre-build internal link validation
+
+`validate-posts.sh` and `content-review.js` both detect broken internal post links at the source-Markdown level, before Jekyll builds. This complements HTML-Proofer (which runs post-build in CI):
+
+- `validate-posts.sh` (check 2c): ERRORs on any `/YYYY/` body link whose target has no corresponding post front matter. Exits non-zero.
+- `content-review.js` (section 7): Classifies internal links as *canonical* (target exists) or *broken* (target absent). Broken links surface as issues in the content-review report; score credit is only awarded for canonical links.
+
+Both tools build a post URL registry from `_posts/` front matter at startup — no `_site/` build required. The `date:` field is used for the URL date path; slugs derive from the filename with Jekyll's `--` → `-` normalization applied.
+
 ### 6.3 Content Integrity Check
 
 Detect posts whose `date:` front-matter year differs from the body content year:

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ board_decision.json
 board_report.md
 test_outputs/
 model_comparison_results.json
+content-review-results.json
 
 # Secrets
 .env

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,94 +1,99 @@
-# SPEC — Tag Taxonomy Policy (Issue #907)
+# SPEC — Internal Link Validator Quality (#904 / #905)
 
 **Status:** Draft  
-**Issue:** [#907](https://github.com/oviney/blog/issues/907)  
-**Label:** `agent:editorial-chief`  
-**Date:** 2026-05-03
+**Issues:** [#904](https://github.com/oviney/blog/issues/904) · [#905](https://github.com/oviney/blog/issues/905)  
+**Labels:** `agent:editorial-chief` · `agent:qa-gatekeeper`  
+**Date:** 2026-05-10
 
 ---
 
-## 1. Objective
+## 1. Situation
 
-Establish and enforce a consistent tag taxonomy across the 24-post archive. Currently 18 of 24 posts have zero tags; the 6 that do use inconsistent casing. Validators do not check tags. The editorial skill shows tags as expected but does not enforce them.
+When these issues were filed, a scan found 16 "legacy redirect link" instances pointing to compatibility routes rather than canonical permalinks. A fresh audit confirms **all internal link targets currently resolve** in `_site/` — no `redirect_from` front matter exists in any post, and HTML-Proofer in CI passes cleanly. Prior content work (notably #908) remediated the specific links called out in #904.
 
-**Target users:** the editorial agent (enforcing on new posts) and future readers/search indexers (benefiting from consistent metadata).
+The **remaining gap** (#905) is in the validator stack:
 
----
+- `scripts/content-review.js` → `countInternalLinks()` awards the 10-pt internal-links credit for any link matching `/\/(20\d\d)\//` or `^\/`. It does **not** verify the target path exists.
+- `scripts/validate-posts.sh` → does not check internal link targets at all.
+- As a result, a post linking to `/2026/04/05/nonexistent-post/` scores full marks on internal links and passes validation.
 
-## 2. Policy Decision
-
-**Tags are required.** The policy:
-
-- Every post must have 2–5 tags from the canonical vocabulary below.
-- New tags may be introduced when none of the existing ones fit; they must use `lowercase-hyphen` format.
-- `validate-posts.sh` will issue an **ERROR** (not warning) on missing tags — consistent with how `categories` is treated.
-- `content-review.js` will deduct 10 points for missing tags (same as the existing internal-links penalty).
-
-**Rationale for ERROR not warning:** 75% of posts already lack tags. Making it a warning risks perpetuating the status quo. Since the remediation below adds tags to all 18 gaps, the archive will be fully compliant before the stricter check lands.
+The fix for #904 (content remediation) is moot today — all links are canonical. The fix for #905 (validator quality) is the real remaining work.
 
 ---
 
-## 3. Canonical Tag Vocabulary
+## 2. Objective
 
-Organised by primary category; tags may be used across categories.
+Make the validator stack detect internal body links that point to paths that do not exist in the site, without requiring a full Jekyll build to run first.
 
-### Quality Engineering
-`quality-engineering` · `software-testing` · `defect-prevention` · `quality-metrics` · `cost-of-quality` · `qa-strategy` · `quality-management`
-
-### Test Automation
-`test-automation` · `ci-cd` · `self-healing-tests` · `playwright` · `test-maintenance` · `test-roi` · `testing-theater`
-
-### Software Engineering
-`software-engineering` · `engineering-leadership` · `technical-debt` · `platform-engineering` · `developer-experience` · `digital-transformation` · `architecture`
-
-### Security
-`security` · `security-debt` · `cybersecurity` · `enterprise-security` · `threat-detection`
-
-### Cross-cutting
-`ai` · `ai-testing` · `code-quality` · `productivity` · `devops` · `cost-benefit`
-
-**Casing rule:** always lowercase-hyphen. Acronyms become lowercase: `AI` → `ai`, `QA` → `qa-strategy`.
+**Approach:** Build a lightweight in-process URL registry from post front matter (date + slug → canonical URL) and validate each internal body link against that registry.
 
 ---
 
-## 4. Remediation Map
+## 3. Acceptance Criteria
 
-Tags to add to the 18 untagged posts:
-
-| Post | Proposed tags |
-|---|---|
-| `2023-12-28-understanding-opendns-cybersecurity-protection.md` | `security`, `cybersecurity`, `enterprise-security` |
-| `2025-12-31-testing-times.md` | `ai-testing`, `test-automation`, `quality-engineering` |
-| `2026-01-02-self-healing-tests-myth-vs-reality.md` | `self-healing-tests`, `test-automation`, `test-maintenance` |
-| `2026-01-18-ai-assisted-development-the-new-industrial-revolut.md` | `ai`, `software-engineering`, `code-quality`, `productivity` |
-| `2026-01-18-the-hidden-technical-debt-of-test-automation.md` | `test-automation`, `technical-debt`, `test-maintenance` |
-| `2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md` | `test-automation`, `quality-metrics`, `productivity` |
-| `2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md` | `testing-theater`, `quality-metrics`, `cost-of-quality` |
-| `2026-01-19-the-surprising-economics-of-test-automation-roi.md` | `test-roi`, `test-automation`, `cost-benefit` |
-| `2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md` | `test-automation`, `test-roi`, `technical-debt` |
-| `2026-04-05-ai-quality-testing-automation.md` | `ai-testing`, `test-automation`, `qa-strategy` |
-| `2026-04-05-building-a-test-strategy-that-works.md` | `qa-strategy`, `test-automation`, `software-testing` |
-| `2026-04-05-copq-in-software-engineering-and-how-quality-engin.md` | `cost-of-quality`, `quality-engineering`, `software-engineering` |
-| `2026-04-05-cost-of-poor-quality-copq.md` | `cost-of-quality`, `quality-engineering`, `defect-prevention` |
-| `2026-04-05-practical-applications-of-ai-in-software-development.md` | `ai`, `software-engineering`, `productivity`, `code-quality` |
-| `2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md` | `test-automation`, `qa-strategy`, `ai-testing` |
-| `2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md` | `ai-testing`, `test-maintenance`, `test-automation` |
-| `2026-04-06-the-concealed-price-tag-of-test-automation.md` | `test-roi`, `cost-of-quality`, `test-automation` |
-| `2026-04-12-the-hidden-economics-of-security-debt.md` | `security-debt`, `security`, `cost-benefit` |
-
-**Also fix casing** in the 6 posts that have tags: `AI` → `ai`.
+- [ ] **AC-1** `content-review.js` distinguishes *canonical* internal links (target exists as a post) from *broken* internal links (target matches `/20xx/` pattern but has no corresponding post). Only canonical links earn the 10-pt credit; broken links generate an `issue`.
+- [ ] **AC-2** `content-review.js` returns `internalLinks` (canonical count) and `brokenInternalLinks` (broken count) separately in the result object and in `content-review-results.json`.
+- [ ] **AC-3** `validate-posts.sh` adds an ERROR for any internal body link whose target does not exist as a known post permalink.
+- [ ] **AC-4** All 24 current posts pass both validators after the change (no regressions — all current links are already canonical).
+- [ ] **AC-5** The Playwright navigation test `QA/QC article keeps one article heading and its internal references resolve` continues to pass (it already checks link resolution at the browser level).
+- [ ] **AC-6** `bundle exec jekyll build` succeeds with no errors.
+- [ ] **AC-7** The updated behavior is noted in `scripts/validate-posts.sh` header and in `.github/skills/jekyll-qa/SKILL.md`.
 
 ---
 
-## 5. Acceptance Criteria
+## 4. URL Registry Design
 
-- [ ] **AC-1** `validate-posts.sh` issues an ERROR when a post has no tags
-- [ ] **AC-2** `validate-posts.sh` issues an ERROR when a post has fewer than 2 tags  
-- [ ] **AC-3** `content-review.js` deducts 10 points when `tags` is absent
-- [ ] **AC-4** All 24 posts pass `validate-posts.sh --all` after remediation
-- [ ] **AC-5** All 24 posts score ≥ 90 on `content-review.js` after remediation
-- [ ] **AC-6** The canonical tag vocabulary and tag format rules are documented in `.github/skills/editorial/SKILL.md`
-- [ ] **AC-7** `bundle exec jekyll build` succeeds with no errors
+Build from `_posts/*.md` front matter at script start-up — no `_site/` build required:
+
+```javascript
+// In content-review.js
+function buildPostRegistry(postsDir) {
+  // Returns Set of canonical permalink strings like '/2026/04/05/self-healing-tests-myth-vs-reality/'
+  const urls = new Set();
+  for (const file of fs.readdirSync(postsDir)) {
+    if (!file.endsWith('.md')) continue;
+    const { fm } = parseFrontMatter(fs.readFileSync(path.join(postsDir, file), 'utf8'));
+    if (fm.permalink) {
+      urls.add(fm.permalink.replace(/\/?$/, '/'));
+    } else if (fm.date) {
+      const d = String(fm.date).slice(0, 10).replace(/-/g, '/');
+      const slug = file.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.md$/, '');
+      urls.add(`/${d}/${slug}/`);
+    }
+  }
+  return urls;
+}
+```
+
+For `validate-posts.sh`, build the registry with a short AWK/Python one-liner over front matter.
+
+---
+
+## 5. `countInternalLinks` Replacement
+
+Replace the current function with one that returns `{ canonical, broken }`:
+
+```javascript
+function countInternalLinks(body, postRegistry) {
+  const links = (body.match(/\[.*?\]\((.*?)\)/g) || []);
+  let canonical = 0, broken = 0;
+  for (const l of links) {
+    const url = l.match(/\(([^)]+)\)/)[1].split('#')[0].replace(/\/?$/, '/');
+    if (!/\/(20\d\d)\//.test(url) && !/^\/(?!http)/.test(url)) continue;
+    if (/^https?:/.test(url)) continue; // external
+    if (/^\/(assets|blog|software-engineering|test-automation|security|search)\b/.test(url)) continue; // non-post pages
+    if (postRegistry.has(url)) canonical++;
+    else broken++;
+  }
+  return { canonical, broken };
+}
+```
+
+Credit logic:
+- `canonical >= 1` → +10 pts, no issue
+- `canonical === 0 && broken === 0` → +0 pts, warning (no links at all)
+- `canonical === 0 && broken >= 1` → +0 pts, issue (links exist but all point nowhere)
+- `broken >= 1` (regardless of canonical count) → issue listing the broken targets
 
 ---
 
@@ -96,27 +101,27 @@ Tags to add to the 18 untagged posts:
 
 | File | Change |
 |---|---|
-| `scripts/validate-posts.sh` | Add tag presence and count checks (ERROR) |
-| `scripts/content-review.js` | Add tag score component (10 pts) |
-| `.github/skills/editorial/SKILL.md` | Add canonical tag vocabulary and enforcement rules |
-| 18 `_posts/*.md` files | Add tags front matter |
-| 6 `_posts/*.md` files | Normalise tag casing (`AI` → `ai`) |
+| `scripts/content-review.js` | Build post registry at startup; replace `countInternalLinks` with registry-aware version; update score logic and return object |
+| `scripts/validate-posts.sh` | Add check: for each `/20xx/` body link, verify it exists in the registry; ERROR if not |
+| `.github/skills/jekyll-qa/SKILL.md` | Note the new validator behaviour |
+
+No post front matter changes needed — all current links are already canonical.
 
 ---
 
 ## 7. Boundaries
 
-| Always | Ask first | Never |
-|---|---|---|
-| Use `lowercase-hyphen` format for all tags | Add a tag outside the canonical list | Fabricate tags that don't match post content |
-| Match tags to actual post content | Change the canonical vocabulary significantly | Modify `_config.yml`, `Gemfile`, layouts |
-| Run `validate-posts.sh --all` before committing | — | Remove existing tags |
-| Run `content-review.js` before committing | — | Touch posts' title, date, or slug |
+| Always | Never |
+|---|---|
+| Build registry from `_posts/` front matter, not from `_site/` | Require a Jekyll build to run the validator |
+| Treat `/blog/`, `/software-engineering/`, `/search/` etc. as non-post pages (not broken links) | Flag links to valid non-post site pages as broken |
+| Run `validate-posts.sh --all` and `content-review.js` before committing | Change post content, front matter dates, or slugs |
+| Keep the Playwright `QA/QC` link-resolution test as the browser-level guard | Remove HTML-Proofer from CI |
 
 ---
 
 ## 8. Out of Scope
 
-- Building tag archive pages (no `/tags/` landing pages exist; creating them is a separate feature)
-- Changing the category taxonomy (separate from tags)
-- Adding tag-based filtering to search (separate feature)
+- Fixing `redirect_from` usage (none exists currently)
+- Checking external links (already handled by HTML-Proofer with `--disable-external`)
+- Building tag archive pages or category-filtered link validators

--- a/scripts/content-review.js
+++ b/scripts/content-review.js
@@ -243,7 +243,8 @@ function classifyInternalLinks(body, registry) {
     if (/^https?:/.test(raw)) continue;
     // Only check date-path links (post permalinks always start with /YYYY/)
     if (!/^\/(20\d\d)\//.test(raw)) continue;
-    const url = raw.split('#')[0].replace(/\/?$/, '/');
+    // Strip fragment and optional Markdown title attribute ([text](/path/ "Title"))
+    const url = raw.split(/[\s#]/)[0].replace(/\/+$/, '/').replace(/([^/])$/, '$1/');
     if (registry.has(url)) {
       canonical++;
     } else {

--- a/scripts/content-review.js
+++ b/scripts/content-review.js
@@ -11,7 +11,7 @@
  *   15 pts — SEO (title length, description length, heading hierarchy)
  *   15 pts — Content length (800–1500 words)
  *   10 pts — Excerpt quality (first paragraph ≥ 50 words)
- *   10 pts — Internal links (≥ 1 link to another post)
+ *   10 pts — Internal links (≥ 1 canonical link to an existing post; broken targets surface as issues)
  *   10 pts — Tags (≥ 2 lowercase-hyphen tags)
  *   10 pts — Citations (≥ 3 references with sources)
  *
@@ -198,12 +198,60 @@ function extractHeadings(body) {
   return (body.match(/^(#{1,6})\s+/gm) || []).map(h => h.trim().length);
 }
 
-function countInternalLinks(body) {
+// Build a Set of canonical post permalink strings from front matter.
+// Uses date: front matter (not filename date) for the URL date path.
+// Slug comes from the filename after stripping the YYYY-MM-DD- prefix,
+// with consecutive hyphens collapsed to one (Jekyll's slug normalization).
+// No _site/ dependency — works before or without a Jekyll build.
+function buildPostRegistry(postsDir) {
+  const registry = new Set();
+  let files;
+  try {
+    files = fs.readdirSync(postsDir).filter(f => f.endsWith('.md'));
+  } catch {
+    return registry;
+  }
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(postsDir, file), 'utf8');
+    const { fm } = parseFrontMatter(content);
+    if (fm.permalink) {
+      const p = String(fm.permalink).trim().replace(/\/?$/, '/');
+      registry.add(p);
+    } else if (fm.date) {
+      const d = String(fm.date).slice(0, 10).replace(/-/g, '/');
+      const slug = file
+        .replace(/^\d{4}-\d{2}-\d{2}-/, '')
+        .replace(/\.md$/, '')
+        .replace(/-{2,}/g, '-');  // Jekyll normalises -- to -
+      registry.add(`/${d}/${slug}/`);
+    }
+  }
+  return registry;
+}
+
+// Classify internal post links in body as canonical (target exists) or broken.
+// Only links containing a year segment (/20xx/) are checked — non-post pages
+// like /blog/, /about/ never contain a year segment and are skipped automatically.
+function classifyInternalLinks(body, registry) {
   const links = (body.match(/\[.*?\]\((.*?)\)/g) || []);
-  return links.filter(l => {
-    const url = l.match(/\(([^)]+)\)/)[1];
-    return /\/(20\d\d)\//.test(url) || /^\/(?!http)/.test(url);
-  }).length;
+  let canonical = 0;
+  let broken = 0;
+  const brokenUrls = [];
+  for (const l of links) {
+    const raw = l.match(/\(([^)]+)\)/)[1];
+    // Skip external URLs first — external links may contain date segments
+    if (/^https?:/.test(raw)) continue;
+    // Only check date-path links (post permalinks always start with /YYYY/)
+    if (!/^\/(20\d\d)\//.test(raw)) continue;
+    const url = raw.split('#')[0].replace(/\/?$/, '/');
+    if (registry.has(url)) {
+      canonical++;
+    } else {
+      broken++;
+      brokenUrls.push(url);
+    }
+  }
+  return { canonical, broken, brokenUrls };
 }
 
 function countCitations(body) {
@@ -251,7 +299,7 @@ function imageHasEmbeddedText(imagePath) {
 
 // ── Scoring ───────────────────────────────────────────────────────────────────
 
-function scorePost(fm, body, filename) {
+function scorePost(fm, body, filename, registry) {
   const issues   = [];
   const warnings = [];
   let   score    = 0;
@@ -399,11 +447,17 @@ function scorePost(fm, body, filename) {
   }
 
   // ── 7. Internal links (10 pts) ────────────────────────────────────────────
-  const internalLinks = countInternalLinks(body);
+  const { canonical: internalLinks, broken: brokenInternalLinks, brokenUrls } =
+    classifyInternalLinks(body, registry || new Set());
   if (internalLinks >= 1) {
     score += 10;
   } else {
     warnings.push('No internal links to other posts — consider linking to related content');
+  }
+  if (brokenInternalLinks > 0) {
+    issues.push(
+      `${brokenInternalLinks} internal link(s) point to non-existent post(s): ${brokenUrls.join(', ')}`
+    );
   }
 
   // ── 8. Tags (10 pts) ──────────────────────────────────────────────────────
@@ -428,7 +482,7 @@ function scorePost(fm, body, filename) {
     issues.push('No citations or external references found — add data points with sources');
   }
 
-  return { score: Math.min(score, 100), words, internalLinks, citations, tags: tags.length, issues, warnings };
+  return { score: Math.min(score, 100), words, internalLinks, brokenInternalLinks, citations, tags: tags.length, issues, warnings };
 }
 
 // ── Cross-article analysis ────────────────────────────────────────────────────
@@ -601,6 +655,9 @@ function main() {
 
   console.error(`Reviewing ${postFiles.length} posts…`);
 
+  // Build registry once — used by every post to validate internal link targets
+  const postRegistry = buildPostRegistry(POSTS_DIR);
+
   const posts   = [];
   const results = [];
 
@@ -612,7 +669,7 @@ function main() {
   }
 
   for (const { filename, fm, body } of posts) {
-    const result = scorePost(fm, body, filename);
+    const result = scorePost(fm, body, filename, postRegistry);
     results.push({ filename, fm, ...result });
     const grade = gradeLabel(result.score);
     console.error(`  ${grade} ${result.score}/100  ${filename}`);

--- a/scripts/validate-posts.sh
+++ b/scripts/validate-posts.sh
@@ -10,6 +10,7 @@
 #      categories, image
 #   2. Tags: ≥ 2 tags in inline bracket format (tags: [foo, bar]),
 #      all lowercase-hyphen (tags must not contain uppercase characters)
+#   2c. Internal links: /YYYY/ body links must resolve to a known post permalink
 #   3. The image: path resolves to a real file under assets/images/
 #   4. The date: value is not in the future
 #
@@ -67,6 +68,40 @@ fm_value() {
     | sed "s/^${key}:[[:space:]]*//" \
     || true
 }
+
+# ---------------------------------------------------------------------------
+# Build post URL registry from front matter.
+# Uses date: front matter (not filename date) for the URL date path.
+# Slug comes from the filename after stripping YYYY-MM-DD- prefix, with
+# consecutive hyphens collapsed to one (Jekyll's slug normalization).
+# No _site/ dependency — works before or without a Jekyll build.
+# ---------------------------------------------------------------------------
+POST_REGISTRY=$(python3 - "$REPO_ROOT/_posts" <<'PYEOF'
+import sys, os, re
+posts_dir = sys.argv[1]
+urls = set()
+for f in sorted(os.listdir(posts_dir)):
+    if not f.endswith('.md'):
+        continue
+    try:
+        content = open(os.path.join(posts_dir, f)).read()
+    except Exception:
+        continue
+    fm_end = content.find('\n---', 3)
+    fm = content[3:fm_end] if fm_end > 0 else ''
+    perma = re.search(r'^permalink:\s*(.+)', fm, re.M)
+    date_m = re.search(r'^date:\s*(\d{4}-\d{2}-\d{2})', fm, re.M)
+    if perma:
+        urls.add(perma.group(1).strip().rstrip('/') + '/')
+    elif date_m:
+        # Slug from filename (not front matter title); apply Jekyll -- normalisation
+        slug = re.sub(r'^\d{4}-\d{2}-\d{2}-', '', f).rstrip('.md').replace('.md', '')
+        slug = re.sub(r'-{2,}', '-', slug)
+        d = date_m.group(1).replace('-', '/')
+        urls.add(f'/{d}/{slug}/')
+print('\n'.join(sorted(urls)))
+PYEOF
+)
 
 # ---------------------------------------------------------------------------
 # Validate each post.
@@ -176,6 +211,26 @@ PYEOF
       post_errors=$((post_errors + 1))
     fi
   fi
+
+  # -- 2c. Internal link targets must resolve to known posts ------------------
+  # Only /YYYY/ date-path links are checked; non-post pages (/blog/, /about/,
+  # etc.) never contain a year segment and are skipped automatically.
+  # The sed 's|#.*||' strips URL fragments — do not remove it; the grep
+  # captures 'post/#section' as a single token that must be cleaned.
+  body_links=$(awk '/^---/{n++; if(n==2){found=1; next}} found{print}' "$post" \
+    | grep -oE '\(/[0-9]{4}/[^)]+\)' \
+    | tr -d '()' \
+    | sed 's|#.*||' \
+    | sed 's|/*$|/|' \
+    || true)
+  while IFS= read -r link_url; do
+    [[ -z "$link_url" ]] && continue
+    if ! echo "$POST_REGISTRY" | grep -qxF "$link_url"; then
+      echo "❌  $rel — internal link points to non-existent post: '$link_url'"
+      ERRORS=$((ERRORS + 1))
+      post_errors=$((post_errors + 1))
+    fi
+  done <<< "$body_links"
 
   if [[ $post_errors -eq 0 ]]; then
     echo "✅  $rel"

--- a/scripts/validate-posts.sh
+++ b/scripts/validate-posts.sh
@@ -95,7 +95,7 @@ for f in sorted(os.listdir(posts_dir)):
         urls.add(perma.group(1).strip().rstrip('/') + '/')
     elif date_m:
         # Slug from filename (not front matter title); apply Jekyll -- normalisation
-        slug = re.sub(r'^\d{4}-\d{2}-\d{2}-', '', f).rstrip('.md').replace('.md', '')
+        slug = re.sub(r'^\d{4}-\d{2}-\d{2}-', '', f[:-3])  # strip date prefix; [:-3] removes .md suffix
         slug = re.sub(r'-{2,}', '-', slug)
         d = date_m.group(1).replace('-', '/')
         urls.add(f'/{d}/{slug}/')
@@ -218,8 +218,9 @@ PYEOF
   # The sed 's|#.*||' strips URL fragments — do not remove it; the grep
   # captures 'post/#section' as a single token that must be cleaned.
   body_links=$(awk '/^---/{n++; if(n==2){found=1; next}} found{print}' "$post" \
-    | grep -oE '\(/[0-9]{4}/[^)]+\)' \
-    | tr -d '()' \
+    | grep -oE '\]\(/[0-9]{4}/[^)]+\)' \
+    | tr -d ']()"' \
+    | sed 's|[[:space:]].*||' \
     | sed 's|#.*||' \
     | sed 's|/*$|/|' \
     || true)

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,249 +1,181 @@
-# Plan — Issue #907: Tag Taxonomy Policy
+# Plan — Issues #904 / #905: Internal Link Validator Quality
 
 **Spec:** [SPEC.md](../SPEC.md)  
-**Date:** 2026-05-03
+**Date:** 2026-05-11
 
 ---
 
-## Current state
+## Context
 
-- 18/24 posts have zero tags (failing after T1)
-- 1/6 tagged posts has `AI` casing that needs normalising to `ai`
-- Both validators ignore tags entirely
-- Editorial SKILL.md mentions tags but gives no vocabulary or count rules
+All 14 internal link targets currently used by posts resolve correctly. One registry design subtlety: the post `2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md` has a double-hyphen in its filename, but Jekyll normalizes that to a single hyphen in the generated URL. The registry builder must apply the same normalization (`--+` → `-`).
+
+**Strategy (revised after staff engineer review):** Front-matter derivation is the **sole** source for the registry. `_site/` is explicitly excluded — it is a stale build artifact that creates false-positive cascades when a developer adds a new post and runs the validator before building. The spec's boundary ("Never: Require a Jekyll build") stands. HTML-Proofer in CI handles post-build link verification; these validators handle pre-build author feedback.
 
 ---
 
 ## Dependency graph
 
 ```
-T1 (validator: error on missing tags) ──► CHECKPOINT-A (RED — 18 failures expected)
-                                              │
-T2 (content-review: 10pt tag score)  ──┐     │
-T3 (SKILL.md docs)                   ──┤     ▼
-                                        │  T4a (add tags: QE posts, 8)
-                                        │  T4b (add tags: TA posts, 7)
-                                        │  T4c (add tags: SE posts, 2)
-                                        │  T4d (add tags: Security posts, 1)
-                                        │  T5  (fix casing: 1 post)
-                                        │     │
-                                        └──►  CHECKPOINT-B (GREEN — all 24 pass)
-                                              │
-                                              ▼
-                                          T6 (final build + close issue)
+T1 (shared registry helper) ──► T2 (content-review.js update)
+                             ──► T3 (validate-posts.sh update)
+                                     │
+                                 CHECKPOINT-A (24/24 pass, 100/100, no regressions)
+                                     │
+                                 T4 (docs + issue close)
 ```
 
-**Key sequencing rule:** T1 must land before any remediation so each fix can be verified against the real check. T2 and T3 can run in parallel with T4/T5 — they touch different files.
+T2 and T3 are independent of each other but both depend on T1's design being settled. T4 depends on T2 and T3 passing.
 
 ---
 
-## Phase 1 — Enforcer (TDD RED)
+## Phase 1 — Registry design (settled in T1, implemented inline in T2 and T3)
 
-### T1 — Add tag checks to `validate-posts.sh`
+### T1 — Design and verify the post URL registry
 
-**Files:** `scripts/validate-posts.sh`  
-**ACs:** AC-1, AC-2
+**Not a code task — design only.** Confirmed correct after staff engineer review.
 
-Add a tag-presence check immediately after the existing required-field loop (line ~92). Tags use inline YAML array format: `tags: [tag1, tag2]`. The `fm_value` helper already reads this line.
+**Registry algorithm (front-matter only, no `_site/` dependency):**
 
-```bash
-# -- 2b. Tag checks ----------------------------------------------------------
-tags_val=$(fm_value "$post" "tags")
-if [[ -z "$tags_val" ]]; then
-  echo "❌  $rel — missing required front-matter field: 'tags' (add 2–5 lowercase-hyphen tags)"
-  ERRORS=$((ERRORS + 1))
-  post_errors=$((post_errors + 1))
-else
-  # Count tags in inline array: strip brackets, count comma-separated items
-  tag_count=$(echo "$tags_val" | tr -d '[]' | tr ',' '\n' | grep -c '[^[:space:]]' || true)
-  if [[ "$tag_count" -lt 2 ]]; then
-    echo "❌  $rel — too few tags: $tag_count found (minimum 2 required)"
-    ERRORS=$((ERRORS + 1))
-    post_errors=$((post_errors + 1))
-  fi
-fi
-```
+- Read `permalink:` field if present → use as the canonical URL (trim, ensure trailing `/`)
+- Otherwise: read `date:` front-matter field for YYYY/MM/DD path; strip the `YYYY-MM-DD-` prefix from the filename for the slug; apply `--+` → `-` normalization (the only Jekyll slug normalization this corpus needs); construct `/YYYY/MM/DD/{slug}/`
+- **Key:** `date:` in front matter overrides the filename date for the URL path. The slug always comes from the filename (after stripping the filename-date prefix), not from the front-matter title. This is correct for all four posts with a 2026-01-18 filename / 2026-04-05 front-matter date mismatch.
 
-**Verify (RED):** `bash scripts/validate-posts.sh --all 2>&1 | grep "❌" | grep "tags" | wc -l` → should be 18.
+**Link entry filter (revised — no exclusion list needed):**
+Only links containing a year segment are checked: `/\/(20\d\d)\//.test(url)`.
+Every non-post page (`/blog/`, `/about/`, `/search/`, etc.) lacks a year segment and never matches. No exclusion list required.
+
+**Verify (T1 output):** Python prototype confirms the registry contains 24 posts and all 14 linked URLs resolve, including the double-hyphen post after normalization.
+
+---
+
+## Phase 2 — Validator updates
+
+### T2 — Update `scripts/content-review.js`
+
+**AC:** AC-1, AC-2
+
+**Changes:**
+
+1. Add `buildPostRegistry(postsDir)` function before `scorePost`. Uses front-matter derivation only — no `_site/` dependency. Returns a `Set<string>`. Add an inline comment noting that `date:` front matter is used for the URL date path (not the filename date), and the slug comes from the filename after stripping the filename-date prefix.
+
+2. Replace `countInternalLinks(body)` with `classifyInternalLinks(body, registry)` returning `{ canonical, broken, brokenUrls }`:
+   - Entry filter: `if (!/\/(20\d\d)\//.test(url)) continue;` — only date-segment links are checked
+   - No exclusion list needed: `/blog/`, `/about/`, etc. never contain a year segment
+   - Checks each matched URL against `registry`
+   - Returns `canonical` count (in registry) and `broken` count + list (not in registry)
+
+3. Update section 7 in `scorePost`:
+   ```javascript
+   const { canonical, broken, brokenUrls } = classifyInternalLinks(body, registry);
+   if (canonical >= 1) {
+     score += 10;
+   } else {
+     warnings.push('No internal links to other posts — consider linking to related content');
+   }
+   if (broken > 0) {
+     issues.push(`${broken} internal link(s) point to non-existent post(s): ${brokenUrls.join(', ')}`);
+   }
+   ```
+
+4. Pass registry into `scorePost(fm, body, filename, registry)` — add it as the 4th parameter.
+
+5. Build registry once in `main()` before the scoring loop.
+
+6. Update return object: `{ ..., internalLinks: canonical, brokenInternalLinks: broken }`.
+
+7. Update header comment line: `10 pts — Internal links (≥ 1 canonical link to an existing post)`.
+
+**Verify (RED → GREEN):**
+- Baseline: run `node scripts/content-review.js` — all 24 at 100/100 (no regressions)
+- Manual test: temporarily add `[bad link](/2026/99/99/no-such-post/)` to a post body → should appear as a broken link issue but not drop score if ≥ 1 canonical link still present
+- Restore after test
+
+---
+
+### T3 — Update `scripts/validate-posts.sh`
+
+**AC:** AC-3, AC-4
+
+**Changes:**
+
+Add a new check section (before the closing `if [[ $post_errors -eq 0 ]]` line) that:
+
+1. Builds the post registry once **outside the per-post loop** (before line ~76) using a Python one-liner:
+   ```bash
+   # Build post URL registry from front matter
+   POST_REGISTRY=$(python3 - "$POSTS_DIR" <<'PYEOF'
+   import sys, os, re
+   posts_dir = sys.argv[1]
+   urls = set()
+   for f in os.listdir(posts_dir):
+       if not f.endswith('.md'): continue
+       content = open(os.path.join(posts_dir, f)).read()
+       fm_end = content.find('---', 3)
+       fm = content[3:fm_end]
+       perma = re.search(r'^permalink:\s*(.+)', fm, re.M)
+       date_m = re.search(r'^date:\s*(\d{4}-\d{2}-\d{2})', fm, re.M)
+       if perma:
+           urls.add(perma.group(1).strip().rstrip('/') + '/')
+       elif date_m:
+           slug = re.sub(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}-', '', f).replace('.md', '')
+           slug = re.sub(r'-{2,}', '-', slug)  # Jekyll normalizes -- to -
+           d = date_m.group(1).replace('-', '/')
+           urls.add(f'/{d}/{slug}/')
+   print('\n'.join(sorted(urls)))
+   PYEOF
+   )
+   ```
+
+2. Inside the per-post loop, after tag checks, scan the post body for internal post links and validate each:
+   ```bash
+   # -- 2c. Internal link targets must resolve to known posts -------------------
+   body_links=$(awk '/^---/{n++; if(n==2){found=1; next}} found{print}' "$post" \
+     | grep -oE '\(/20[0-9][0-9]/[^)]+/\)' \
+     | tr -d '()' \
+     | sed 's|#.*||' \
+     | sed 's|/*$|/|' \
+     || true)
+   while IFS= read -r link_url; do
+     [[ -z "$link_url" ]] && continue
+     if ! echo "$POST_REGISTRY" | grep -qF "$link_url"; then
+       echo "❌  $rel — internal link points to non-existent post: '$link_url'"
+       ERRORS=$((ERRORS + 1))
+       post_errors=$((post_errors + 1))
+     fi
+   done <<< "$body_links"
+   ```
+
+3. Update header comment to add: `2c. Internal links: /20xx/ body links resolve to known posts`.
+4. Add comment above the `sed 's|#.*||'` line in the body-link extractor explaining it strips URL fragments before registry lookup — do not remove it even though it looks like dead code (the `grep -oE` pattern captures `post/#section` as a single token).
+
+**Verify (RED → GREEN):**
+- `bash scripts/validate-posts.sh --all` → PASSED (24/24 — no regressions)
+- Manual test: temporarily add `[bad](/2026/99/99/no-such-post/)` to a post → should ERROR; restore
 
 ---
 
 ### CHECKPOINT A
 
-Run `bash scripts/validate-posts.sh --all 2>&1 | grep -c "tags"` → confirms exactly 18 (or 19 if the casing post's `AI` tag count is also wrong) failures before any remediation.
-
----
-
-## Phase 2 — Remediation and Scoring (GREEN)
-
-T2, T3, T4, T5 can run in any order. T4/T5 each self-verify with the validator.
-
----
-
-### T2 — Add tag scoring to `content-review.js`
-
-**File:** `scripts/content-review.js`  
-**AC:** AC-3
-
-Add a new section after the existing `// ── 7. Internal links` block (currently the last scoring section before citations):
-
-```javascript
-// ── 3b. Tags (10 pts) ───────────────────────────────────────────────────────
-const tags = Array.isArray(fm.tags) ? fm.tags : [];
-if (tags.length >= 2) {
-  score += 10;
-} else if (tags.length === 1) {
-  score += 5;
-  warnings.push('Only 1 tag — add at least one more (target: 2–5 lowercase-hyphen tags)');
-} else {
-  issues.push('No tags — add 2–5 lowercase-hyphen tags from the canonical vocabulary');
-}
-```
-
-Also update the header comment (lines ~10-15) to add: `10 pts — Tags (≥ 2 canonical tags)` and raise the implicit max from 100.
-
-**Note:** After adding this section, any post currently at 100/100 without tags will drop to 90/100. All 18 untagged posts must be remediated (T4/T5) before this is committed, or commit T2 after T4/T5.
-
-**Sequencing adjustment:** Commit T2 last in Phase 2 — after T4/T5 — so the score doesn't regress for the archive while remediation is in flight.
-
-**Verify:** `node scripts/content-review.js 2>&1 | grep -E "100/100|90/100"` — after T2+T4+T5 all posts should show ≥ 90/100.
-
----
-
-### T3 — Update `.github/skills/editorial/SKILL.md`
-
-**File:** `.github/skills/editorial/SKILL.md`  
-**AC:** AC-6
-
-Add a `### Tags` section after the existing `### Categories` section:
-
-```markdown
-### Tags (required: 2–5 per post)
-
-Use `lowercase-hyphen` format. Acronyms become lowercase (`AI` → `ai`).
-
-**Canonical vocabulary** (add new tags by exception only):
-
-| Group | Tags |
-|---|---|
-| Quality Engineering | `quality-engineering` `software-testing` `defect-prevention` `quality-metrics` `cost-of-quality` `qa-strategy` `quality-management` |
-| Test Automation | `test-automation` `ci-cd` `self-healing-tests` `playwright` `test-maintenance` `test-roi` `testing-theater` |
-| Software Engineering | `software-engineering` `engineering-leadership` `technical-debt` `platform-engineering` `developer-experience` `digital-transformation` `architecture` |
-| Security | `security` `security-debt` `cybersecurity` `enterprise-security` `threat-detection` |
-| Cross-cutting | `ai` `ai-testing` `code-quality` `productivity` `devops` `cost-benefit` |
-
-Tags outside this list are allowed when none of the above fit; document the addition in the PR.
-```
-
-Also update the SEO checklist item from `- [ ] Category and tags set correctly` to:
-`- [ ] Category correct (one of the four allowed values)`  
-`- [ ] Tags: 2–5 entries, lowercase-hyphen, from canonical vocabulary`
-
-**Verify:** No script check — visual review of the SKILL.md diff.
-
----
-
-### T4a — Add tags to Quality Engineering posts (8 posts)
-
-Tags to add (see SPEC §4 Remediation Map):
-
-| Post | Tags |
-|---|---|
-| `2025-12-31-testing-times.md` | `ai-testing, test-automation, quality-engineering` |
-| `2026-04-05-building-a-test-strategy-that-works.md` | `qa-strategy, test-automation, software-testing` |
-| `2026-04-05-copq-in-software-engineering-and-how-quality-engin.md` | `cost-of-quality, quality-engineering, software-engineering` |
-| `2026-04-05-cost-of-poor-quality-copq.md` | `cost-of-quality, quality-engineering, defect-prevention` |
-| `2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md` | `test-automation, quality-metrics, productivity` |
-| `2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md` | `testing-theater, quality-metrics, cost-of-quality` |
-| `2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md` | `test-automation, qa-strategy, ai-testing` |
-| `2026-04-12-understanding-qa-qc-and-quality-engineering.md` _(has tags)_ | No change needed — already has correct tags |
-
-Wait — `understanding-qa-qc` already has tags. Remove from this batch.
-
-Actual T4a posts (7 untagged QE posts):
-- `2025-12-31-testing-times.md`
-- `2026-04-05-building-a-test-strategy-that-works.md`
-- `2026-04-05-copq-in-software-engineering-and-how-quality-engin.md`
-- `2026-04-05-cost-of-poor-quality-copq.md`
-- `2026-01-18-the-productivity-paradox-of-test-coverage-metrics.md`
-- `2026-01-18-the-real-cost-of-testing-theater-when-quality-metr.md`
-- `2026-04-05-the-end-of-manual-qa-why-2026-is-the-tipping-point.md`
-
-**Verify after each post:** `bash scripts/validate-posts.sh <post-file>` shows ✅ for that post.
-
----
-
-### T4b — Add tags to Test Automation posts (7 posts)
-
-| Post | Tags |
-|---|---|
-| `2026-01-02-self-healing-tests-myth-vs-reality.md` | `self-healing-tests, test-automation, test-maintenance` |
-| `2026-01-18-the-hidden-technical-debt-of-test-automation.md` | `test-automation, technical-debt, test-maintenance` |
-| `2026-01-19-the-surprising-economics-of-test-automation-roi.md` | `test-roi, test-automation, cost-benefit` |
-| `2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md` | `test-automation, test-roi, technical-debt` |
-| `2026-04-05-ai-quality-testing-automation.md` | `ai-testing, test-automation, qa-strategy` |
-| `2026-04-05-why-ai-test-generation-tools-overpromise-on-maintenance-savi.md` | `ai-testing, test-maintenance, test-automation` |
-| `2026-04-06-the-concealed-price-tag-of-test-automation.md` | `test-roi, cost-of-quality, test-automation` |
-
-**Verify:** `bash scripts/validate-posts.sh` passes for all 7.
-
----
-
-### T4c — Add tags to Software Engineering posts (2 posts)
-
-| Post | Tags |
-|---|---|
-| `2026-01-18-ai-assisted-development-the-new-industrial-revolut.md` | `ai, software-engineering, code-quality, productivity` |
-| `2026-04-05-practical-applications-of-ai-in-software-development.md` | `ai, software-engineering, productivity, code-quality` |
-
-**Verify:** both pass validator.
-
----
-
-### T4d — Add tags to Security posts (2 posts)
-
-| Post | Tags |
-|---|---|
-| `2023-12-28-understanding-opendns-cybersecurity-protection.md` | `security, cybersecurity, enterprise-security` |
-| `2026-04-12-the-hidden-economics-of-security-debt.md` | `security-debt, security, cost-benefit` |
-
-**Verify:** both pass validator.
-
----
-
-### T5 — Fix casing: `AI` → `ai` in one post
-
-**File:** `_posts/2026-04-12-ai-threat-detection-enterprise.md`
-
-Current: `tags: [cybersecurity, AI, threat-detection, machine-learning, enterprise-security]`  
-New: `tags: [cybersecurity, ai, threat-detection, machine-learning, enterprise-security]`
-
-**Note:** `machine-learning` is outside the canonical vocabulary (it's fine — the policy allows it).
-
-**Verify:** `bash scripts/validate-posts.sh _posts/2026-04-12-ai-threat-detection-enterprise.md` → ✅
-
----
-
-### CHECKPOINT B
-
-After T1 + T4a + T4b + T4c + T4d + T5:
-
+After T2 and T3:
 ```bash
-bash scripts/validate-posts.sh --all
+bash scripts/validate-posts.sh --all                          # PASSED 24/24
+node scripts/content-review.js 2>&1 | grep -c "100/100"      # 24
+bundle exec jekyll build                                       # clean
 ```
-
-Expected: `validate-posts: PASSED — all posts valid.`
 
 ---
 
-## Phase 3 — Verification
+## Phase 3 — Docs + close
 
-### T6 — Final build, content-review, close issue
+### T4 — Update jekyll-qa SKILL.md, close issues
 
-1. `bash scripts/validate-posts.sh --all` → PASSED
-2. `node scripts/content-review.js 2>&1 | grep -E "🔴|🟡|score"` → all ≥ 90/100
-3. `bundle exec jekyll build` → clean
-4. `gh issue close 907 --repo oviney/blog --comment "..."` → closed
+**AC:** AC-7
+
+Add to `.github/skills/jekyll-qa/SKILL.md` under the validator section:
+- `validate-posts.sh` now checks that internal body links (`/20xx/…/`) resolve to known posts
+- `content-review.js` now distinguishes canonical from broken internal links; broken links appear as issues
+
+Close #904 (verified clean — no legacy links found in audit) and #905 (validator now detects broken internal targets).
 
 ---
 
@@ -251,7 +183,7 @@ Expected: `validate-posts: PASSED — all posts valid.`
 
 | Risk | Mitigation |
 |---|---|
-| T1 grep-based tag count fails for multi-line YAML block arrays | All current posts use inline `tags: [...]` format; the count logic handles this correctly |
-| T2 adds tag scoring and existing 100/100 posts drop | Commit T2 after T4/T5 so no regression window |
-| A proposed tag in the remediation map is wrong for a post's content | Read each post title/category before applying tags |
-| `AI` in `ai-threat-detection` post has other implications | It's just a tag value, not a category; normalising to `ai` is purely stylistic |
+| Registry misses a post due to slug normalization differences | T1 Python prototype already verified all 14 linked URLs match; `--` normalization explicitly applied |
+| `_site/` not built when running locally | Registry falls back to front-matter derivation; same normalization logic used in both paths |
+| `/blog/` or `/software-engineering/` links flagged as broken | Non-post page exclusion list hardcoded; only `/20xx/` date-pattern URLs are checked |
+| The QA/QC Playwright test relies on specific link resolution | `validate-posts.sh` check + `content-review.js` broken-link issue catch the same gap; Playwright test (AC-5) is a browser-level guard that runs independently |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,21 +1,21 @@
-# TODO — Issue #907: Tag Taxonomy Policy
+# TODO — Issues #904 / #905: Internal Link Validator Quality
 
-## Phase 1 — Enforcer (RED)
+## Phase 1 — Design
+- [x] **T1** Verify registry algorithm: Python prototype confirms 24/25 posts found; `--` → `-` normalization required for `2026-04-04-the-real-cost-of-test-automation--balancing-speed-and-sustai.md`
 
-- [ ] **T1** Add tag presence + count (≥2) ERROR checks to `scripts/validate-posts.sh` (AC-1, AC-2)
-- [ ] **CHECKPOINT A** `validate-posts.sh --all | grep tags | wc -l` == 18
+## Phase 2 — Implementation
+- [ ] **T2** Update `scripts/content-review.js`:
+  - Add `buildPostRegistry()` (\_site/ primary, front-matter fallback)
+  - Replace `countInternalLinks()` with `classifyInternalLinks(body, registry)` returning `{canonical, broken, brokenUrls}`
+  - Update section 7 scoring: canonical links earn credit; broken links generate an issue
+  - Pass registry to `scorePost()` as 4th param
+  - Update return object: `internalLinks → canonical count`, add `brokenInternalLinks`
+  - Update header comment
+- [ ] **T3** Update `scripts/validate-posts.sh`:
+  - Build POST_REGISTRY once before the per-post loop (Python one-liner)
+  - Add check 2c in per-post loop: ERROR if any `/20xx/` body link not in registry
+  - Update header comment
+- [ ] **CHECKPOINT A** `validate-posts.sh --all` PASSED · `content-review.js` 24/24 at 100/100 · `jekyll build` clean
 
-## Phase 2 — Remediation + Scoring
-
-- [ ] **T3** Add canonical vocabulary + casing rule to `.github/skills/editorial/SKILL.md` (AC-6)
-- [ ] **T4a** Add tags to 7 Quality Engineering posts (testing-times, building-test-strategy, copq×2, productivity-paradox, testing-theater, end-of-manual-qa)
-- [ ] **T4b** Add tags to 7 Test Automation posts (self-healing-tests, hidden-technical-debt, surprising-economics, real-cost-test-automation, ai-quality-testing, ai-test-generation, concealed-price-tag)
-- [ ] **T4c** Add tags to 2 Software Engineering posts (ai-assisted-development, practical-applications)
-- [ ] **T4d** Add tags to 2 Security posts (understanding-opendns, hidden-economics-of-security-debt)
-- [ ] **T5** Fix `AI` → `ai` casing in `ai-threat-detection-enterprise.md`
-- [ ] **CHECKPOINT B** `validate-posts.sh --all` → PASSED (all 24 posts)
-- [ ] **T2** Add 10-pt tag scoring to `scripts/content-review.js` (AC-3) — commit AFTER T4/T5
-
-## Phase 3 — Final
-
-- [ ] **T6** `validate-posts.sh --all` ✓ · `content-review.js` all ≥90 ✓ · `jekyll build` ✓ · close #907 (AC-4, AC-5, AC-7)
+## Phase 3 — Docs + close
+- [ ] **T4** Update `.github/skills/jekyll-qa/SKILL.md`; close #904 (verified clean) and #905 (fixed)


### PR DESCRIPTION
## Summary

Re-opening as a fresh PR after #935 got stuck on a pre-rebase head SHA following a close-reopen → admin-merge-of-dependency → rebase sequence. Content is unchanged from the rebased-onto-main version of #935.

Ships work that was implemented locally but never made it to `origin/main`. Both #904 and #905 were closed manually on 2026-05-12 00:34Z with `stateReason: COMPLETED` but **no PR ever landed the code**. Verified via `git diff` and `gh issue view --json closedByPullRequestsReferences` (both empty).

## What's in the box

| # | Commit | Source |
|---|--------|--------|
| 1 | `feat(validators): add broken internal-link detection (#905)` | Authored locally 2026-05-11 |
| 2 | `docs(jekyll-qa): document pre-build internal link validation (#905)` | Authored locally 2026-05-11 |
| 3 | `fix(validators): handle Markdown title attributes and .md filename suffix` | Forward-correctness fixes |
| 4 | `chore: add audience-research SKILL.md and ignore content-review-results.json` | Closes #923 |

## How the registry-based detector works

Both validators build a post URL registry from `_posts/` front-matter at startup (no `_site/` build required):

- **`scripts/validate-posts.sh`** (check 2c): ERRORs on any `/YYYY/` body link whose target has no post in the registry. Exit non-zero.
- **`scripts/content-review.js`** (section 7): Classifies internal links as *canonical* (target exists) or *broken*. Broken links surface as per-post issues; the 10-pt score only credits canonical.

## Why correctness fixes were folded in (commit 3)

The orphan's regex doesn't handle Markdown title attributes — \`[text](/path/ "Title")\` would have been classified as broken. The `rstrip('.md')` call in the registry builder strips trailing `m`/`d` characters, not the suffix. Neither bug affects today's `_posts/` corpus, but shipping the validator without these fixes guarantees a follow-up PR.

## Verification

- [x] `node scripts/content-review.js --dry-run --json` — 24/24 posts at 100/100, 26 canonical / 0 broken
- [x] `bash scripts/validate-posts.sh --all` — PASSED
- [x] `bundle exec jekyll build` — clean
- [x] Diff of per-post `{score, internalLinks, brokenInternalLinks}` between pre-fix and post-fix is **empty** — correctness fixes are forward-only
- [x] `scorePost()` math reviewed: 9 sections sum to 110, `Math.min(score, 100)` cap intact. §7 (#905) and §8 (#907) are independent — no double-count

Closes #904.
Closes #905.
Closes #923.

Note: previous PR #935 superseded by this one due to GitHub PR head-ref desync after a close-reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)