### PR TITLE
chore: gitignore .agents/ + capture two session lessons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ Thumbs.db
 # Claude settings
 .claude/settings.local.json
 
+# Vendor lifecycle skills (upstream: addyosmani/agent-skills @ refs/tags/0.6.0)
+# Synced locally as tooling; not part of the site or its build.
+.agents/
+
 # Healing monitoring (runtime data)
 healing-metrics/
 healing-reports/

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,60 @@
+# Lessons — operational playbooks captured in flight
+
+Non-obvious findings from real recovery work. Each entry is a pattern that cost time the first time it surfaced; the goal is to avoid paying for it twice.
+
+---
+
+## L1 — Orphan commits with closed issues: verify ship state, not issue state
+
+**Symptom.** A GitHub issue is `CLOSED` with `stateReason: COMPLETED`. Local `git log` shows commits whose messages reference the issue and look like the implementation. It feels done.
+
+**Trap.** "Closed" on GitHub and "shipped to `origin/main`" are independent facts. An issue can be manually closed without a PR ever landing the code. We hit this on 2026-05-12 with #904/#905 — both closed, but the implementation commits (`7e793c8`, `bd91f5f`) were authored locally and never pushed. Recent `gh issue list` reports treated them as resolved; the validator capability was missing from production.
+
+**How to detect early.**
+
+```bash
+# Are there local commits referencing the issue that aren't on origin?
+git log origin/main..HEAD --oneline | grep -E "#(904|905)"
+
+# Did the issue close with no PR attached?
+gh issue view <N> --repo <repo> --json closedByPullRequestsReferences,stateReason
+# closedByPullRequestsReferences: []  AND  stateReason: COMPLETED  →  manual close, suspect
+```
+
+**Recovery.** Don't treat the closure as authoritative. Verify the actual code on `origin/main` matches what the issue described (`git diff origin/main HEAD -- <expected paths>`). If the code is missing, ship it on a fresh branch. Leave the issue closed; use `Closes #N` on the PR to re-associate cleanly. Comment on the closed issue with the PR link so other agents have the trail.
+
+---
+
+## L2 — Cherry-pick is not integration: re-verify against current `main`
+
+**Symptom.** Orphan commits cherry-pick cleanly with no merge conflicts. Tree, lockfile, even tests "look fine."
+
+**Trap.** A clean cherry-pick proves textual non-conflict, not behavioral correctness. Between the orphan's author date and today, other PRs may have changed the *shape* of what the orphan integrates with — return types, scoring bands, function signatures, JSON schemas. The cherry-pick won't fail; the system will just quietly mis-behave.
+
+**Concrete case from 2026-05-13.** Orphan `7e793c8` added §7 "broken internal-link detection" returning a 10-pt score band. Three weeks later, PR #907 (`f68962a`) added §8 "tag scoring" — also 10 pts. A naive cherry-pick of `7e793c8` would have summed correctly only because `scorePost()` already had `Math.min(score, 100)` at the return (sections sum to 110, capped to 100 by design — see `scripts/content-review.js` header comment). Without verifying this, the integration could just as easily have double-counted into 110/100 scores leaking into automation that assumes 0–100.
+
+**Required pre-PR check.**
+
+```bash
+# 1. Run the relevant script end-to-end on local main, capture output
+node scripts/content-review.js --dry-run --json
+cp content-review-results.json /tmp/baseline.json
+
+# 2. Cherry-pick onto a trial branch, re-run, diff
+git checkout -b trial origin/main && git cherry-pick <orphan-shas>
+node scripts/content-review.js --dry-run --json
+diff <(jq -S '.results[] | {filename, score, ...}' /tmp/baseline.json) \
+     <(jq -S '.results[] | {filename, score, ...}' content-review-results.json)
+```
+
+**Heuristic.** Any cherry-pick more than ~1 week old that touches scoring, schema, or a return shape: re-run end-to-end before opening the PR. The fact that `git cherry-pick` returned 0 is not the gate.
+
+---
+
+## Adding new lessons
+
+Lessons here should be:
+
+- **Operational, not architectural.** Architecture goes in `.github/skills/*/SKILL.md` and `AGENTS.md`.
+- **Patterns, not one-off fixes.** A specific bug fix lives in its commit/PR; the *recognition pattern* that lets future-you spot it earlier lives here.
+- **Bounded — each lesson is ≤ ~200 lines and has a Symptom / Trap / Detection / Recovery (or analog) structure.** If it's longer than that, it probably wants its own document.


### PR DESCRIPTION
## Summary

End-of-session housekeeping, two single-file changes bundled because they're both knowledge-locking actions:

1. **`.gitignore` adds `.agents/`** — vendor lifecycle skills synced from `addyosmani/agent-skills @ refs/tags/0.6.0`. Has been untracked since 2026-05-02 (11 days). It's been showing up in every `git status` and is a real accidental-`git add -A` risk on a tired day.

2. **`tasks/lessons.md` (new file)** — two non-obvious operational lessons from today's recovery work:
   - **L1.** GitHub issue closure does not imply the code shipped to `origin/main`. (Cost us a full SPEC→PLAN→BUILD on PR #936 today after we discovered #904/#905 had been closed manually with no PR.)
   - **L2.** Cherry-pick is not integration: week-old picks touching scoring, schema, or return shapes need end-to-end re-verification, even when `git cherry-pick` exits 0. (The code-reviewer agent caught this twice today — initial discovery + end-of-session stop/continue call.)

Each lesson uses a Symptom / Trap / Detection / Recovery structure and is bounded to ≤ 200 lines. The file's own header sets the rules so it stays a curated playbook rather than a chronological dumping ground.

## Why bundle vs. split

Both are one-file diffs in adjacent concerns (working-tree hygiene + tribal knowledge from the same session). A reviewer can read the entire PR in under a minute. Splitting would double the CI cost for zero review-quality gain.

## Verification

- [x] `git status` no longer shows `.agents/` after this commit
- [x] `tasks/lessons.md` parses as well-formed markdown (no broken code fences or table syntax)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)