### PR TITLE
chore(deps): align pa11y-ci to 4.1.1 with existing lodash override

### DIFF
--- a/.github/skills/jekyll-qa/SKILL.md
+++ b/.github/skills/jekyll-qa/SKILL.md
@@ -35,6 +35,13 @@ Optional: Steps to Reproduce, Reference/Screenshots, Affected URL
 **Jekyll Build Time**: ~30-60 seconds
 **Deployment Time**: ~2 minutes after merge
 
+### Toolchain pins (npm side)
+
+- `@playwright/test ^1.59.1`
+- `pa11y-ci ^4.1.0` (lockfile resolves to **4.1.1** as of #944; aligns with native lodash `~4.18.1` dep)
+- `lighthouse ^12.8.2`
+- `package.json` override `lodash: ^4.18.1` — predates pa11y-ci 4.1.1 and may still be load-bearing for other transitive deps; do not remove without auditing the dep graph (see #944 closing notes)
+
 ## S0. Diagnose CI Failures (FIRST STEP)
 
 **When CI tests are failing, ALWAYS investigate before making changes.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5357,9 +5357,9 @@
       }
     },
     "node_modules/pa11y-ci": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-4.1.0.tgz",
-      "integrity": "sha512-jRKRwQo03mZK0Ot8mo9C2qIktvRHHiwi37tH5DJpIDhRGnNi2xU1Lt6atN6YuSnXbjtF1wRdEzyjo2PuU6qQzA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-4.1.1.tgz",
+      "integrity": "sha512-urSrJTTDtXypYxpjhYSzVsbHlFblmbPgMfCxJI6WyTF3oSxNHfQ77mFIv5PKGiN/k46Qc/tVc8+4Ny+y13pGow==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
@@ -5368,7 +5368,7 @@
         "commander": "~14.0.3",
         "globby": "~6.1.0",
         "kleur": "~4.1.5",
-        "lodash": "~4.17.23",
+        "lodash": "~4.18.1",
         "node-fetch": "~2.7.0",
         "pa11y": "^9.1.1",
         "protocolify": "~3.0.0",


### PR DESCRIPTION
## Summary

- Bumps `pa11y-ci` from 4.1.0 → 4.1.1 via `npm update` (lockfile only; `package.json` semver range `^4.1.0` already covers it).
- pa11y-ci 4.1.1 natively declares `lodash ~4.18.1`, which matches the version the existing `package.json` `overrides: { lodash: ^4.18.1 }` block was already forcing.
- Updates `.github/skills/jekyll-qa/SKILL.md` with a new "Toolchain pins" block noting the resolved version and the override's continued role.

**This is hygiene, not a CVE response.** The original #902 sweep framed this as a security patch, but `npm audit --omit=dev` was already reporting 0 vulnerabilities on `main` — the lodash override predates the bump. See #944 (reframed body) and `tasks/lessons.md` L3 for the methodology gap.

Closes #944. Unblocks #947 (Playwright bump now sees the aligned pa11y-ci on first install).

## Test plan

- [x] `npm ls pa11y-ci` reports `4.1.1`
- [x] `npm audit --omit=dev` reports 0 vulnerabilities (regression check, not the purpose)
- [x] `package.json` semver range unchanged (`^4.1.0`)
- [x] `bundle exec jekyll build` succeeds locally (0.94s)
- [ ] CI `test-quality.yml` (pa11y-ci runner) passes against the refreshed lockfile
- [ ] CI `build` check passes

## Out of scope

- Removing the `lodash` override — may still be load-bearing for other transitive deps; auditing that is its own task.
- Playwright bump (tracked in #947).
- `package.json` semver range change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)