### PR TITLE
docs: refocus blog repo boundary and align CI docs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,116 +1,97 @@
 # Getting Started
 
-This guide covers local setup, running tests, and deploying changes to the blog at https://www.viney.ca/.
+This guide covers local setup, validation, and the standard Pull Request workflow for changes to https://www.viney.ca/.
 
 ## Prerequisites
 
 - **Ruby 3.3** — install via [rbenv](https://github.com/rbenv/rbenv) (`rbenv install 3.3.6`)
 - **Bundler** — `gem install bundler`
-- **Node.js 18+** — install via [nvm](https://github.com/nvm-sh/nvm)
+- **Node.js 20+** — install via [nvm](https://github.com/nvm-sh/nvm)
 - **Git**
 
-## Local Setup
+## Local setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/oviney/blog.git
 cd blog
-
-# Install Ruby dependencies
 bundle install
-
-# Install Node.js dependencies
 npm install
 ```
 
-## Running the Site Locally
+## Run the site locally
 
-```bash
-bundle exec jekyll serve --livereload
-```
-
-Visit http://localhost:4000 in your browser. The site auto-reloads on file changes.
-
-> **Note**: If you encounter SSL errors related to remote themes, the pre-commit hook handles this gracefully. You can still commit and rely on GitHub Actions for full builds.
-
-### Development config
-
-Use `_config_dev.yml` to override settings for local development:
+Use the development config so local-only settings stay out of production:
 
 ```bash
 bundle exec jekyll serve --config _config.yml,_config_dev.yml --livereload
 ```
 
-## Running Tests
+Visit http://localhost:4000 after the server starts.
 
-Tests require the Jekyll server to be running on port 4000 first.
+## Validate your changes
+
+Run the canonical build before opening a PR:
 
 ```bash
-# Start the server (in a separate terminal)
-bundle exec jekyll serve
-
-# Run all tests
-npm test
-
-# Run individual test suites
-npm run test:visual          # Visual regression (BackstopJS)
-npm run test:a11y            # Accessibility (pa11y-ci, WCAG 2.1 AA)
-npm run test:lighthouse      # Performance/SEO (Lighthouse CI)
-npm run test:playwright      # Playwright end-to-end tests
-npm run test:security        # Security audit (npm audit)
+bundle exec jekyll build
+bash scripts/check-pr-scope.sh
 ```
 
-### First-time visual baseline
-
-Before running visual regression tests for the first time, generate reference screenshots:
+Run the existing repo QA commands that match your change:
 
 ```bash
-npm run test:visual:reference
+npm run test:playwright
+npm run test:a11y
+npm run test:lighthouse
+npm run test:security
 ```
 
-## Pre-commit Hook
+If you need the full browser-facing suite, keep the Jekyll server running on port 4000 in a separate terminal.
 
-A pre-commit hook runs automatically on `git commit`. It validates Jekyll builds for content changes and skips the build for docs-only changes. No setup is required — the hook is included in the repository.
+## Pre-commit hook
 
-## Deploying Changes
+The repository includes a pre-commit hook that validates Jekyll builds for content changes and skips the build for docs-only changes. Treat it as an early warning, not a replacement for the full commands above.
 
-Push to `main` to trigger an automatic deployment:
+## Standard workflow
 
-```bash
-git add .
-git commit -m "your message"
-git push origin main
-```
-
-GitHub Actions builds and deploys to GitHub Pages within ~1–2 minutes. Monitor progress at https://github.com/oviney/blog/actions.
-
-### Publishing a new article
+All non-trivial changes should ship through a feature branch and Pull Request.
 
 ```bash
-# Create the post file
-touch _posts/YYYY-MM-DD-article-slug.md
-
-# Add front matter and content, then commit
-git add _posts/YYYY-MM-DD-article-slug.md
-git commit -m "Publish: Article title"
-git push origin main
-```
-
-## Feature Branch Workflow
-
-All bug fixes and new features should use feature branches and Pull Requests — never commit directly to `main`.
-
-```bash
-git checkout -b fix/issue-description
+git checkout -b docs/short-description
 # make changes
-git push origin fix/issue-description
-# open a Pull Request on GitHub
+git add <files>
+git commit -m "docs: concise description"
+git push origin docs/short-description
 ```
 
-## Useful Links
+Open a PR after pushing, then let GitHub Actions run the repo checks. Once the PR is merged to `main`, the site deploys automatically to GitHub Pages.
+
+## Publishing a new article
+
+Create new posts on a branch, not directly on `main`:
+
+```bash
+touch _posts/YYYY-MM-DD-article-slug.md
+git checkout -b post/article-slug
+git add _posts/YYYY-MM-DD-article-slug.md
+git commit -m "docs: add article slug"
+git push origin post/article-slug
+```
+
+## Governance-surface PRs
+
+If your PR intentionally changes `.github/skills/` or `.github/instructions/`, run the scope guard with the governance label mirrored locally:
+
+```bash
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
+```
+
+Those PRs must also carry the `governance-update` label on GitHub.
+
+## Useful links
 
 - **Production site**: https://www.viney.ca/
 - **GitHub Actions**: https://github.com/oviney/blog/actions
-- **Healing dashboard**: https://oviney.github.io/blog/dashboard/
+- **Development workflow**: [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
 - **Architecture overview**: [ARCHITECTURE.md](ARCHITECTURE.md)
 - **Full documentation**: [docs/](docs/)

--- a/README.md
+++ b/README.md
@@ -9,278 +9,90 @@
 ![Healing Success](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/oviney/blog/main/.github/badges/healing-success.json)
 ![Healing Trend](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/oviney/blog/main/.github/badges/healing-trend.json)
 
-Software engineering insights on quality, testing, and AI - written in The Economist's signature style.
+This repository is the publication and site source for [viney.ca](https://www.viney.ca): posts, layouts, styling, assets, search data, scripts, and the GitHub Actions workflows that validate and deploy the site.
 
-**Theme:** Custom Economist-inspired design system  
-**Typography:** Merriweather (serif) + Inter (sans-serif)  
-**Build:** Jekyll 4.3.2 via GitHub Actions  
-**Deployment:** GitHub Pages
+The blog publishes software engineering commentary on quality, test automation, security, and AI in an Economist-inspired editorial style.
 
-## About
+## What lives here
 
-Professional commentary on software quality engineering, test automation, and emerging technologies. 
+- Jekyll source for the production site
+- Published posts and supporting page content
+- Custom Economist-inspired theme assets and layouts
+- QA, accessibility, performance, and security automation for the site
+- Contributor and governance docs for working safely in this repository
 
-**Content Generation**: Articles are produced using [economist-agents](https://github.com/oviney/economist-agents), a multi-agent AI system that generates publication-quality content with The Economist's voice.
-
-## Local Development
+## Quick start
 
 ```bash
-# Install Jekyll
 bundle install
-
-# Run locally
-bundle exec jekyll serve
-
-# Visit http://localhost:4000
-```
-
-**Testing Locally:**
-
-```bash
-# Install testing dependencies
 npm install
-
-# Create baseline screenshots (first time only)
-npm run test:visual:reference
-
-# Run visual regression tests
-npm run test:visual
-
-# Run accessibility audit
-npm run test:a11y
-
-# Run Lighthouse performance/SEO tests
-npm run test:lighthouse
-
-# Run security audit
-npm run test:security
-
-# Run all tests
-npm test
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
 ```
 
-**Pre-commit Hook:**
-The pre-commit hook automatically validates Jekyll builds before commits. This catches build errors locally before pushing to GitHub.
+Visit http://localhost:4000 after the server starts.
 
-## Publishing
+## Local validation
 
-Content is published via Git:
+Run the canonical site build before opening a PR:
 
 ```bash
-git add _posts/new-article.md
-git commit -m "Publish: Article title"  
-git push origin main
-```
-
-GitHub Actions automatically builds and deploys changes to GitHub Pages.
-
-**Build & Deployment:**
-- Triggers on push to `main` branch
-- Uses Jekyll 4.3.2 with custom Economist theme
-- Deployment time: 1-2 minutes
-- Monitor progress: https://github.com/oviney/blog/actions
-
-**Quality Gates:**
-- ✅ Pre-commit: Jekyll build validation (local)
-- ✅ CI: Jekyll build test + HTML validation
-- ✅ CI: Visual regression testing (BackstopJS)
-- ✅ CI: Accessibility testing (pa11y-ci WCAG 2.1 AA)
-- ✅ CI: Performance testing (Lighthouse CI - Performance, SEO, Best Practices)
-- ✅ CI: Security audit (npm audit)
-- ✅ Deployment: Automated to GitHub Pages
-
-## Custom Theme
-
-The site features a bespoke design system inspired by The Economist:
-
-- **Typography**: Merriweather serif for body text, Inter for UI elements
-- **Colors**: The Economist red (#E3120B) for accents, clean blacks and grays
-- **Layout**: Red header banner, horizontal navigation, article cards, dark footer
-- **Components**: Category breadcrumbs, read time indicators, featured images, related posts
-- **Responsive**: Mobile-first design with breakpoints at 768px and 1024px
-
-Theme source: `_sass/economist-theme.scss` (600+ lines)
-
-## Project Structure
-
-```
-blog/
-├── _posts/          # Blog articles (markdown)
-├── _layouts/        # Custom theme layouts (default.html, post.html)
-├── _sass/           # Custom Economist theme SCSS  
-├── _includes/       # Reusable components
-├── assets/          # Images, CSS, charts
-├── _config.yml      # Jekyll configuration
-└── Gemfile          # Ruby dependencies
-```
-
-## Content Generation System
-
-For details on the AI content generation pipeline, see [oviney/economist-agents](https://github.com/oviney/economist-agents).
-
-## Agent PR Eval Harness
-
-Tools that agents run to self-validate their PRs before requesting review.
-
-### Scope Self-Check
-
-**Script:** `scripts/check-pr-scope.sh`
-
-A lightweight pre-push self-check that every agent should run before opening or updating a PR. It diffs the current branch against `origin/main` and enforces three scope rules:
-
-| Rule | What it flags |
-|------|--------------|
-| **Protected files** | Any change to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `AGENTS.md`, or `ARCHITECTURE.md` |
-| **Scope explosion** | More than 15 files changed in a single PR |
-| **Governance surfaces** | Any change under `.github/skills/` or `.github/instructions/` — these require a dedicated issue |
-
-**When to run:** Before every `git push` on an agent branch.
-
-```bash
+bundle exec jekyll build
 bash scripts/check-pr-scope.sh
 ```
 
-- Exit `0` → no violations; safe to push.
-- Exit `1` → one or more violations found; fix them before pushing.
-
-No dependencies beyond `git` and `bash`.
-## Agent Merge Unblocker
-
-Every Copilot-authored PR passes through the normal branch-protection rules on
-`main`.  Two settings were found (see [#586](https://github.com/oviney/blog/issues/586))
-that silently block agent PRs from ever merging:
-
-| # | Setting | Symptom | Fix |
-|---|---------|---------|-----|
-| 1 | `dismiss_stale_reviews = true` (branch protection, `main`) | Bot follow-up commits silently dismiss human approvals; PR drifts back to `REVIEW_REQUIRED`. | Set to `false` — approval survives subsequent bot commits. |
-| 2 | Actions → "Require approval for all outside collaborators" | Copilot bot is treated as a first-time contributor; every workflow ends in `action_required` (0 s); `build` context never passes. | Change policy to "first-time contributors who are new to GitHub". |
-
-**Setting 1** is patched automatically by the script.  
-**Setting 2** must be changed manually in the web UI (GitHub does not expose this toggle via REST API for user-owned repositories).
-
-### Running the fix script
+Run additional existing repo checks as needed for your change:
 
 ```bash
-# Requires: gh CLI (authenticated as a repo admin), jq
-bash scripts/fix-agent-merge-blockers.sh [owner/repo]
+npm run test:playwright
+npm run test:a11y
+npm run test:lighthouse
+npm run test:security
 ```
 
-The script is **idempotent** — it reads current state before every write and
-exits 0 without making changes if a setting is already correct.
-
-**What the script does automatically (via REST API):**
-
-1. Reads the full branch-protection payload for `main`.
-2. Patches `dismiss_stale_reviews → false` while preserving every other
-   existing setting (required status checks, review count, admin enforcement,
-   restrictions, etc.).
-3. Confirms the write took effect.
-4. Reports `default_workflow_permissions` and `can_approve_pull_request_reviews`
-   for operator awareness — **no changes are made** to these values.
-   `can_approve_pull_request_reviews` must remain `false`; enabling it would
-   allow workflow tokens to self-approve PRs, removing the human-approval
-   requirement.
-
-**What must be done manually (web UI):**
-
-GitHub does not expose the fork-PR approval gate via REST API for
-user-owned repositories.  After running the script:
-
-1. Open **https://github.com/oviney/blog/settings/actions**
-2. Locate **"Fork pull request workflows from outside collaborators"**
-3. Select **"Require approval for first-time contributors who are new to GitHub"**
-   (or the least-restrictive option acceptable to the repository owner)
-4. Click **Save**
-
-### When to re-run
-
-Re-run the script any time branch-protection settings are reset by a GitHub
-UI change, a repository transfer, or a new admin modifying the settings.  The
-script is safe to run repeatedly.
-`scripts/eval-agent-pr.sh` scores any PR against a five-dimension quality rubric
-and writes a JSON snapshot to `.agent-evals/<pr>.json`.
-
-**Dependencies:** `gh` CLI (authenticated) and `jq`.
+If a PR intentionally changes `.github/skills/` or `.github/instructions/`, mirror CI locally with:
 
 ```bash
-# Score PR #578
-./scripts/eval-agent-pr.sh 578
-
-# Score a PR in a different repo
-./scripts/eval-agent-pr.sh 42 owner/other-repo
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
 ```
 
-The script exits **0** when every dimension passes its hard threshold, **1** otherwise.
+## Publishing workflow
 
-### Rubric
-
-| Dimension | What is measured | Hard threshold |
-|-----------|-----------------|----------------|
-| **Scope adherence** | Changed files vs. protected files list (`_config.yml`, `Gemfile`, etc.) | Fail if any protected file is modified |
-| **Atomic commits** | Commit-message heuristic: subject containing two distinct action verbs | Fail if any commit bundles multiple concerns |
-| **Test coverage** | `test_loc / code_loc` for `.js/.ts/.sh/.rb/.py` files | Fail if `code_loc > 50` and `test_loc == 0` |
-| **CI status** | All completed check-runs conclude `success` or `skipped` | Fail if any check-run fails |
-| **Review churn** | Force-pushes after first non-pending review | Fail if > 2 force-pushes post-review |
-
-### Interpreting scores
-
-Each dimension in the output JSON contains:
-
-- **`pass`** (`true`/`false`) — whether the hard threshold was met
-- **`note`** — human-readable explanation
-- Dimension-specific counters (e.g. `commit_count`, `force_push_count`)
-
-**`all_pass: true`** means the PR passed every threshold — a signal of
-high-quality, reviewable agent work.  Individual dimensions can be inspected
-when `all_pass` is `false` to identify which governance rule was violated.
-
-Fixture evaluations for reference PRs live in `.agent-evals/`
-(e.g. `565.json`, `569.json`, `574.json`).
-## Agent Merge Unblocker
-
-A small collection of standalone scripts that correct repository settings which
-can silently block Copilot-agent PRs from merging.  Each script is idempotent,
-uses only `gh` CLI and `jq`, and follows a read → modify → write → verify
-pattern so that no other protection setting is disturbed.
-
-### Require up-to-date branches
-
-**Script:** `scripts/require-up-to-date-branches.sh`
-
-#### What it does
-
-Patches `required_status_checks.strict → true` on the `main` branch
-protection.  With this enabled, a PR cannot merge unless its base commit equals
-the current tip of `main`, forcing an explicit rebase or merge-up that either
-surfaces conflicts or confirms the diff is genuinely in-scope.
-
-The script follows a strict read-modify-write pattern:
-
-1. Reads the full branch-protection payload for `main` via `GET /repos/{owner}/{repo}/branches/main/protection`.
-2. If `required_status_checks.strict` is already `true`, prints `✓` and exits 0 with **no API writes**.
-3. Otherwise, builds a `PUT` payload that sets `strict → true` while preserving every other existing setting (review counts, dismiss-stale, code-owner reviews, restrictions, enforce-admins, etc.).
-4. Verifies the write took effect by re-reading the endpoint and comparing.
-5. Exits 1 on any API failure with a clear error message.
-
-#### Why it is needed
-
-The RCA in [#590](https://github.com/oviney/blog/issues/590) identified the primary root cause of phantom commits seen in PRs [#576](https://github.com/oviney/blog/issues/576), [#561](https://github.com/oviney/blog/issues/561), and [#578](https://github.com/oviney/blog/issues/578): all three branches forked from `main` before a large merge landed.  Copilot's platform auto-update mechanism then cherry-picked `main`'s new commits onto each stale branch with the original author date preserved, making the phantom commits invisible in reviewer diffs.
-
-Requiring branches to be up to date before merge eliminates this failure mode at the root: Copilot must rebase or merge `main` explicitly, producing a visible, auditable diff.
-
-#### Usage
+Use a feature branch and Pull Request for changes to this repository.
 
 ```bash
-# Requires: gh CLI (authenticated as a repo admin), jq
-bash scripts/require-up-to-date-branches.sh [owner/repo]
+git checkout -b docs/short-description
+git add <files>
+git commit -m "docs: concise description"
+git push origin docs/short-description
 ```
 
-`owner/repo` defaults to `oviney/blog`.  The script is safe to run with any
-admin-scoped `gh` token.
+After the PR is merged to `main`, GitHub Actions builds and deploys the site to GitHub Pages.
 
-#### When to re-run
+## CI/CD at a glance
 
-Re-run any time branch-protection settings are reset — for example after a
-GitHub UI change, a repository transfer, or a new admin modifying the
-settings.  The script is safe to run repeatedly; it exits 0 immediately when
-the setting is already correct.
+- `test-build.yml` validates the Jekyll build
+- `test-quality.yml` runs QA, accessibility, performance, and security checks
+- `jekyll.yml` deploys the site after changes land on `main`
+- Workflow runs are visible at <https://github.com/oviney/blog/actions>
+
+## Project structure
+
+```text
+_posts/          Blog articles
+_layouts/        Site layouts
+_includes/       Reusable Liquid partials
+_sass/           Theme styles
+assets/          Images, CSS, charts, and JS
+docs/            Contributor and operational documentation
+scripts/         Repo automation and guardrails
+.github/workflows/ CI and deploy workflows
+```
+
+## Related docs
+
+- [GETTING_STARTED.md](GETTING_STARTED.md)
+- [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
+- [AGENTS.md](AGENTS.md)
+- [CLAUDE.md](CLAUDE.md)
+
+For the external AI content-generation pipeline that feeds this site, see [oviney/economist-agents](https://github.com/oviney/economist-agents).

--- a/decisions.md
+++ b/decisions.md
@@ -77,3 +77,13 @@ configuration, design conventions, or content standards.
 ---
 
 *Add new decisions below this line, following the ADR-NNN format.*
+
+---
+
+## ADR-008: `oviney/blog` Is the Publication Repo First
+
+**Date**: May 2026
+**Status**: Active
+**Context**: Contributor-facing documentation had drifted toward describing `oviney/blog` as a general agent platform, which obscured its primary purpose and left workflow guidance inconsistent with the actual Jekyll, QA, and Pull Request flow used to publish viney.ca.
+**Decision**: Treat `oviney/blog` first as the production publication repository for viney.ca. Root docs must lead with the site, content, theme, validation, and deployment workflow. Agent, governance, and automation material remains in the repository, but as supporting operational documentation rather than the repo's primary identity.
+**Consequences**: `README.md`, onboarding docs, and workflow guides should describe feature-branch plus PR delivery, `bundle exec jekyll build` as the canonical build validation, and `bash scripts/check-pr-scope.sh` as the standard scope guard. Governance-surface changes under `.github/skills/` or `.github/instructions/` must keep using the `governance-update` label flow without broadening ordinary content or site work into governance updates.

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -1,200 +1,126 @@
 # Development Workflow
 
-## Starting the Local Jekyll Server
+This repository is the working source for the viney.ca publication site. Use this workflow when changing posts, layouts, styles, scripts, tests, or contributor docs in `oviney/blog`.
 
-### Quick Start
+## 1. Install dependencies
+
 ```bash
-cd /Users/ouray.viney/code/economist-blog-v5
-bundle exec jekyll serve
+bundle install
+npm install
 ```
 
-The server will start at: **http://127.0.0.1:4000/**
+## 2. Run the site locally
 
-### Expected Warnings (Safe to Ignore)
+Use the development config for local work:
 
-When starting the server, you'll see these warnings that don't affect functionality:
-
-1. **CSV Warning**: 
-   ```
-   csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
-   ```
-   - **Fix (optional)**: Add `gem 'csv'` to Gemfile
-
-2. **Faraday Middleware Warning**:
-   ```
-   To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
-   ```
-   - **Fix (optional)**: Run `bundle add faraday-retry`
-
-### Successful Server Output
-```
-Configuration file: /Users/ouray.viney/code/economist-blog-v5/_config.yml
-            Source: /Users/ouray.viney/code/economist-blog-v5
-       Destination: /Users/ouray.viney/code/economist-blog-v5/_site
- Incremental build: disabled. Enable with --incremental
-      Generating... 
-       Jekyll Feed: Generating feed for posts
-                    done in 0.329 seconds.
- Auto-regeneration: enabled for '/Users/ouray.viney/code/economist-blog-v5'
-    Server address: http://127.0.0.1:4000/
-  Server running... press ctrl-c to stop.
+```bash
+bundle exec jekyll serve --config _config.yml,_config_dev.yml --livereload
 ```
 
-### Stopping the Server
-Press `Ctrl-C` in the terminal to stop the server.
+The site is served at http://localhost:4000.
 
----
+## 3. Make a focused change
 
-## Local Development Without `jekyll serve`
+Work on a feature branch and keep the diff scoped to the issue you are solving.
 
-The local server is now working, but the pre-commit hook workflow is still recommended for most development. The server is useful for rapid iteration on CSS/layout changes.
+```bash
+git checkout -b docs/short-description
+```
 
-## Recommended Workflow
+Examples:
 
-### 1. Make Changes
-Edit markdown files, layouts, CSS, or configuration.
+- `docs/issue-963-repo-boundary`
+- `fix/post-slug-date`
+- `feat/mobile-bottom-nav`
 
-### 2. Commit Changes
+## 4. Run the canonical validations
+
+Before opening or updating a PR, run:
+
+```bash
+bundle exec jekyll build
+bash scripts/check-pr-scope.sh
+```
+
+Run the existing repo QA commands that match your change:
+
+```bash
+npm run test:playwright
+npm run test:a11y
+npm run test:lighthouse
+npm run test:security
+```
+
+Browser-facing tests expect the Jekyll server to be running on port 4000.
+
+## 5. Commit and push
+
 ```bash
 git add <files>
-git commit -m "description"
+git commit -m "docs: concise description"
+git push origin docs/short-description
 ```
 
-**Pre-commit hook automatically runs:**
-- ✅ Jekyll build validation
-- ✅ Broken link detection
-- ✅ YAML front matter validation
-- ✅ Required fields check (title, date)
-- ✅ Future date warnings
+Open a Pull Request after pushing. Do not treat direct pushes to `main` as the normal contributor workflow.
 
-If any check fails, commit is blocked until fixed.
+## 6. Let CI validate the PR
 
-### 3. Push to GitHub
-```bash
-git push origin main
-```
+GitHub Actions is the source of truth for repository validation:
 
-### 4. GitHub Actions Builds and Deploys
-- GitHub Actions workflow triggers on push to main
-- Build with Jekyll 4.3.2 and all plugins (~45 seconds)
-- Deploy to GitHub Pages (~30 seconds)
-- Total deployment time: 1-2 minutes
-- View progress: https://github.com/oviney/blog/actions
+- `test-build.yml` checks the Jekyll build
+- `test-quality.yml` runs quality, accessibility, performance, and security checks
+- `jekyll.yml` deploys the site after merge to `main`
 
-### 5. Verify on Production
-Visit https://www.viney.ca/ to see changes live.
+Monitor runs at <https://github.com/oviney/blog/actions>.
 
-Optionally run Blog QA Agent:
-```bash
-cd ~/code/economist-agents
-python3 scripts/blog_qa_agent.py --blog-dir ~/code/economist-blog-v5
-```
+## 7. Merge and deploy
 
-## Why This Works
+Once the PR is reviewed and merged, the deployment workflow publishes the site to GitHub Pages. Verify the published result on <https://www.viney.ca/> when the workflow completes.
 
-### Pre-commit Validation Prevents Bugs
-The `.git/hooks/pre-commit` script catches:
-- Syntax errors (Jekyll build fails)
-- Configuration issues
-- Missing required metadata
-- Broken internal links
+## Governance-surface changes
 
-### GitHub Actions Handles Build & Deployment
-- Jekyll 4.3.2 with full plugin support
-- Consistent build environment (Ubuntu)
-- No local SSL/certificate issues
-- Complete build logs for debugging
-- Minimal Mistakes theme support
-
-### Blog QA Agent Learns from Issues
-- Self-improving validation
-- Learns patterns from any missed issues
-- Stores knowledge in `skills/blog_qa_skills.json`
-
-## Benefits Over Local Server
-
-| Aspect | Local `jekyll serve` | Pre-commit + GitHub Pages |
-|--------|---------------------|---------------------------|
-| Setup complexity | High (Ruby versions, SSL certs) | Low (already configured) |
-| Build environment | Local (may differ from prod) | Production-identical |
-| Validation | Manual (must remember) | Automatic (can't skip) |
-| Preview speed | Instant | 1-2 minutes |
-| SSL certificate issues | Yes (macOS + Ruby 3.3.6) | No |
-| Remote theme fetching | Fails | Works |
-
-## When to Use Each Approach
-
-### Use Pre-commit + GitHub Pages (Recommended)
-- ✅ Content changes (blog posts, pages)
-- ✅ Configuration tweaks
-- ✅ CSS/layout modifications
-- ✅ Daily development workflow
-
-### Use Local Jekyll Server
-- Complex theme development
-- Rapid iteration on layout
-- CSS experimentation
-- Real-time preview of changes
-
-**Command:** `bundle exec jekyll serve` (see section above for details)
-
-## Emergency: Bypass Pre-commit Hook
-
-**Only in emergencies** (hook is broken, urgent hotfix):
+If a PR intentionally changes `.github/skills/` or `.github/instructions/`, mirror the labeled CI path locally:
 
 ```bash
-git commit --no-verify -m "Emergency fix"
+PR_LABELS=governance-update bash scripts/check-pr-scope.sh
 ```
 
-This skips validation - use with extreme caution.
+Those PRs must also carry the `governance-update` label on GitHub.
 
-## Verification Checklist
+## Pre-commit hook
 
-Before pushing major changes:
-
-1. **Pre-commit passed** ✅ (automatic)
-2. **Commit message descriptive** ✅
-3. **GitHub Actions status** - Check after push
-4. **Production site** - Verify at viney.ca after 2 minutes
-5. **Blog QA Agent** - Run for additional validation
+The repository pre-commit hook is useful early feedback, especially for content changes, but it does not replace the full validation commands above.
 
 ## Troubleshooting
 
-### Pre-commit Hook Fails on Jekyll Build
+### `bundle exec jekyll build` fails because a gem is missing
 
-**Symptoms:**
-```
-📦 Testing Jekyll build...
-❌ Jekyll build failed! Fix errors before committing.
-```
+Run:
 
-**Solutions:**
-1. Check `_config.yml` for syntax errors
-2. Verify all posts have valid YAML front matter
-3. Run `bundle install` if dependencies changed
-4. Check that all referenced layouts exist
-
-### GitHub Actions Fails
-
-**Check:**
-- Visit https://github.com/oviney/blog/actions
-- Click latest workflow run
-- Review logs for specific error
-- Fix and push again
-
-### Pre-commit Hook Not Running
-
-**Fix:**
 ```bash
-chmod +x .git/hooks/pre-commit
+bundle install
 ```
 
-## Related Documentation
+Then rerun the build.
 
-- [Pre-commit Hook](PRE_COMMIT_HOOK.md) - Validation script
-- [GitHub Actions](../.github/workflows/jekyll.yml) - CI/CD pipeline
-- Blog QA Agent - external companion project in `oviney/economist-agents`
+### GitHub Actions fails
 
----
+1. Open <https://github.com/oviney/blog/actions>
+2. Inspect the failing workflow
+3. Fix the issue on your branch
+4. Push again to rerun CI
 
-**Bottom Line:** Your current workflow (pre-commit + GitHub Pages) is production-grade. No local `jekyll serve` needed.
+### Scope guard fails
+
+Check whether the PR:
+
+- touches a protected file
+- changes too many files
+- needs the `governance-update` label flow for governance surfaces
+
+## Related docs
+
+- [README.md](../README.md)
+- [GETTING_STARTED.md](../GETTING_STARTED.md)
+- [AGENTS.md](../AGENTS.md)
+- [CLAUDE.md](../CLAUDE.md)


### PR DESCRIPTION
## Summary
- refocus root contributor docs around oviney/blog as the publication repo for viney.ca
- align setup and workflow guidance to the actual Jekyll, QA, branch, and scope-check commands
- record the publication-first boundary in decisions.md

Closes #963