### PR TITLE
test: scope-guard label retrigger (do not merge — #937)

### DIFF
--- a/.github/skills/jekyll-qa/SKILL.md
+++ b/.github/skills/jekyll-qa/SKILL.md
@@ -1255,3 +1255,4 @@ gh pr list --repo oviney/blog --state open \
   - Enhanced troubleshooting with step-by-step accessibility verification
 - **1.1.0** (2026-01-05): Added "Step 0: Diagnose CI Failures" - Always investigate logs before fixing
 - **1.0.0** (2026-01-05): Initial skill creation - QA Gatekeeper workflow for PR review, CI monitoring, and production verification
+

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    # types: include `labeled`/`unlabeled` so the scope guard re-fires
+    # when `governance-update` (or any label-driven scope skip) is
+    # added or removed mid-PR. Without these, the workflow only observes
+    # the pre-label state and the close-reopen workaround is required
+    # (which desynced PR #935 → forced PR #936 on 2026-05-12). See #937.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   test:


### PR DESCRIPTION
## Throwaway test PR for #937 acceptance criteria AC-2

**Do not merge.** This PR exists only to prove that the `labeled` and `unlabeled` triggers added to `.github/workflows/test-build.yml` fire correctly. It will be closed (not merged) once the verification is complete.

## Expected state transitions

1. **At open (no label):** \`check-agent-scope\` **fails** with VIOLATION [governance-surface] on \`.github/skills/jekyll-qa/SKILL.md\`. (Demonstrates the bug we're fixing — scope guard is firing.)
2. **After \`governance-update\` label added:** new workflow run fires automatically (proves \`labeled\` trigger works); \`check-agent-scope\` **passes** (skips Rule 3).
3. **After \`governance-update\` label removed:** new workflow run fires automatically (proves \`unlabeled\` trigger works); \`check-agent-scope\` **fails** again.

## Verification artifact

Run IDs and status transitions will be captured before closing. After closure, the real PR for #937 will reference this as evidence for AC-2.