### PR TITLE
docs(actions): README for setup-node-with-puppeteer-cache (#958 AC-5 verification)

### DIFF
--- a/.github/actions/setup-node-with-puppeteer-cache/README.md
+++ b/.github/actions/setup-node-with-puppeteer-cache/README.md
@@ -1,0 +1,12 @@
+# setup-node-with-puppeteer-cache
+
+Composite action for `.github/workflows/test-quality.yml` jobs. See [#958](https://github.com/oviney/blog/issues/958) for the flake history that motivated this action and `action.yml` for the inputs/steps.
+
+## Files
+
+- `action.yml` — the composite action (called as `uses: ./.github/actions/setup-node-with-puppeteer-cache`)
+- `_retry-test.sh` — local unit harness for the retry loop. Run with `fail-fail-fail` (RED) or `fail-fail-succeed` (GREEN).
+
+## When updating the retry loop
+
+The retry shape is duplicated between `action.yml` and `_retry-test.sh`. Keep them in sync — see the comments in both files for the rationale (control flow differs intentionally; the shape must match).


### PR DESCRIPTION
## Purpose

Tiny PR (1 new file, 11 lines) to:

1. **Verify AC-5 from #958** — observe `Cache restored from key:` in at least one of the 7 `test-quality.yml` jobs' install steps, proving #958's puppeteer cache populated correctly on its merge run.
2. **Provide a navigation aid** for future maintainers landing in `.github/actions/setup-node-with-puppeteer-cache/`.

## Test plan

- [ ] CI runs the migrated `test-quality.yml` workflow on this PR
- [ ] Inspect at least one job's logs (e.g., `quality-checks`) for `Cache restored from key: Linux-puppeteer-node20-<hash>` near the start of the `Setup Node + cache + install deps` step
- [ ] If cache hits: AC-5 verified, merge or close
- [ ] If cache misses on a key that should exist: investigate (don't merge until resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)