### PR TITLE
feat(content-review): surface broken-link debt inline in report table (#938)

### DIFF
--- a/scripts/content-review.js
+++ b/scripts/content-review.js
@@ -592,7 +592,12 @@ function buildReport(results, cross) {
   const sorted = [...results].sort((a, b) => a.score - b.score);
   for (const r of sorted) {
     const title = String(r.fm.title || r.filename).slice(0, 55);
-    md += `| ${r.score}/100 | ${gradeLabel(r.score)} | ${title} | ${r.words} | ${r.internalLinks} | ${r.citations} |\n`;
+    // Surface broken-link debt inline so editors can triage from the table
+    // alone; full URLs still appear in the per-post Critical Issues section.
+    const linksCell = r.brokenInternalLinks > 0
+      ? `${r.internalLinks} (⚠ ${r.brokenInternalLinks} broken)`
+      : String(r.internalLinks);
+    md += `| ${r.score}/100 | ${gradeLabel(r.score)} | ${title} | ${r.words} | ${linksCell} | ${r.citations} |\n`;
   }
   md += '\n';
 


### PR DESCRIPTION
## Summary

Renders the \`Links\` column of the Per-Post Scores table as \`N (⚠ M broken)\` when \`brokenInternalLinks > 0\`, else as a plain integer. Broken targets were already surfaced as per-post Critical Issues, but the table — the most-read section of the report — hid the signal.

## Why inline vs separate column

Current corpus has **zero broken internal links** across all 24 posts (verified during this session). A 7th \`Broken\` column would add a `0` to every row indefinitely for no benefit. Inline rendering stays noise-free on the happy path and stands out visually when debt appears.

## Diff scope

One file, +6/-1 lines in \`scripts/content-review.js\` (renderer-only). JSON output schema unchanged — \`content-remediation.js\`, the dashboard, and any other consumer reading \`content-review-results.json\` are unaffected.

## Verification

| Case | Result |
|---|---|
| 24/24 current posts | All Links cells render as plain integers (zero broken corpus-wide) |
| Synthetic broken link injected | Row renders `0 (⚠ 1 broken)` as expected |
| Post restored after test | Zero residual diff (\`git diff --stat\` is empty) |

## Example

Before:
\`\`\`
| 100/100 | 🟢 Excellent | Platform engineering's adoption trap | 826 | 0 | 7 |
\`\`\`

After (synthetic broken link present):
\`\`\`
| 100/100 | 🟢 Excellent | Platform engineering's adoption trap | 826 | 0 (⚠ 1 broken) | 7 |
\`\`\`

After (zero broken — the current state of every post):
\`\`\`
| 100/100 | 🟢 Excellent | Platform engineering's adoption trap | 826 | 0 | 7 |
\`\`\`

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)