### PR TITLE
docs: refocus repo boundary and CI guidance

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -17,6 +17,11 @@ local lifecycle skills such as `spec`, `planning-and-task-breakdown`, `build`,
 Custom agents and MCP/tool integrations are runtime-dependent. Treat them as
 optional execution aids when available, not as guarantees across every runtime.
 
+These skills exist to operate **the viney.ca blog repository**. They are not a
+claim that `oviney/blog` should be the permanent home for every reusable Copilot
+or agent-governance pattern. When a workflow becomes useful beyond this site,
+prefer extracting it rather than broadening the repo's purpose indefinitely.
+
 ## Lifecycle Backbone
 
 | Phase | Callable skill | Reference file | Notes |
@@ -31,7 +36,7 @@ optional execution aids when available, not as guarantees across every runtime.
 
 ## Blog Augmentations
 
-These skills remain valuable because they encode repo-specific workflows, constraints, and quality gates:
+These skills remain valuable because they encode repo-specific workflows, constraints, and quality gates for running the publication safely:
 
 | Domain | Skill | File | Use for |
 |---|---|---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,18 @@ Use the repo's instruction sources as complementary layers:
 
 Runtime features such as custom agents or MCP/tool integrations can vary by execution environment. Use them when available, but do not imply every runtime exposes the same surface area.
 
+## Product Boundary
+
+`oviney/blog` is the source repository for the viney.ca publication. The primary
+job of the instructions and skills in this repo is to help agents publish,
+validate, review, and safely operate the blog.
+
+Some agent and governance machinery in this repo is broader than the publishing
+surface itself. Treat that machinery as supporting infrastructure, not as the
+reason the repository exists. If a workflow, skill, or automation pattern
+proves broadly reusable outside this site, it is a candidate for extraction
+rather than indefinite expansion here.
+
 ## Persona Layers
 
 Use the repo's current agent documentation in two complementary layers:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Professional commentary on software quality engineering, test automation, and em
 
 **Content Generation**: Articles are produced using [economist-agents](https://github.com/oviney/economist-agents), a multi-agent AI system that generates publication-quality content with The Economist's voice.
 
+## Repository Boundary
+
+`oviney/blog` is the source repository for the **viney.ca publication**: content, theme, layouts, reader-facing quality checks, and deployment all live here.
+
+The repository also contains some agent and governance automation used to operate the site today. That automation exists to support the blog, not to redefine this repository as a general-purpose agent platform. Reusable orchestration, evaluation, or governance tooling that proves valuable beyond this site should be treated as an **extraction candidate** for a separate repository rather than expanded indefinitely here.
+
 ## Local Development
 
 ```bash
@@ -110,6 +116,8 @@ blog/
 ├── _sass/           # Custom Economist theme SCSS  
 ├── _includes/       # Reusable components
 ├── assets/          # Images, CSS, charts
+├── .github/         # Deploy, QA, and repo-governance automation
+├── scripts/         # Blog validation and operational support scripts
 ├── _config.yml      # Jekyll configuration
 └── Gemfile          # Ruby dependencies
 ```
@@ -118,9 +126,11 @@ blog/
 
 For details on the AI content generation pipeline, see [oviney/economist-agents](https://github.com/oviney/economist-agents).
 
-## Agent PR Eval Harness
+## Repo Governance and Maintenance Tooling
 
-Tools that agents run to self-validate their PRs before requesting review.
+This repository includes agent and governance tooling because it currently helps maintain the blog safely. It should be read as **supporting infrastructure for the publication**, not as the primary product of the repo.
+
+Some of this tooling may move to a separate repository over time if it becomes broadly reusable outside viney.ca. Until then, the operating rule is simple: blog publishing, reader experience, and site quality come first; supporting automation should stay tightly scoped to those needs.
 
 ### Scope Self-Check
 
@@ -144,7 +154,8 @@ bash scripts/check-pr-scope.sh
 - Exit `1` → one or more violations found; fix them before pushing.
 
 No dependencies beyond `git` and `bash`.
-## Agent Merge Unblocker
+
+### Agent Merge Unblocker
 
 Every Copilot-authored PR passes through the normal branch-protection rules on
 `main`.  Two settings were found (see [#586](https://github.com/oviney/blog/issues/586))
@@ -197,6 +208,8 @@ user-owned repositories.  After running the script:
 Re-run the script any time branch-protection settings are reset by a GitHub
 UI change, a repository transfer, or a new admin modifying the settings.  The
 script is safe to run repeatedly.
+### Agent PR Eval Harness
+
 `scripts/eval-agent-pr.sh` scores any PR against a five-dimension quality rubric
 and writes a JSON snapshot to `.agent-evals/<pr>.json`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The repository also contains some agent and governance automation used to operat
 bundle install
 
 # Run locally
-bundle exec jekyll serve
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
 
 # Visit http://localhost:4000
 ```
@@ -46,8 +46,14 @@ bundle exec jekyll serve
 # Install testing dependencies
 npm install
 
+# Build the site (primary build truth)
+bundle exec jekyll build
+
 # Create baseline screenshots (first time only)
 npm run test:visual:reference
+
+# Start Jekyll before browser-based QA
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
 
 # Run visual regression tests
 npm run test:visual
@@ -63,6 +69,12 @@ npm run test:security
 
 # Run all tests
 npm test
+
+# Run the PR scope guard before opening a PR
+bash scripts/check-pr-scope.sh
+
+# If the PR changes .github/skills/ or .github/instructions/
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
 ```
 
 **Pre-commit Hook:**
@@ -93,6 +105,7 @@ GitHub Actions automatically builds and deploys changes to GitHub Pages.
 - ✅ CI: Accessibility testing (pa11y-ci WCAG 2.1 AA)
 - ✅ CI: Performance testing (Lighthouse CI - Performance, SEO, Best Practices)
 - ✅ CI: Security audit (npm audit)
+- ✅ PR scope guard: `bash scripts/check-pr-scope.sh`
 - ✅ Deployment: Automated to GitHub Pages
 
 ## Custom Theme

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,17 @@ clear publication path.
    (for example, security debt, platform engineering, or AI adoption) so the
    roadmap produces clusters rather than isolated essays.
 
+## Operating Model
+
+This repository's roadmap is for the **publication** first: content, discovery,
+reader experience, and the quality gates required to ship viney.ca safely.
+
+Operational automation is in scope only when it directly improves publishing,
+validation, deployment, or reader-facing reliability. Agent orchestration,
+governance experiments, and reusable workflow tooling should be treated as
+supporting infrastructure and, where they become broader than the blog itself,
+as candidates for extraction into a separate repository.
+
 ## Tech Debt
 
 1. **Sass `@import` → `@use`/`@forward`** — Dart Sass has deprecated `@import`;
@@ -58,4 +69,4 @@ clear publication path.
 
 ---
 
-*Last updated: April 2026*
+*Last updated: May 2026*

--- a/decisions.md
+++ b/decisions.md
@@ -76,4 +76,14 @@ configuration, design conventions, or content standards.
 
 ---
 
+## ADR-008: Publication-First Repository Boundary
+
+**Date**: May 2026
+**Status**: Active
+**Context**: `oviney/blog` grew beyond the blog itself and now contains agent governance, orchestration, reporting, and workflow tooling alongside the publication. That made the repository harder to reason about and blurred whether its primary purpose was the blog or a broader automation platform.
+**Decision**: Treat `oviney/blog` as the source repository for the viney.ca publication first: content, theme, layouts, deployment, and reader-facing quality gates belong here by default. Supporting automation may remain when it directly helps run the site, but reusable agent/governance tooling with standalone value should be treated as an extraction candidate rather than expanded indefinitely in this repo.
+**Consequences**: Contributor and agent documentation should describe the repo as blog-first, not platform-first. New workflows or scripts should justify their place in terms of publishing, validating, deploying, or protecting viney.ca. Extraction discussions should start by classifying automation into keep-in-blog, extract, or decide-later buckets instead of assuming the blog repo is the permanent home for every tool.
+
+---
+
 *Add new decisions below this line, following the ADR-NNN format.*

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -4,6 +4,11 @@
 
 A production Jekyll blog with a **custom Economist-inspired theme**, deployed via GitHub Actions to GitHub Pages at **https://www.viney.ca/**.
 
+The primary purpose of this repository is the publication itself: content,
+theme, deployment, and the quality gates needed to keep the site trustworthy for
+readers. Supporting agent and governance automation exists here today, but that
+automation should be treated as operational support rather than the core product.
+
 ## Site Overview
 
 | Property | Value |
@@ -28,7 +33,7 @@ Custom Economist-inspired design system (`_sass/economist-theme.scss`, 600+ line
 
 ## CI/CD Pipeline
 
-Four GitHub Actions workflows run automatically on push to `main`:
+Core workflows that matter directly to the published blog include:
 
 | Workflow | File | Purpose |
 |---|---|---|
@@ -36,6 +41,11 @@ Four GitHub Actions workflows run automatically on push to `main`:
 | Test Build | `test-build.yml` | Jekyll build validation + HTML checks |
 | Quality Tests | `test-quality.yml` | Visual regression, a11y, Lighthouse, security |
 | Healing Monitor | `healing-monitor.yml` | Playwright test healing (runs every 4 hours) |
+
+The repository also contains additional operational workflows for agent support,
+reporting, and governance. Those workflows are part of the current operating
+model, but not all of them necessarily belong in the long-term product boundary
+of `oviney/blog`.
 
 ## Quality Gates
 
@@ -70,6 +80,12 @@ Blog articles are produced using the [economist-agents](https://github.com/ovine
 - **Actions**: https://github.com/oviney/blog/actions
 - **Dashboard**: https://oviney.github.io/blog/dashboard/
 
+## Boundary Note
+
+If a script, workflow, or dashboard has clear value outside this blog, it should
+be evaluated as an extraction candidate into a separate repository rather than
+used to redefine the purpose of `oviney/blog`.
+
 ---
 
-**Last updated**: April 2026
+**Last updated**: May 2026

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -4,8 +4,8 @@
 
 ### Quick Start
 ```bash
-cd /Users/ouray.viney/code/economist-blog-v5
-bundle exec jekyll serve
+cd /home/ouray/blog
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
 ```
 
 The server will start at: **http://127.0.0.1:4000/**
@@ -28,14 +28,14 @@ When starting the server, you'll see these warnings that don't affect functional
 
 ### Successful Server Output
 ```
-Configuration file: /Users/ouray.viney/code/economist-blog-v5/_config.yml
-            Source: /Users/ouray.viney/code/economist-blog-v5
-       Destination: /Users/ouray.viney/code/economist-blog-v5/_site
+Configuration file: /home/ouray/blog/_config.yml
+            Source: /home/ouray/blog
+       Destination: /home/ouray/blog/_site
  Incremental build: disabled. Enable with --incremental
       Generating... 
        Jekyll Feed: Generating feed for posts
                     done in 0.329 seconds.
- Auto-regeneration: enabled for '/Users/ouray.viney/code/economist-blog-v5'
+ Auto-regeneration: enabled for '/home/ouray/blog'
     Server address: http://127.0.0.1:4000/
   Server running... press ctrl-c to stop.
 ```
@@ -83,9 +83,30 @@ git commit -m "description"
 
 If any check fails, commit is blocked until fixed.
 
+### 2b. Run the Same Local Checks CI Expects
+```bash
+bundle exec jekyll build
+
+# Start Jekyll before browser-based QA
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
+
+npm run test:security
+npm run test:playwright
+npm run test:a11y
+npm run test:lighthouse
+bash scripts/check-pr-scope.sh
+```
+
+For governance-surface PRs that touch `.github/skills/` or `.github/instructions/`,
+mirror CI locally with:
+
+```bash
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
+```
+
 ### 3. Push to GitHub
 ```bash
-git push origin main
+git push origin <branch>
 ```
 
 ### 4. GitHub Actions Builds and Deploys
@@ -167,10 +188,11 @@ This skips validation - use with extreme caution.
 Before pushing major changes:
 
 1. **Pre-commit passed** ✅ (automatic)
-2. **Commit message descriptive** ✅
-3. **GitHub Actions status** - Check after push
-4. **Production site** - Verify at viney.ca after 2 minutes
-5. **Blog QA Agent** - Run for additional validation
+2. **`bundle exec jekyll build` passed** ✅
+3. **Relevant QA command(s) passed** ✅ (`npm run test:security`, `npm run test:playwright`, `npm run test:a11y`, `npm run test:lighthouse`)
+4. **Scope guard passed** ✅ (`bash scripts/check-pr-scope.sh`)
+5. **GitHub Actions status** - Check after push
+6. **Production site** - Verify at viney.ca after deployment
 
 ## Troubleshooting
 

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -49,6 +49,20 @@ Press `Ctrl-C` in the terminal to stop the server.
 
 The local server is now working, but the pre-commit hook workflow is still recommended for most development. The server is useful for rapid iteration on CSS/layout changes.
 
+## Repository Boundary
+
+This repository is primarily the source of the viney.ca publication. Day-to-day
+development should optimise for:
+
+- publishing content
+- maintaining the Jekyll theme and layouts
+- protecting reader-facing quality with builds, tests, and validation
+
+The repo currently contains some supporting agent/governance automation as well.
+Treat that automation as maintenance infrastructure for the blog, not as the
+primary product. If a script or workflow becomes useful outside this site, it
+should be considered for extraction rather than expanded by default here.
+
 ## Recommended Workflow
 
 ### 1. Make Changes
@@ -99,17 +113,17 @@ The `.git/hooks/pre-commit` script catches:
 - Missing required metadata
 - Broken internal links
 
-### GitHub Actions Handles Build & Deployment
+### GitHub Actions Handle Build & Deployment
 - Jekyll 4.3.2 with full plugin support
 - Consistent build environment (Ubuntu)
 - No local SSL/certificate issues
 - Complete build logs for debugging
-- Minimal Mistakes theme support
+- Static-site publishing and QA support for viney.ca
 
-### Blog QA Agent Learns from Issues
-- Self-improving validation
-- Learns patterns from any missed issues
-- Stores knowledge in `skills/blog_qa_skills.json`
+### External Companion Tooling
+The blog may be operated with companion tooling from other repositories, such as
+`oviney/economist-agents`. Keep that relationship explicit: those tools support
+this site, but they are not part of the publication repo's core product boundary.
 
 ## Benefits Over Local Server
 
@@ -197,4 +211,4 @@ chmod +x .git/hooks/pre-commit
 
 ---
 
-**Bottom Line:** Your current workflow (pre-commit + GitHub Pages) is production-grade. No local `jekyll serve` needed.
+**Bottom Line:** Develop this repo as a publication system first. Keep supporting tooling scoped to what the blog actually needs.

--- a/specs/copilot-skills-agents-redesign-spec.md
+++ b/specs/copilot-skills-agents-redesign-spec.md
@@ -1,0 +1,195 @@
+# Spec: GitHub Copilot Skills and Agents Workflow Redesign
+
+**Status:** Draft - awaiting approval  
+**Date:** 2026-05-17  
+**Lifecycle phase:** SPECIFY
+
+## Assumptions I'm Making
+
+1. The goal is to improve how this repository defines and uses **GitHub Copilot Skills and Agents**, not to redesign the blog product itself.
+2. This redesign should cover both **direct/local agent execution** and **issue-assigned Copilot cloud agent** workflows, while acknowledging they are not identical runtimes.
+3. The target outcome is a clearer, lower-drift governance model for skills, agent personas, routing, and validation, not a net-new automation platform.
+4. It is acceptable for the redesign to touch governance docs, skill files, and supporting validation scripts/workflows, but not protected files such as `_config.yml`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `Gemfile`, or `Gemfile.lock`.
+5. Success should be measured by **clearer routing, fewer overlapping concepts, and machine-checkable consistency**, not by adding more personas or more prose.
+
+## Objective
+
+Redesign the repository's GitHub Copilot Skills and Agents setup so it is easier for agents and humans to answer four questions consistently:
+
+1. Which skill should be invoked first?
+2. Which persona owns the work?
+3. Which files and workflows are in scope?
+4. How do we verify the governance docs and skills are internally consistent?
+
+The users are maintainers and agents working inside `oviney/blog`. Success means the repo has a single, comprehensible workflow model with explicit contracts between:
+
+- lifecycle skills (`spec`, `plan`, `build`, `test`, `review`, `ship`)
+- repo-specific augmentation skills (`jekyll-development`, `jekyll-qa`, `editorial`, `economist-theme`, etc.)
+- persona routing (`agent:*` labels and scope boundaries)
+- automated checks that catch drift before merge
+
+## Tech Stack
+
+- GitHub Copilot CLI / Copilot cloud agent workflows
+- Markdown governance docs
+- GitHub issue labels and PR workflow
+- Bash automation in `scripts/`
+- GitHub Actions workflows in `.github/workflows/`
+- Jekyll repo validation via `bundle exec jekyll build`
+
+## Commands
+
+```bash
+# Build the site after governance/doc changes
+bundle exec jekyll build
+
+# Run scope checks for governance-surface work
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
+
+# Run the documentation audit locally when issue filing is intended
+GH_TOKEN="$GH_TOKEN" GITHUB_REPOSITORY=oviney/blog bash scripts/doc-audit.sh
+
+# Manually dispatch the documentation audit workflow
+gh workflow run doc-audit.yml --repo oviney/blog
+
+# Inspect current skill inventory
+find .github/skills -name SKILL.md | sort
+```
+
+## Project Structure
+
+```text
+.github/
+  skills/                         Skill definitions and lifecycle/reference guidance
+    */SKILL.md
+  instructions/                   Path-specific editing rules
+  workflows/                      CI and governance workflows
+AGENTS.md                         Persona roster, ownership, handoffs, conventions
+CLAUDE.md                         Local/direct lifecycle backbone
+scripts/
+  check-pr-scope.sh               Scope/governance guardrail
+  doc-audit.sh                    Documentation and skill consistency audit
+specs/
+  copilot-skills-agents-redesign-spec.md
+```
+
+Likely implementation surfaces for this redesign:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.github/skills/README.md`
+- selected `./.github/skills/*/SKILL.md` files
+- `scripts/doc-audit.sh`
+- `.github/workflows/doc-audit.yml`
+- optionally a new machine-readable governance manifest if needed
+
+## Code Style
+
+Prefer short, declarative skill metadata and explicit routing language over narrative duplication.
+
+```yaml
+---
+name: review
+description: Review changes before merge
+phase: review
+callable: true
+domain: lifecycle
+allowed_paths:
+  - ".github/skills/"
+  - "AGENTS.md"
+required_checks:
+  - "bundle exec jekyll build"
+  - "PR_LABELS=governance-update bash scripts/check-pr-scope.sh"
+---
+```
+
+Conventions this redesign should follow:
+
+- one primary callable skill per lifecycle phase
+- augmentation skills describe repo-specific guidance, not duplicate the lifecycle contract
+- personas define domain ownership and scope boundaries
+- docs summarize and link to the canonical source rather than restating it
+- examples should be concrete and executable
+
+## Testing Strategy
+
+This redesign is primarily governance, documentation, and validation work, so testing is structural rather than feature-UI based.
+
+1. **Build validation**
+   - `bundle exec jekyll build`
+   - Ensures repo docs and pages still build cleanly
+
+2. **Scope validation**
+   - `PR_LABELS=governance-update bash scripts/check-pr-scope.sh`
+   - Confirms governance-surface changes are deliberate and within repo guardrails
+
+3. **Governance consistency validation**
+   - Extend or refine `scripts/doc-audit.sh` and/or related workflow checks so they can detect:
+     - mismatched persona labels across docs
+     - overlapping or ambiguous callable skill names
+     - missing required skill metadata
+     - drift in protected-file lists and ownership tables
+
+4. **Review-level verification**
+   - Diff review confirms routing is unambiguous:
+     - one canonical lifecycle map
+     - one canonical persona/scope source
+     - reference docs link rather than fork behavior
+
+5. **Change-level verification**
+   - Each implementation slice should touch a small number of files and ship with a specific before/after contract, e.g.:
+     - "callable vs reference-only skill metadata exists everywhere"
+     - "Audience Researcher is either fully routable or explicitly local-only"
+     - "Doc audit fails when a skill omits required metadata"
+
+## Boundaries
+
+- **Always do:**
+  - Keep lifecycle routing explicit and phase-first
+  - Keep persona scope boundaries machine-checkable where possible
+  - Update validation logic when governance rules change
+  - Validate with `bundle exec jekyll build`
+  - Validate governance work with `PR_LABELS=governance-update bash scripts/check-pr-scope.sh`
+
+- **Ask first:**
+  - Adding or removing personas
+  - Renaming existing public-facing slash commands or lifecycle skill names
+  - Introducing a new manifest file or schema for skill metadata
+  - Expanding doc-audit behavior to enforce new repo policy in CI
+  - Changing label strategy for issue-assigned Copilot cloud agents
+
+- **Never do:**
+  - Modify protected files: `_config.yml`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `Gemfile`, `Gemfile.lock`
+  - Assume all runtimes expose the same agent, skill, or MCP integrations
+  - Leave duplicate routing rules in multiple docs without a canonical owner
+  - Add new dependencies just to manage governance metadata
+  - Treat overlapping callable skill names as acceptable ambiguity
+
+## Success Criteria
+
+1. A maintainer can identify the correct first skill for a task in under 30 seconds from one canonical routing source.
+2. Each lifecycle phase has exactly one primary callable skill, with any supporting/reference files clearly marked as non-primary.
+3. Persona ownership, allowed paths, and handoff expectations are defined in one canonical place and referenced elsewhere without semantic drift.
+4. The repo's agent model clearly distinguishes:
+   - local/direct execution guidance
+   - issue-assigned Copilot cloud agent guidance
+   - optional runtime-specific capabilities
+5. Audience-research / ancillary personas are either fully integrated into routing or explicitly documented as secondary/local-only.
+6. Skill files expose consistent machine-checkable metadata sufficient to validate callable status, lifecycle phase, and scope intent.
+7. Automated governance checks can detect at least:
+   - missing required skill metadata
+   - mismatched agent labels across governing docs
+   - duplicate/conflicting routing declarations
+   - stale or broken links among skill/governance docs
+8. The redesign can be implemented incrementally in reviewable slices rather than a repo-wide rewrite.
+
+## Open Questions
+
+1. Should the canonical routing source be `CLAUDE.md`, `.github/skills/README.md`, or a new dedicated manifest-backed doc?
+2. Should `AGENTS.md` remain the canonical persona/scope source, or should scope data move into a machine-readable file consumed by docs and checks?
+3. Should `agent:audience-researcher` become part of issue-label routing, or remain a local/direct persona only?
+4. Should callable/reference-only metadata live in front matter on each `SKILL.md`, in a central registry, or both?
+5. Should this redesign ship as:
+   - one governance PR,
+   - a spec PR plus follow-up implementation PRs,
+   - or a phased sequence (routing first, metadata second, linting third)?


### PR DESCRIPTION
## Summary
- clarify that oviney/blog is the viney.ca publication repo first
- align contributor-facing CI/CD guidance with the repo's real commands
- record the publication-first boundary in ADR-008

Closes #963

## Verification
- bundle exec jekyll build
- PR_LABELS=governance-update bash scripts/check-pr-scope.sh

## Rollback
Revert this PR cleanly if the boundary language or contributor guidance proves misleading.

## Notes
This PR changes .github/skills/README.md, so it depends on the governance-update label flow.