### PR TITLE
ci(test-build): re-fire scope-guard on label change (#937)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    # types: include `labeled`/`unlabeled` so the scope guard re-fires
+    # when `governance-update` (or any label-driven scope skip) is
+    # added or removed mid-PR. Without these, the workflow only observes
+    # the pre-label state and the close-reopen workaround is required
+    # (which desynced PR #935 → forced PR #936 on 2026-05-12). See #937.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Adds `labeled` and `unlabeled` to the \`pull_request:\` trigger's \`types:\` list in \`.github/workflows/test-build.yml\` so the scope guard re-runs whenever a label is applied or removed.

The default trigger types (\`opened\`, \`synchronize\`, \`reopened\`) silently ignored mid-PR label changes. To unblock a PR after adding \`governance-update\` we had to use empty commits or close-reopen — and on 2026-05-12, close-reopen desynced PR #935's head SHA from its branch, forcing PR #936 to ship the same content.

## Verification (AC-2 evidence from throwaway PR #939)

| State | Run ID | Conclusion |
|---|---|---|
| Opened, no label | [25774256985](https://github.com/oviney/blog/actions/runs/25774256985) | failure ✓ |
| +`governance-update` | [25774270026](https://github.com/oviney/blog/actions/runs/25774270026) | success ✓ (proves `labeled` fires) |
| -`governance-update` | [25774347605](https://github.com/oviney/blog/actions/runs/25774347605) | failure ✓ (proves `unlabeled` fires) |

PR #939 was closed without merging once verification was complete.

## Scope (AC-3)

\`\`\`
$ grep -l 'github.event.pull_request.labels\|PR_LABELS' .github/workflows/*.yml
.github/workflows/test-build.yml
\`\`\`

Only this workflow reads PR labels. Other PR-triggered workflows are unchanged.

## Diff

One file, six added lines (four are an inline comment explaining *why* — without it, a future "simplify" pass would likely strip the list back to defaults).

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)