### PR TITLE
feat(tests): bump @playwright/test to ^1.60.0 + page-level homepage ARIA snapshot (#947)

### DIFF
--- a/.github/skills/jekyll-qa/SKILL.md
+++ b/.github/skills/jekyll-qa/SKILL.md
@@ -37,7 +37,8 @@ Optional: Steps to Reproduce, Reference/Screenshots, Affected URL
 
 ### Toolchain pins (npm side)
 
-- `@playwright/test ^1.59.1`
+- `@playwright/test ^1.60.0` (bumped from `^1.59.1` in #947 — adds page-level `expect(page).toMatchAriaSnapshot()`, `test.abort()`, HAR-on-tracing, `locator.drop()`)
+  - `test.abort()` (Playwright 1.60+) is available for "tests must not call X" guardrails (issue #947) — abort the current test from a fixture, hook, or route handler with an optional message
 - `pa11y-ci ^4.1.0` (lockfile resolves to **4.1.1** as of #944; aligns with native lodash `~4.18.1` dep)
 - `lighthouse ^12.8.2`
 - `package.json` override `lodash: ^4.18.1` — predates pa11y-ci 4.1.1 and may still be load-bearing for other transitive deps; do not remove without auditing the dep graph (see #944 closing notes)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,46 +1,54 @@
-# SPEC — Puppeteer Chrome-Download Flake Mitigation (#958)
+# SPEC — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
 
 **Status:** Draft — awaiting approval
-**Issue:** [#958](https://github.com/oviney/blog/issues/958)
+**Issue:** [#947](https://github.com/oviney/blog/issues/947)
 **Labels:** `agent:qa-gatekeeper`
 **Date:** 2026-05-17
 **Lifecycle phase:** DEFINE
-**Spawned from:** observed twice in one day (#944 first run, #957 first run) — Chrome 146.0.7680.153 download flakes from puppeteer's CDN providers.
+**Blocker status:** [#944](https://github.com/oviney/blog/issues/944) **closed** 2026-05-17 — this issue is now unblocked.
+**Related PR:** [#959](https://github.com/oviney/blog/pull/959) — open Dependabot PR already bumps `package.json` + `package-lock.json` to 1.60.0 with CI green. We will supersede it (close in favour of this branch) so the lockfile bump, the snapshot migration, and the skill update ship as one atomic change.
 
 ---
 
 ## 1. Situation
 
-`actions/setup-node@v6` is already configured with `cache: 'npm'` in `.github/workflows/test-quality.yml`, so npm packages themselves are cached. **The flake is in puppeteer's post-install script** (`node install.mjs`, run during `npm ci`), which downloads Chrome from a separate CDN into `~/.cache/puppeteer/`. That directory is **not** covered by setup-node's npm cache.
+We pin `@playwright/test ^1.59.1` in `package.json`. Playwright 1.60.0 (released 2026-05-11) is additive over 1.59 — no breaking changes — and ships four features relevant to this repo:
 
-Observed flake stack: `Error: ERROR: Failed to set up chrome v146.0.7680.153! ... All providers failed for chrome 146.0.7680.153: DefaultProvider: ENOENT: no such file or directory ...puppeteer/chrome/146.0.7680.153-chrome-linux64.zip`.
+1. **Page-level `expect(page).toMatchAriaSnapshot()`** — equivalent to asserting against `page.locator('body')`, strictly more expressive than the element-scoped form for any test that wants to capture the entire accessibility tree of a route.
+2. **`test.abort()`** — abort the current test from a fixture, hook, or route handler with an optional message. Useful for the kind of "tests must not call X" guardrails we have informally today.
+3. **HAR recording on Tracing** (`tracing.startHar()` / `stopHar()`) — available but not required by this issue.
+4. **`locator.drop()`** — file/clipboard drag-and-drop simulation. Not used today.
 
-`test-quality.yml` defines 7 jobs that pair `setup-node@v6` + `npm ci`: `quality-checks`, `security`, `playwright-partial`, `playwright-shard1`, `playwright-shard2`, `playwright-shard3`, `quality-report`. Each is an independent flake surface. We've taken ~10 minutes of human time today (2 reruns × 5 min) plus a noticeable interruption to two PR merges (#955 indirectly, #957 directly).
+Current ARIA-snapshot usage (3 call-sites total, audited at HEAD `6480f00`):
+
+| File | Line | Locator | Page-level upgrade verdict |
+|---|---|---|---|
+| `tests/playwright-agents/homepage.spec.ts` | 192 | `page.locator('main').first()` | **Migrate.** `main` is the dominant landmark on `/`; page-level snapshot adds header + footer signal at zero authoring cost. |
+| `tests/playwright-agents/navigation.spec.ts` | 96 | `page.locator('main article').first()` | **Keep element-scoped.** Snapshot is intentionally narrow to the article landmark; page-level would balloon the snapshot with site chrome and create review noise on every layout tweak. |
+| `tests/playwright-agents/navigation.spec.ts` | 460 | `page.locator('#site-navigation')` | **Keep element-scoped.** Mobile-nav-open assertion is a deliberately tight check on the nav landmark in its open state; page-level captures unrelated content and weakens the assertion's intent. |
+
+The issue body anticipates this: *"or a justification is recorded in the PR description if migration is deferred."* Two of three call-sites are better left as element-scoped, and we'll record the per-test rationale in the PR description rather than mechanically migrate.
+
+There is **no footer.spec.ts** in `tests/playwright-agents/` despite the issue mentioning "footer at minimum" — `grep -l footer tests/playwright-agents/*.spec.ts` returns no file. Footer ARIA assertions live inline in `navigation.spec.ts` but do not currently use `toMatchAriaSnapshot`. We will not introduce a new footer snapshot in this PR; that is a separate authoring decision.
 
 ---
 
 ## 2. Objective
 
-Eliminate the puppeteer Chrome-download flake from `.github/workflows/test-quality.yml` by:
-
-1. **Caching `~/.cache/puppeteer/`** keyed on `package-lock.json` so warm runs skip the Chrome download entirely.
-2. **Retrying `npm ci` up to 3 times with 10s backoff** so cold-cache runs (lockfile change, cache eviction) tolerate transient CDN failures.
-
-Both mechanisms live in a **composite action** at `.github/actions/setup-node-with-puppeteer-cache/` so the 7 jobs share a single source of truth. Other workflows (`healing-monitor.yml`, `copilot-setup-steps.yml`) are **out of scope** — migrate later if the pattern proves out.
+Bump `@playwright/test` to `^1.60.0`, migrate exactly one ARIA snapshot to page-level, and update the QA skill so future agents know the new minor is in play. Ship one atomic PR with lockfile, snapshot baseline update (if regenerated), and skill doc together — so the version bump is verifiable end-to-end on a single CI run.
 
 ---
 
 ## 3. Acceptance Criteria
 
-- [ ] **AC-1** New composite action at `.github/actions/setup-node-with-puppeteer-cache/action.yml` exists with documented inputs (`node-version` default `'20'`, plus optionally `npm-cache` default `'npm'`).
-- [ ] **AC-2** The composite action's steps are: (a) `actions/setup-node@v6` with `cache: '${{ inputs.npm-cache }}'`, (b) `actions/cache@vN` for `~/.cache/puppeteer/` keyed on `${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}` with a restore-key fallback to `${{ runner.os }}-puppeteer-`, (c) `npm ci` wrapped in a 3-attempt retry shell loop with 10s backoff between attempts.
-- [ ] **AC-3** Every job in `.github/workflows/test-quality.yml` that currently uses the `setup-node@v6` + `npm ci` pair now uses the composite action instead. Count baseline: 7 jobs (confirmed at SHA `b965ddb`). No `npm ci` invocation in `test-quality.yml` ships outside the composite action.
-- [ ] **AC-4** First post-merge run populates the cache: at least one of the 7 jobs reports `Cache not found for input keys` followed by a successful Chrome download and cache save (`Cache saved with key: <runner-os>-puppeteer-<hash>`).
-- [ ] **AC-5** Second post-merge run (or a sibling job in the first run) reports `Cache restored from key: <runner-os>-puppeteer-<hash>` and completes `npm ci` significantly faster than the cold run (target: ≥ 20s saved on the install step).
-- [ ] **AC-6** The retry loop fires on a deliberately-mocked failure — locally verifiable with a shell harness that overrides `npm` to fail twice then succeed; assert exit 0 with 2 retry log lines.
-- [ ] **AC-7** All other test-quality.yml jobs (Jekyll build, content validation, security audit, etc.) still pass green on this PR.
-- [ ] **AC-8** Zero changes to `.github/workflows/healing-monitor.yml`, `.github/workflows/copilot-setup-steps.yml`, `.github/workflows/research-sweep.yml`, `.github/workflows/auto-regression.yml`, `.github/workflows/agent-eval.yml`. AC-8 boundary check: `git diff --stat .github/workflows/` shows only `test-quality.yml` modified.
-- [ ] **AC-9** `action.yml` parses as valid composite action YAML (verified by GitHub Actions during workflow run; locally verifiable via a schema linter if available).
+- [ ] **AC-1** `package.json` pins `@playwright/test` at `^1.60.0`.
+- [ ] **AC-2** `package-lock.json` is regenerated against `^1.60.0` and committed in this PR. `npm ls @playwright/test` reports `@playwright/test@1.60.0` (or the highest `1.60.x` available at install time).
+- [ ] **AC-3** `tests/playwright-agents/homepage.spec.ts:192` is migrated to `await expect(page).toMatchAriaSnapshot(...)` with the snapshot text updated to include header + footer landmarks. The other two call-sites (`navigation.spec.ts:96`, `:460`) remain element-scoped with a one-line `// element-scoped: …` comment recording the rationale.
+- [ ] **AC-4** *(amended 2026-05-17 during PLAN — see [tasks/plan.md](tasks/plan.md) §"Spec Amendment Proposal")* `.github/workflows/test-quality.yml` passes green on a single PR run. `.github/workflows/auto-regression.yml` is verified by inspection — it triggers on `issues: labeled` only (not `pull_request`) and does not install or run Playwright at runtime; it only writes test scaffolding files that depend on the lockfile-installed version exercised by `test-quality.yml`. Zero Playwright-shaped retries tolerated; one retry tolerated only if the failure stack matches the puppeteer Chrome-cache pattern from #958.
+- [ ] **AC-5** `npx playwright test` exits 0 locally with `bundle exec jekyll serve` running on `:4000` (Playwright shards 1+2+3 individually, then the full sweep).
+- [ ] **AC-6** `.github/skills/jekyll-qa/SKILL.md` line 40 updates `@playwright/test ^1.59.1` → `@playwright/test ^1.60.0`, and a one-line note is added in the same section recording that `test.abort()` is now available for the kind of "tests must not call X" guardrails we already do informally.
+- [ ] **AC-7** PR description records: (a) why two of the three ARIA call-sites stayed element-scoped, (b) closure of Dependabot PR #959 (superseded), (c) the unblock notice (#944 closed 2026-05-17).
+- [ ] **AC-8** Scope-guard boundary: `git diff --name-only main...HEAD` returns **exactly** this set — `package.json`, `package-lock.json`, `tests/playwright-agents/homepage.spec.ts`, `tests/playwright-agents/navigation.spec.ts` (if comment-only edits land), `.github/skills/jekyll-qa/SKILL.md`. Five files maximum, zero changes to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, or `.github/copilot-instructions.md`.
 
 ---
 
@@ -48,163 +56,102 @@ Both mechanisms live in a **composite action** at `.github/actions/setup-node-wi
 
 ```bash
 # Inspect baseline
-grep -nE "actions/setup-node|npm ci" .github/workflows/test-quality.yml
-grep -lE "actions/cache" .github/workflows/
+grep -n "@playwright/test" package.json
+grep -rn "toMatchAriaSnapshot" tests/playwright-agents/
+grep -n "@playwright/test ^" .github/skills/jekyll-qa/SKILL.md
 
-# After implementation
-ls .github/actions/setup-node-with-puppeteer-cache/
-grep -c "setup-node-with-puppeteer-cache" .github/workflows/test-quality.yml   # expect ≥ 5
-grep -c "setup-node@v6" .github/workflows/test-quality.yml                      # expect 0
+# Bump
+npm install --save-dev @playwright/test@^1.60.0
+npm ls @playwright/test                                          # expect 1.60.x
 
-# Local retry-loop test harness
-PATH=/tmp/mock-npm:$PATH bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh
+# Migrate snapshot (homepage only)
+$EDITOR tests/playwright-agents/homepage.spec.ts                 # line 192 → page-level
+
+# Regenerate baseline if Playwright auto-updates the inline snapshot
+npx playwright test tests/playwright-agents/homepage.spec.ts --update-snapshots
+git diff tests/playwright-agents/homepage.spec.ts                # review the snapshot drift
+
+# Local verification
+bundle exec jekyll serve --config _config.yml,_config_dev.yml &  # background
+npx playwright test                                              # full sweep
+npx playwright test tests/playwright-agents/homepage.spec.ts
+npx playwright test tests/playwright-agents/navigation.spec.ts
+
+# Skill doc edit
+$EDITOR .github/skills/jekyll-qa/SKILL.md                        # line 40 + test.abort() note
 ```
 
 ---
 
-## 5. Project Structure
+## 5. Project Structure (touched files)
 
 ```
-.github/
-  actions/                                          # NEW directory
-    setup-node-with-puppeteer-cache/
-      action.yml                                    # Composite action definition
-  workflows/
-    test-quality.yml                                # Modified: 7 jobs use the composite action
-SPEC.md, tasks/plan.md, tasks/todo.md              # Lifecycle artifacts
+package.json                                       # M — pin bump
+package-lock.json                                  # M — regenerate
+tests/playwright-agents/homepage.spec.ts           # M — line 192 → page-level snapshot + baseline drift
+tests/playwright-agents/navigation.spec.ts         # M (optional) — add per-test "element-scoped: …" rationale comments
+.github/skills/jekyll-qa/SKILL.md                  # M — line 40 version + test.abort() note
 ```
 
-Total files touched: **2 net new + 1 modified** = 3 files. Well under the 15-file scope-explosion limit; no `bulk-content` label needed.
+No new files. No deletions.
 
 ---
 
-## 6. Composite action interface
+## 6. Code Style
 
-```yaml
-# .github/actions/setup-node-with-puppeteer-cache/action.yml
-name: 'Setup Node with Puppeteer Cache'
-description: 'Sets up Node via actions/setup-node@v6, caches the puppeteer Chrome download, and runs npm ci with retry to tolerate transient CDN failures.'
-inputs:
-  node-version:
-    description: 'Node.js version (default 20)'
-    required: false
-    default: '20'
-  npm-cache:
-    description: 'setup-node cache strategy (default npm)'
-    required: false
-    default: 'npm'
-runs:
-  using: 'composite'
-  steps:
-    # 1. Standard Node setup with npm cache (unchanged behaviour)
-    - uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.npm-cache }}
-
-    # 2. Cache puppeteer's Chrome download (the actual flake fix)
-    - uses: actions/cache@v4
-      with:
-        path: ~/.cache/puppeteer
-        key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-puppeteer-
-
-    # 3. Install deps with retry on transient failure
-    - name: Install dependencies (with retry)
-      shell: bash
-      run: |
-        for attempt in 1 2 3; do
-          if npm ci; then
-            echo "npm ci succeeded on attempt $attempt"
-            exit 0
-          fi
-          if [ $attempt -lt 3 ]; then
-            echo "::warning::npm ci attempt $attempt failed; retrying in 10s..."
-            sleep 10
-          fi
-        done
-        echo "::error::npm ci failed after 3 attempts"
-        exit 1
-```
-
-Pin `actions/cache@v4` (current stable major). Pin `actions/setup-node@v6` to match the rest of the repo's pins.
+- Page-level snapshot uses the same indented-YAML block style already in the codebase (see `homepage.spec.ts:193-216` for the model). Indent with 2 spaces inside the template literal.
+- Keep `await page.waitForLoadState('networkidle')` before the snapshot — networkidle is the load gate the rest of the homepage suite uses; do not switch to `domcontentloaded` in this PR.
+- Rationale comments for the two element-scoped sites: one short line beginning `// element-scoped:` — no multi-line block comments.
 
 ---
 
-## 7. Call-site migration pattern
+## 7. Testing Strategy
 
-For each affected job in `test-quality.yml`, the replacement is mechanical:
-
-**Before:**
-
-```yaml
-- name: Setup Node.js
-  uses: actions/setup-node@v6
-  with:
-    node-version: '20'
-    cache: 'npm'
-
-- name: Install dependencies
-  run: npm ci
-```
-
-**After:**
-
-```yaml
-- name: Setup Node + cache + install deps
-  uses: ./.github/actions/setup-node-with-puppeteer-cache
-```
-
-Defaults match the prior behaviour (`node-version: '20'`, `cache: 'npm'`). No job currently uses different values — confirmed at baseline SHA.
+1. **Local first:** run the three Playwright shards individually (`npm run test:playwright:shard1|2|3`), then the full `npx playwright test` against a live `bundle exec jekyll serve`.
+2. **Snapshot drift is expected and intentional on the migrated test only.** Review the diff manually — if the snapshot picks up dynamic content (timestamps, generated IDs), narrow the snapshot or use the existing `/.+/` placeholder pattern already used at `homepage.spec.ts:194-196`.
+3. **CI confirms the bump end-to-end:** Quality Tests workflow (Playwright shards 1+2+3) **and** the Auto-Regression workflow both green on the PR. A single retry is tolerated **only** if its failure mode matches the puppeteer Chrome-cache flake (#958) — anything Playwright-shaped is a real regression.
+4. **No new tests written in this PR.** This is a dependency bump + targeted migration, not a coverage expansion. `test.abort()` adoption is documented (AC-6) but not exercised; that is follow-up work.
 
 ---
 
-## 8. Retry test harness
+## 8. Boundaries
 
-Local verification of the retry loop without round-tripping CI. Implementation lives in the same composite-action directory:
+**Always do:**
+- Close Dependabot PR #959 with a comment pointing to this PR before merge.
+- Run the local Playwright sweep against a live Jekyll server, not against a cached build, before pushing.
+- Keep the diff at ≤ 5 files. If a sixth file becomes necessary, surface the reason in the PR description and reassess the scope.
 
-```
-.github/actions/setup-node-with-puppeteer-cache/
-  action.yml
-  _retry-test.sh          # Local mock; not a CI dependency
-```
+**Ask first:**
+- Any snapshot drift in `navigation.spec.ts` (we said we wouldn't touch its snapshots; if the upgrade forces a re-baseline, stop and confirm).
+- Adding HAR tracing to any existing test (out of scope per issue body).
+- Migrating the second or third ARIA snapshot if reviewer pushback says the element-scoped rationale is unconvincing.
 
-`_retry-test.sh` script overrides `npm` via `PATH` manipulation to fail-fail-succeed, asserts the retry loop produces exit 0 with two warning log lines. This is the unit-style coverage for the retry behaviour. Cheap, reliable, doesn't require the GitHub Actions runner.
+**Never do:**
+- Bump to `1.60.x` where `x > 0` proactively — track the patch as a separate follow-up if 1.60.1 lands during this PR's lifetime.
+- Modify `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`.
+- Add the `bulk-content` or `governance-update` label (this PR is neither).
+- Use `--no-verify` or otherwise skip hooks.
+- Cherry-pick the Dependabot lockfile change without re-resolving locally — `npm install` from a clean working tree to avoid drift between lockfile and `node_modules`.
 
 ---
 
-## 9. Boundaries
+## 9. Risks & Mitigations
 
-| Always | Ask first | Never |
+| Risk | Likelihood | Mitigation |
 |---|---|---|
-| Pin every action to a specific major (`@v4`, `@v6`) | Whether to migrate `healing-monitor.yml` in the same PR (recommended: no — separate cycle) | Upgrade `pa11y`, `puppeteer`, or `@playwright/test` versions in this PR (handled separately under #947 and the lockfile work) |
-| Verify `git diff --stat .github/workflows/` shows only `test-quality.yml` after the migration | Whether to introduce a third-party retry action (`nick-fields/retry`) vs. inline shell loop (recommend inline; one fewer dep) | Change the retry count or backoff timing without ACs to back it up (3 attempts × 10s is the documented default; deviating requires updating SPEC) |
-| Run the local `_retry-test.sh` harness before pushing | Whether to gate the composite action behind a `PUPPETEER_SKIP_DOWNLOAD=1` env var | Touch `package.json`, `package-lock.json`, or any dep |
-| Confirm cache key works as expected by reading workflow run logs post-merge | — | Mask flakes for tests that aren't actually the puppeteer Chrome-download flake (retry should not paper over real test failures) |
+| Page-level snapshot includes dynamic content that drifts on every build (post timestamps, build hashes) | Medium | Use the existing `/.+/` regex placeholders; if drift persists, narrow snapshot to the regions that are stable. |
+| Migrated snapshot exposes a pre-existing a11y bug in the header/footer that wasn't visible before | Low-medium | Fix in this PR if trivial; otherwise open a separate `bug` issue and narrow the snapshot to omit the offending region, with a TODO comment referencing the new issue. |
+| Auto-regression workflow flakes on first run with new Playwright version | Low | Tolerate a single Chrome-cache retry only (per AC-4). Anything Playwright-shaped is investigated, not retried. |
+| Dependabot PR #959 auto-rebases mid-flight and creates a conflicting state | Low | Close #959 *first* as the opening move of the BUILD phase. |
 
 ---
 
-## 10. Out of Scope
+## 10. Out of Scope (deferred)
 
-- Migrating `healing-monitor.yml`, `copilot-setup-steps.yml`, or other workflows — separate cycle if and when needed.
-- Upgrading `pa11y`, `puppeteer`, `@playwright/test`, or any other dep — orthogonal concern.
-- Replacing puppeteer with Playwright's bundled browser in pa11y's chain — architectural change.
-- Setting `PUPPETEER_SKIP_DOWNLOAD=1` — pa11y needs Chrome to render pages; the dependency is real.
-- Reducing the Playwright shard count to lower flake surface — fixes symptom, not cause.
-- Adding cache for `~/.cache/ms-playwright/` (Playwright's own browser binaries) — Playwright Shard 1/2/3 use `@playwright/test` which has its own caching story; separate evaluation.
-- Modifying the retry shape (count, backoff) — change requires SPEC amendment.
-
----
-
-## 11. Definition of Done
-
-- All 9 ACs checked.
-- `_retry-test.sh` exits 0 locally before push.
-- PR description includes:
-  - Baseline job count (5) and post-migration call-site count (5)
-  - The retry-test output (mock npm fails twice, succeeds on 3rd attempt)
-  - A note that cache hit/miss behaviour will be verifiable in CI logs once merged
-  - AC-8 boundary check confirmation (`git diff --stat` output)
-- PR merged via standard flow; admin-merge acceptable per repo convention.
-- Post-merge: open a new PR (any small change) and verify the cache-hit path logs `Cache restored from key:` for puppeteer. If it doesn't, that's a regression to investigate immediately, not a problem to defer.
+- Pa11y-ci bumps (tracked in closed #944 — already shipped).
+- Lighthouse major version bump (Watch item in #902).
+- HAR tracing as a default artifact (#947 explicitly excludes).
+- `locator.drop()` adoption — no current upload-zone test in the suite.
+- Adopting `test.abort()` in actual tests — this PR documents availability only.
+- Backstop or other visual-regression tooling changes.
+- Adding a new `footer.spec.ts` — issue language implied one exists but it does not; introducing one is a separate authoring decision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@lhci/cli": "^0.15.1",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "backstopjs": "^6.3.25",
         "lighthouse": "^12.8.2",
         "pa11y-ci": "^4.1.0"
@@ -1642,13 +1642,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5581,13 +5581,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5600,9 +5600,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "backstopjs": "^6.3.25",
     "lighthouse": "^12.8.2",
     "pa11y-ci": "^4.1.0"

--- a/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/SPEC.md
+++ b/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/SPEC.md
@@ -1,0 +1,210 @@
+# SPEC — Puppeteer Chrome-Download Flake Mitigation (#958)
+
+**Status:** Draft — awaiting approval
+**Issue:** [#958](https://github.com/oviney/blog/issues/958)
+**Labels:** `agent:qa-gatekeeper`
+**Date:** 2026-05-17
+**Lifecycle phase:** DEFINE
+**Spawned from:** observed twice in one day (#944 first run, #957 first run) — Chrome 146.0.7680.153 download flakes from puppeteer's CDN providers.
+
+---
+
+## 1. Situation
+
+`actions/setup-node@v6` is already configured with `cache: 'npm'` in `.github/workflows/test-quality.yml`, so npm packages themselves are cached. **The flake is in puppeteer's post-install script** (`node install.mjs`, run during `npm ci`), which downloads Chrome from a separate CDN into `~/.cache/puppeteer/`. That directory is **not** covered by setup-node's npm cache.
+
+Observed flake stack: `Error: ERROR: Failed to set up chrome v146.0.7680.153! ... All providers failed for chrome 146.0.7680.153: DefaultProvider: ENOENT: no such file or directory ...puppeteer/chrome/146.0.7680.153-chrome-linux64.zip`.
+
+`test-quality.yml` defines 7 jobs that pair `setup-node@v6` + `npm ci`: `quality-checks`, `security`, `playwright-partial`, `playwright-shard1`, `playwright-shard2`, `playwright-shard3`, `quality-report`. Each is an independent flake surface. We've taken ~10 minutes of human time today (2 reruns × 5 min) plus a noticeable interruption to two PR merges (#955 indirectly, #957 directly).
+
+---
+
+## 2. Objective
+
+Eliminate the puppeteer Chrome-download flake from `.github/workflows/test-quality.yml` by:
+
+1. **Caching `~/.cache/puppeteer/`** keyed on `package-lock.json` so warm runs skip the Chrome download entirely.
+2. **Retrying `npm ci` up to 3 times with 10s backoff** so cold-cache runs (lockfile change, cache eviction) tolerate transient CDN failures.
+
+Both mechanisms live in a **composite action** at `.github/actions/setup-node-with-puppeteer-cache/` so the 7 jobs share a single source of truth. Other workflows (`healing-monitor.yml`, `copilot-setup-steps.yml`) are **out of scope** — migrate later if the pattern proves out.
+
+---
+
+## 3. Acceptance Criteria
+
+- [ ] **AC-1** New composite action at `.github/actions/setup-node-with-puppeteer-cache/action.yml` exists with documented inputs (`node-version` default `'20'`, plus optionally `npm-cache` default `'npm'`).
+- [ ] **AC-2** The composite action's steps are: (a) `actions/setup-node@v6` with `cache: '${{ inputs.npm-cache }}'`, (b) `actions/cache@vN` for `~/.cache/puppeteer/` keyed on `${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}` with a restore-key fallback to `${{ runner.os }}-puppeteer-`, (c) `npm ci` wrapped in a 3-attempt retry shell loop with 10s backoff between attempts.
+- [ ] **AC-3** Every job in `.github/workflows/test-quality.yml` that currently uses the `setup-node@v6` + `npm ci` pair now uses the composite action instead. Count baseline: 7 jobs (confirmed at SHA `b965ddb`). No `npm ci` invocation in `test-quality.yml` ships outside the composite action.
+- [ ] **AC-4** First post-merge run populates the cache: at least one of the 7 jobs reports `Cache not found for input keys` followed by a successful Chrome download and cache save (`Cache saved with key: <runner-os>-puppeteer-<hash>`).
+- [ ] **AC-5** Second post-merge run (or a sibling job in the first run) reports `Cache restored from key: <runner-os>-puppeteer-<hash>` and completes `npm ci` significantly faster than the cold run (target: ≥ 20s saved on the install step).
+- [ ] **AC-6** The retry loop fires on a deliberately-mocked failure — locally verifiable with a shell harness that overrides `npm` to fail twice then succeed; assert exit 0 with 2 retry log lines.
+- [ ] **AC-7** All other test-quality.yml jobs (Jekyll build, content validation, security audit, etc.) still pass green on this PR.
+- [ ] **AC-8** Zero changes to `.github/workflows/healing-monitor.yml`, `.github/workflows/copilot-setup-steps.yml`, `.github/workflows/research-sweep.yml`, `.github/workflows/auto-regression.yml`, `.github/workflows/agent-eval.yml`. AC-8 boundary check: `git diff --stat .github/workflows/` shows only `test-quality.yml` modified.
+- [ ] **AC-9** `action.yml` parses as valid composite action YAML (verified by GitHub Actions during workflow run; locally verifiable via a schema linter if available).
+
+---
+
+## 4. Commands
+
+```bash
+# Inspect baseline
+grep -nE "actions/setup-node|npm ci" .github/workflows/test-quality.yml
+grep -lE "actions/cache" .github/workflows/
+
+# After implementation
+ls .github/actions/setup-node-with-puppeteer-cache/
+grep -c "setup-node-with-puppeteer-cache" .github/workflows/test-quality.yml   # expect ≥ 5
+grep -c "setup-node@v6" .github/workflows/test-quality.yml                      # expect 0
+
+# Local retry-loop test harness
+PATH=/tmp/mock-npm:$PATH bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh
+```
+
+---
+
+## 5. Project Structure
+
+```
+.github/
+  actions/                                          # NEW directory
+    setup-node-with-puppeteer-cache/
+      action.yml                                    # Composite action definition
+  workflows/
+    test-quality.yml                                # Modified: 7 jobs use the composite action
+SPEC.md, tasks/plan.md, tasks/todo.md              # Lifecycle artifacts
+```
+
+Total files touched: **2 net new + 1 modified** = 3 files. Well under the 15-file scope-explosion limit; no `bulk-content` label needed.
+
+---
+
+## 6. Composite action interface
+
+```yaml
+# .github/actions/setup-node-with-puppeteer-cache/action.yml
+name: 'Setup Node with Puppeteer Cache'
+description: 'Sets up Node via actions/setup-node@v6, caches the puppeteer Chrome download, and runs npm ci with retry to tolerate transient CDN failures.'
+inputs:
+  node-version:
+    description: 'Node.js version (default 20)'
+    required: false
+    default: '20'
+  npm-cache:
+    description: 'setup-node cache strategy (default npm)'
+    required: false
+    default: 'npm'
+runs:
+  using: 'composite'
+  steps:
+    # 1. Standard Node setup with npm cache (unchanged behaviour)
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.npm-cache }}
+
+    # 2. Cache puppeteer's Chrome download (the actual flake fix)
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/puppeteer
+        key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-puppeteer-
+
+    # 3. Install deps with retry on transient failure
+    - name: Install dependencies (with retry)
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if npm ci; then
+            echo "npm ci succeeded on attempt $attempt"
+            exit 0
+          fi
+          if [ $attempt -lt 3 ]; then
+            echo "::warning::npm ci attempt $attempt failed; retrying in 10s..."
+            sleep 10
+          fi
+        done
+        echo "::error::npm ci failed after 3 attempts"
+        exit 1
+```
+
+Pin `actions/cache@v4` (current stable major). Pin `actions/setup-node@v6` to match the rest of the repo's pins.
+
+---
+
+## 7. Call-site migration pattern
+
+For each affected job in `test-quality.yml`, the replacement is mechanical:
+
+**Before:**
+
+```yaml
+- name: Setup Node.js
+  uses: actions/setup-node@v6
+  with:
+    node-version: '20'
+    cache: 'npm'
+
+- name: Install dependencies
+  run: npm ci
+```
+
+**After:**
+
+```yaml
+- name: Setup Node + cache + install deps
+  uses: ./.github/actions/setup-node-with-puppeteer-cache
+```
+
+Defaults match the prior behaviour (`node-version: '20'`, `cache: 'npm'`). No job currently uses different values — confirmed at baseline SHA.
+
+---
+
+## 8. Retry test harness
+
+Local verification of the retry loop without round-tripping CI. Implementation lives in the same composite-action directory:
+
+```
+.github/actions/setup-node-with-puppeteer-cache/
+  action.yml
+  _retry-test.sh          # Local mock; not a CI dependency
+```
+
+`_retry-test.sh` script overrides `npm` via `PATH` manipulation to fail-fail-succeed, asserts the retry loop produces exit 0 with two warning log lines. This is the unit-style coverage for the retry behaviour. Cheap, reliable, doesn't require the GitHub Actions runner.
+
+---
+
+## 9. Boundaries
+
+| Always | Ask first | Never |
+|---|---|---|
+| Pin every action to a specific major (`@v4`, `@v6`) | Whether to migrate `healing-monitor.yml` in the same PR (recommended: no — separate cycle) | Upgrade `pa11y`, `puppeteer`, or `@playwright/test` versions in this PR (handled separately under #947 and the lockfile work) |
+| Verify `git diff --stat .github/workflows/` shows only `test-quality.yml` after the migration | Whether to introduce a third-party retry action (`nick-fields/retry`) vs. inline shell loop (recommend inline; one fewer dep) | Change the retry count or backoff timing without ACs to back it up (3 attempts × 10s is the documented default; deviating requires updating SPEC) |
+| Run the local `_retry-test.sh` harness before pushing | Whether to gate the composite action behind a `PUPPETEER_SKIP_DOWNLOAD=1` env var | Touch `package.json`, `package-lock.json`, or any dep |
+| Confirm cache key works as expected by reading workflow run logs post-merge | — | Mask flakes for tests that aren't actually the puppeteer Chrome-download flake (retry should not paper over real test failures) |
+
+---
+
+## 10. Out of Scope
+
+- Migrating `healing-monitor.yml`, `copilot-setup-steps.yml`, or other workflows — separate cycle if and when needed.
+- Upgrading `pa11y`, `puppeteer`, `@playwright/test`, or any other dep — orthogonal concern.
+- Replacing puppeteer with Playwright's bundled browser in pa11y's chain — architectural change.
+- Setting `PUPPETEER_SKIP_DOWNLOAD=1` — pa11y needs Chrome to render pages; the dependency is real.
+- Reducing the Playwright shard count to lower flake surface — fixes symptom, not cause.
+- Adding cache for `~/.cache/ms-playwright/` (Playwright's own browser binaries) — Playwright Shard 1/2/3 use `@playwright/test` which has its own caching story; separate evaluation.
+- Modifying the retry shape (count, backoff) — change requires SPEC amendment.
+
+---
+
+## 11. Definition of Done
+
+- All 9 ACs checked.
+- `_retry-test.sh` exits 0 locally before push.
+- PR description includes:
+  - Baseline job count (5) and post-migration call-site count (5)
+  - The retry-test output (mock npm fails twice, succeeds on 3rd attempt)
+  - A note that cache hit/miss behaviour will be verifiable in CI logs once merged
+  - AC-8 boundary check confirmation (`git diff --stat` output)
+- PR merged via standard flow; admin-merge acceptable per repo convention.
+- Post-merge: open a new PR (any small change) and verify the cache-hit path logs `Cache restored from key:` for puppeteer. If it doesn't, that's a regression to investigate immediately, not a problem to defer.

--- a/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/plan.md
+++ b/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/plan.md
@@ -1,0 +1,289 @@
+# Plan — Puppeteer Chrome-Download Flake Mitigation (#958)
+
+**Spec:** [SPEC.md](../SPEC.md)
+**Issue:** [#958](https://github.com/oviney/blog/issues/958)
+**Date:** 2026-05-17
+**Lifecycle phase:** PLAN
+**Plan SHA:** `b965ddb`
+
+**Anchors confirmed at this SHA:**
+
+- **Affected workflow:** `.github/workflows/test-quality.yml` only (`grep -l setup-node .github/workflows/*.yml` confirms 4 other workflows also use it, but they're explicit Out-of-Scope per SPEC §10)
+- **7 affected jobs** in `test-quality.yml`, each with a `setup-node@v6` + `npm ci` pair to migrate:
+  - `quality-checks` — setup-node line 124, npm ci line 130
+  - `security` — setup-node line 188, npm ci line 194
+  - `playwright-partial` — setup-node line 220, npm ci line 226
+  - `playwright-shard1` — setup-node line 312, npm ci line 318
+  - `playwright-shard2` — setup-node line 377, npm ci line 383
+  - `playwright-shard3` — setup-node line 442, npm ci line 448
+  - `quality-report` — setup-node line 506, npm ci line 512
+- **No `.github/actions/` directory exists yet** — this PR creates it
+- **No existing `actions/cache` usage anywhere** in workflows — confirmed at SHA `b965ddb`
+
+---
+
+## Context
+
+3 files net: 2 new (`action.yml`, `_retry-test.sh`) + 1 modified (`test-quality.yml`). Well under the 15-file scope-explosion limit; no `bulk-content` label needed on this PR.
+
+The migration is mechanical: every call-site is the same `setup-node@v6` (with `node-version: '20'` and `cache: 'npm'`) immediately followed by `npm ci`. The composite action's defaults match those values exactly, so each migration is a pure 8-line → 2-line substitution.
+
+The retry-loop unit test (`_retry-test.sh`) is the load-bearing local verification. Cache hit/miss behavior is only observable in CI logs post-merge, so the local gate before push is: composite action exists, all 7 call-sites migrated, YAML parses, retry harness passes.
+
+---
+
+## Dependency graph
+
+```
+T1 (composite action: action.yml + _retry-test.sh)
+  │
+  ├──► T2 (RED retry test: mock npm that fails 3x → harness exits 1)
+  │       │
+  │       ▼
+  │     (proves the harness can detect failure modes)
+  │
+  ▼
+T3 (RED→GREEN retry test: mock npm fails 2x, succeeds 3rd → harness exits 0)
+  │
+  ▼
+T4 (migrate 7 call-sites in test-quality.yml)
+  │
+  ▼
+T5 (local verification: YAML parses, no other workflows touched, retry harness still green)
+  │
+  ▼
+CHECKPOINT-A — local gate (composite action works, all 7 sites migrated, AC-8 boundary clean)
+  │
+  ▼
+T6 (/review pass via code-reviewer agent)
+  │
+  ▼
+T7 (apply any /review revisions; commit)
+  │
+  ▼
+T8 (push branch + open PR with retry-test output, baseline counts, AC-8 confirmation)
+  │
+  ▼
+T9 (CI passes — note that THIS PR runs against the OLD workflow + a NEW workflow; the renamed steps may invalidate cached results; tolerate one rerun if Chrome flake hits during transition)
+  │
+  ▼
+T10 (admin-merge after CI green)
+  │
+  ▼
+T11 (post-merge: open a tiny follow-up PR to verify `Cache restored from key:` logs appear for puppeteer — confirms AC-5 in real CI)
+```
+
+T1–T3 deliver the composite action with local proof of the retry behavior. T4 activates it. T5 is the local gate. T6 closes the lifecycle's review-phase gap. T11 is the **AC-5 verification** that can only happen post-merge.
+
+---
+
+## Phase 1 — Composite action
+
+### T1 — Write `action.yml` + `_retry-test.sh` scaffolds
+
+**ACs satisfied:** AC-1 (interface), AC-2 (steps shape — verified by inspection), AC-9 (YAML well-formed)
+**Touches:** `.github/actions/setup-node-with-puppeteer-cache/action.yml` (new), `.github/actions/setup-node-with-puppeteer-cache/_retry-test.sh` (new)
+
+**Steps:**
+
+1. `mkdir -p .github/actions/setup-node-with-puppeteer-cache`
+2. Write `action.yml` per SPEC §6 verbatim — pinned `actions/setup-node@v6`, `actions/cache@v4`, inline shell retry loop with `for attempt in 1 2 3` + 10s `sleep` between attempts, `::warning::` / `::error::` log syntax.
+3. Write `_retry-test.sh` as the local harness. It must:
+   - Create a temp dir, write a fake `npm` script that reads a counter file, fails N times, then succeeds
+   - Extract the retry-loop shell code from `action.yml` (or duplicate it in the harness — see T2/T3 decision below)
+   - Assert exit codes and log-line counts for the two scenarios in T2 and T3
+4. Decision: **duplicate the retry-loop code** in `_retry-test.sh` rather than extract from YAML. Reason: parsing the inline shell script out of YAML is fragile; duplication keeps the harness honest about what it's testing. The two copies must stay in sync — `_retry-test.sh` header carries a comment naming `action.yml` as the source of truth and instructing future editors to update both.
+
+**Verify (mechanical):** `python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup-node-with-puppeteer-cache/action.yml'))"` exits 0; `bash -n .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh` exits 0.
+
+---
+
+### T2 — RED retry test (mock npm fails 3 times)
+
+**ACs satisfied:** AC-6 (partial — proves the harness can detect failure)
+**Touches:** none beyond T1
+
+**Steps:**
+
+1. Run `bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh fail-fail-fail`
+2. Expect: exit code **1**, stdout contains 3 attempt-failure log lines, ends with `npm ci failed after 3 attempts`
+3. **This is the RED proof** — the retry loop genuinely surfaces failures rather than swallowing them.
+
+**Verify:** assert exit 1, count log lines, no false positives.
+
+---
+
+### T3 — GREEN retry test (mock npm fails twice, succeeds on 3rd)
+
+**ACs satisfied:** AC-6 (full)
+**Touches:** none beyond T1
+
+**Steps:**
+
+1. Run `bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh fail-fail-succeed`
+2. Expect: exit code **0**, stdout contains 2 retry-warning lines, ends with `npm ci succeeded on attempt 3`
+
+**Verify:** assert exit 0, 2 retry-warning lines, no `::error::` lines.
+
+---
+
+## Phase 2 — Migrate call-sites
+
+### T4 — Replace 7 `setup-node + npm ci` pairs in `test-quality.yml`
+
+**ACs satisfied:** AC-3 (full)
+**Touches:** `.github/workflows/test-quality.yml`
+
+**Migration pattern (per SPEC §7) — every call-site:**
+
+Before:
+```yaml
+- name: Setup Node.js
+  uses: actions/setup-node@v6
+  with:
+    node-version: '20'
+    cache: 'npm'
+
+- name: Install dependencies
+  run: npm ci
+```
+
+After:
+```yaml
+- name: Setup Node + cache + install deps
+  uses: ./.github/actions/setup-node-with-puppeteer-cache
+```
+
+Apply to all 7 jobs listed in "Anchors confirmed" above. The substitution is pure — no input overrides needed because every call-site uses the default values (`node-version: '20'`, `cache: 'npm'`).
+
+**Verify (per-job, after each substitution):**
+- The job's step list is shorter by 6 lines (2 steps × 4 / 3 lines minus the new 2-line step)
+- The job's YAML still parses
+
+**Verify (after all 7 are done):**
+- `grep -c "setup-node@v6" .github/workflows/test-quality.yml` → **0**
+- `grep -c "uses: ./.github/actions/setup-node-with-puppeteer-cache" .github/workflows/test-quality.yml` → **7**
+- `grep -c "^      - name: Install dependencies$" .github/workflows/test-quality.yml` → drops from 7 to 0
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-quality.yml'))"` exits 0
+
+---
+
+## Phase 3 — Local verification
+
+### T5 — AC-8 boundary check + re-run retry harness
+
+**ACs satisfied:** AC-8 (boundary), AC-6 (re-confirm post-migration)
+**Touches:** none (read-only verification)
+
+**Steps:**
+
+1. `git diff --stat .github/workflows/` — expect ONLY `.github/workflows/test-quality.yml` modified.
+2. `git diff --stat .github/actions/` — expect TWO new files under `.github/actions/setup-node-with-puppeteer-cache/`.
+3. `git diff --stat` (whole repo) — expect 3 files total (2 new + 1 modified). No `_posts/`, `_layouts/`, `_sass/`, `package.json`, `package-lock.json`, etc.
+4. Re-run `_retry-test.sh` in both modes (`fail-fail-fail`, `fail-fail-succeed`). Both still pass.
+
+---
+
+### CHECKPOINT-A — Local gate before /review
+
+**Gate criteria (all must be true before T6):**
+
+- [ ] T1 deliverables exist; YAML and bash both parse cleanly
+- [ ] T2 RED test produces exit 1 with 3 failure log lines
+- [ ] T3 GREEN test produces exit 0 with 2 retry-warning lines + success line
+- [ ] T4 substitutions complete (grep counts match: 0 `setup-node@v6`, 7 composite-action references)
+- [ ] T5 AC-8 boundary check clean (exactly 3 files modified)
+- [ ] `git status --short` shows only the 3 expected files
+
+---
+
+## Phase 4 — REVIEW pass
+
+### T6 — `/review` via code-reviewer agent
+
+**ACs satisfied:** lifecycle requirement, not a specific spec AC
+**Touches:** none (read-only review)
+
+**Brief the reviewer on:**
+- The composite action's interface and step ordering (cache step **before** npm ci to populate the cache directory before puppeteer reads it)
+- `actions/cache@v4` key strategy — `${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}` with restore-key fallback
+- The retry loop's exit handling — does the wrapper genuinely fail-fast when npm ci returns non-zero, vs. silently retrying forever?
+- AC-3 substitution fidelity — 7 jobs migrated, defaults preserved
+- Whether `_retry-test.sh` is a real test or a placeholder
+
+**Expected findings shape:** Major (cache-key correctness, step ordering, retry-exit-handling), Minor (action.yml descriptive prose, _retry-test.sh hygiene), Nit (commit-message hygiene).
+
+### T7 — Apply revisions; commit any post-review changes
+
+**ACs satisfied:** finishes any open AC items raised by /review
+**Touches:** depends on review findings
+
+---
+
+## Phase 5 — Ship
+
+### T8 — Push branch + open PR
+
+**ACs satisfied:** DoD bullet 4 (PR description includes test output, counts, AC-8 confirmation)
+**Touches:** git remote.
+
+**Commit structure on branch `chore/958-puppeteer-cache-and-retry`:**
+- **Commit A** (T1): `chore(ci): add setup-node-with-puppeteer-cache composite action (#958)` — action.yml + _retry-test.sh; no callers yet (no behaviour change to any workflow).
+- **Commit B** (T4): `chore(ci): migrate 7 test-quality.yml jobs to use puppeteer-cache composite action (#958)` — pure substitution; closes #958.
+- **Commit C** (T7, if any): `chore(ci): apply /review revisions (#958)` — only if revisions were applied.
+
+PR body includes:
+- The 7 affected jobs listed by name
+- Verbatim output of both `_retry-test.sh` runs (3-fail and 2-fail-succeed)
+- `git diff --stat` output showing the AC-8 boundary
+- Note that AC-4 / AC-5 (cache miss + cache hit) verification happens post-merge in CI logs
+
+**Labels:** no `agent:*` label (the PR touches `.github/actions/` and `.github/workflows/` — both are QA scope under `agent:qa-gatekeeper`'s `FORBIDDEN_PATTERN` of `^_sass/|^_layouts/|^_posts/|^_config\.yml$`, so `agent:qa-gatekeeper` is **valid** and should be applied). No `governance-update` (workflows aren't in `.github/skills/` or `.github/instructions/`).
+
+### T9 — CI passes
+
+**Note:** This PR's CI run will execute the **new** composite action against itself (the workflow file changes apply to this PR's own run). Two outcomes possible:
+
+- **Best case:** cache is empty on first run → puppeteer downloads → cache populates → next run uses it. Single CI cycle.
+- **Same-flake case:** Chrome 146 download flake hits the cold-cache install. Retry loop's job is to absorb it. If the retry loop fails (e.g., 3 attempts × 10s isn't enough for a wide CDN outage), one rerun should fix it just like #957's first run.
+
+Tolerate one rerun if the Chrome flake hits during this transition PR; the cache will be primed for subsequent runs.
+
+### T10 — Admin-merge after green
+
+**ACs satisfied:** AC-3 (final, in `main`)
+**Touches:** git remote (merge).
+
+`gh pr merge <N> --admin --squash --delete-branch` once CI green. Sync local `main`. Verify the composite action file and migrated workflow both made it.
+
+---
+
+### T11 — Post-merge AC-5 verification
+
+**ACs satisfied:** AC-5 (cache hit observed in real CI)
+**Touches:** open a tiny follow-up PR (e.g., a docs typo fix or whitespace edit) to trigger a fresh CI run.
+
+**Steps:**
+
+1. Open a trivial PR (any small change) on `main` after #958 merges.
+2. Inspect the CI logs for one of the 7 affected jobs.
+3. Look for `Cache restored from key: <runner-os>-puppeteer-<hash>` near the start of the install step.
+4. If found: AC-5 satisfied, close the trivial PR with a comment linking to the cache-hit log.
+5. If not found: investigate immediately — cache misses on a known key indicate a key-mismatch bug.
+
+**Justification for the trivial PR:** AC-5 can only be observed in real CI, not local. Without the post-merge check, AC-5 remains unverified. A small follow-up PR is the cheapest way to observe cache-hit behavior without waiting for an unrelated future change.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| `actions/cache@v4` is not available or API changed | Pin to `@v4` (current stable major); if unavailable, fall back to `@v3` with a comment. Confirm at runtime via CI logs. |
+| Cache key collision between Node versions or OS variants | Key includes `${{ runner.os }}-puppeteer-…`; restore-keys fallback to OS-prefix. Different Node versions on the same OS share the puppeteer dir, which is correct (Chrome binary is OS+arch-dependent, not Node-dependent). |
+| Retry loop swallows a genuine, non-transient failure | Loop preserves npm ci's exit code on the third attempt; `::error::` log line on terminal failure makes it visible in the workflow run summary. Reviewer should confirm. |
+| Composite action's relative-path reference (`./.github/actions/...`) doesn't resolve when called from a workflow | This is the standard GitHub Actions convention for in-repo composite actions; works as long as `actions/checkout@v6` runs before the composite-action call (verified in all 7 affected jobs at baseline). |
+| First post-merge run still hits the Chrome flake before cache populates | Acceptable — the retry loop absorbs it; if even the retry exhausts, one manual rerun (same pattern we paid twice today). Once cache is primed, subsequent runs skip the download. |
+| One of the 7 jobs has a subtly different setup-node configuration that the composite action's defaults don't match | Verified at baseline: all 7 use `node-version: '20'` + `cache: 'npm'` verbatim. T4's grep checks would flag any drift mid-migration. |
+| The reviewer raises a "use third-party retry action" objection | Documented in SPEC §9 boundaries (chose inline shell loop for fewer deps). Reviewer is free to disagree; absent strong evidence, defer to the SPEC's decision. |
+| AC-5 verification PR (T11) doesn't trigger the right jobs (e.g., change-based test selection skips them) | If `select-tests` skips the affected jobs, manually `gh workflow run test-quality.yml` against the branch to force a full run. Documented as a fallback in T11. |

--- a/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/todo.md
+++ b/tasks/archive/2026-05-17-puppeteer-chrome-cache-958/todo.md
@@ -1,0 +1,46 @@
+# TODO — Puppeteer Chrome-Download Flake Mitigation (#958)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Plan SHA:** `b965ddb` · 3 files (2 new + 1 modified) · 7 jobs to migrate
+
+---
+
+## Phase 1 — Composite action
+- [x] **T1** Created `.github/actions/setup-node-with-puppeteer-cache/action.yml` + `_retry-test.sh`. YAML parses; bash syntax-checks clean.
+- [x] **T2** RED retry test passed: `_retry-test.sh fail-fail-fail` → exit 1, 2 `::warning::` + 1 `::error::` lines.
+- [x] **T3** GREEN retry test passed: `_retry-test.sh fail-fail-succeed` → exit 0, 2 `::warning::` + success-on-attempt-3 line.
+
+## Phase 2 — Migrate call-sites
+- [x] **T4** Replaced 7 call-sites in `test-quality.yml`. Grep counts verified (0 `setup-node@v6`, 7 composite-action references). YAML still parses.
+
+## Phase 3 — Local verification
+- [x] **T5** AC-8 boundary clean (3 files total: 2 new under `.github/actions/`, 1 modified workflow). Retry harness re-runs green post-migration.
+
+## CHECKPOINT-A — Local gate before /review
+- [x] All T1–T5 ACs satisfied. Commits A (`5924993`) + B (`901c95b`) on branch.
+
+## Phase 4 — /review pass
+- [x] **T6** Code-reviewer agent verdict: **Approve**, no blockers. 2 Majors + 2 minor revisions identified.
+- [x] **T7** Applied all 4 revisions in Commit C (`5c72a7a`): M2 cache-key salts on Node version; M1 tightened sync-comment in both files (retry SHAPE not byte-identical); m1 set-uo-pipefail rationale comment; n1 RETRY-TEST PASS/FAIL banner prefix. Harness still green post-revision.
+
+## Phase 5 — Ship
+- [ ] **T8** Push branch; `gh pr create` with retry-test outputs + 7-job list + AC-8 diff stat; label `agent:qa-gatekeeper`.
+- [ ] **T9** CI passes — tolerate one Chrome-flake rerun during transition (cache priming on first run).
+- [ ] **T10** `gh pr merge --admin --squash --delete-branch` once green; sync local main.
+
+## Phase 6 — Post-merge verification
+- [ ] **T11** Open a trivial follow-up PR (any small change) to trigger fresh CI; inspect logs for `Cache restored from key:` on at least one of the 7 affected jobs (AC-5 verification — only observable in real CI)
+
+---
+
+## Acceptance criteria checklist (mirrors SPEC §3)
+
+- [ ] **AC-1** Composite action exists with documented `node-version` (default `'20'`) and `npm-cache` (default `'npm'`) inputs
+- [ ] **AC-2** Steps order: setup-node, cache puppeteer dir, retry-wrapped npm ci
+- [ ] **AC-3** 7 jobs in `test-quality.yml` use composite action; no `setup-node@v6 + npm ci` pair remains outside it
+- [ ] **AC-4** First post-merge run logs cache miss + cache save (verified via CI logs at T11)
+- [ ] **AC-5** Subsequent run logs cache restored from key, ≥ 20s install-step time savings vs cold (T11)
+- [ ] **AC-6** `_retry-test.sh` passes both RED (3-fail) and GREEN (2-fail-succeed) cases
+- [ ] **AC-7** All 11 other test-quality.yml jobs continue passing
+- [ ] **AC-8** `git diff --stat .github/workflows/` shows only `test-quality.yml` modified
+- [ ] **AC-9** `action.yml` parses as valid composite-action YAML

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,186 +1,209 @@
-# Plan — Puppeteer Chrome-Download Flake Mitigation (#958)
+# Plan — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
 
-**Spec:** [SPEC.md](../SPEC.md)
-**Issue:** [#958](https://github.com/oviney/blog/issues/958)
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#947](https://github.com/oviney/blog/issues/947)
 **Date:** 2026-05-17
 **Lifecycle phase:** PLAN
-**Plan SHA:** `b965ddb`
+**Plan SHA:** `6480f00`
 
-**Anchors confirmed at this SHA:**
+---
 
-- **Affected workflow:** `.github/workflows/test-quality.yml` only (`grep -l setup-node .github/workflows/*.yml` confirms 4 other workflows also use it, but they're explicit Out-of-Scope per SPEC §10)
-- **7 affected jobs** in `test-quality.yml`, each with a `setup-node@v6` + `npm ci` pair to migrate:
-  - `quality-checks` — setup-node line 124, npm ci line 130
-  - `security` — setup-node line 188, npm ci line 194
-  - `playwright-partial` — setup-node line 220, npm ci line 226
-  - `playwright-shard1` — setup-node line 312, npm ci line 318
-  - `playwright-shard2` — setup-node line 377, npm ci line 383
-  - `playwright-shard3` — setup-node line 442, npm ci line 448
-  - `quality-report` — setup-node line 506, npm ci line 512
-- **No `.github/actions/` directory exists yet** — this PR creates it
-- **No existing `actions/cache` usage anywhere** in workflows — confirmed at SHA `b965ddb`
+## Anchors confirmed at this SHA
+
+- **Current pin:** `package.json` line referencing `"@playwright/test": "^1.59.1"` (devDependencies section).
+- **ARIA-snapshot call-sites:** exactly 3, audited via `grep -rn "toMatchAriaSnapshot" tests/`.
+  - `tests/playwright-agents/homepage.spec.ts:192` — `page.locator('main').first()` → **migrate to page-level** (per SPEC §1 table).
+  - `tests/playwright-agents/navigation.spec.ts:96` — `page.locator('main article').first()` → **keep element-scoped**, add rationale comment.
+  - `tests/playwright-agents/navigation.spec.ts:460` — `page.locator('#site-navigation')` → **keep element-scoped**, add rationale comment.
+- **Skill doc edit point:** `.github/skills/jekyll-qa/SKILL.md:40` reads `` - `@playwright/test ^1.59.1` ``. Surrounding lines 41-43 list `pa11y-ci`, `lighthouse`, `lodash override` — the `test.abort()` note belongs after line 40 as a sub-bullet.
+- **Open Dependabot PR #959** mutates exactly `package.json` (+1/-1) and `package-lock.json` (+12/-12). CI is **green** on its current head. We will close it as part of T8 once our PR opens — not earlier (per SPEC §10 "ask first / never do" — closing late avoids a window with no PR open for the bump).
+- **No `tests/playwright-agents/footer.spec.ts` exists** — `ls tests/playwright-agents/*footer*` returns nothing. SPEC §1 already records this. No new file is added by this PR.
+- **`.github/workflows/auto-regression.yml`** triggers on `issues: labeled` (line 3-5) and does **not** run `npm ci` or `npx playwright test` (only `git add tests/playwright-agents/regression/` at line 147). See **Spec Amendment Proposal** below.
+
+---
+
+## Spec Amendment Proposal — AC-4 (raise before BUILD)
+
+**SPEC §3 AC-4 currently reads:** *"`.github/workflows/test-quality.yml` AND `.github/workflows/auto-regression.yml` pass green on a single PR run."*
+
+**Problem:** `auto-regression.yml` triggers exclusively on `issues: labeled` events (specifically when `production` or `bug` is applied to an issue already carrying the other label). It does not run on `pull_request` or `push` — it physically cannot fire on this PR. It also does not install or invoke Playwright; it only generates new test scaffolding files and commits them. The Playwright minor bump has **zero runtime impact** on this workflow.
+
+**Proposed amendment to AC-4:** *"`.github/workflows/test-quality.yml` passes green on a single PR run. `auto-regression.yml` is verified by inspection (it does not install or run Playwright at runtime; it only writes test files that depend on the lockfile-installed version, which is exercised by test-quality.yml shards). No retry tolerated for Playwright-shaped failures; one retry tolerated for the puppeteer Chrome-cache flake pattern from #958."*
+
+**Decision needed before BUILD:** confirm this amendment, or specify an alternate verification path (e.g., labeling a sentinel issue post-merge to fire the workflow once). My recommendation: accept the amendment — adding `workflow_dispatch` to `auto-regression.yml` would be scope creep, and labeling a sentinel issue produces a real PR that we'd then have to clean up.
 
 ---
 
 ## Context
 
-3 files net: 2 new (`action.yml`, `_retry-test.sh`) + 1 modified (`test-quality.yml`). Well under the 15-file scope-explosion limit; no `bulk-content` label needed on this PR.
+5 files net at most (per SPEC AC-8): `package.json`, `package-lock.json`, `tests/playwright-agents/homepage.spec.ts`, `tests/playwright-agents/navigation.spec.ts`, `.github/skills/jekyll-qa/SKILL.md`. Well under the 15-file scope-explosion limit; **no `bulk-content` label needed**.
 
-The migration is mechanical: every call-site is the same `setup-node@v6` (with `node-version: '20'` and `cache: 'npm'`) immediately followed by `npm ci`. The composite action's defaults match those values exactly, so each migration is a pure 8-line → 2-line substitution.
+The risk profile is dominated by **snapshot drift on the migrated test**. Element-scoped `main` snapshot today is 22 lines; page-level will include `banner`, `navigation`, and `contentinfo` landmarks above and below the existing `main` block. The exact text is something Playwright generates via `--update-snapshots` and we review. The plan accommodates a non-trivial diff in `homepage.spec.ts:192` — that's the expected outcome, not a regression.
 
-The retry-loop unit test (`_retry-test.sh`) is the load-bearing local verification. Cache hit/miss behavior is only observable in CI logs post-merge, so the local gate before push is: composite action exists, all 7 call-sites migrated, YAML parses, retry harness passes.
+There is no separate baseline file to manage; ARIA snapshots are **inline template literals** in the spec file. `--update-snapshots` rewrites the literal in place. Git diff carries the entire change.
+
+The migration is one-directional (page-level is strictly more inclusive than element-scoped); if the new snapshot is unstable we narrow it back rather than reverting the API form.
 
 ---
 
 ## Dependency graph
 
 ```
-T1 (composite action: action.yml + _retry-test.sh)
+T1 (bump @playwright/test ^1.60.0 in package.json + regenerate package-lock.json)
   │
-  ├──► T2 (RED retry test: mock npm that fails 3x → harness exits 1)
+  ├──► T2 (homepage.spec.ts:192 → page-level snapshot, regenerate baseline, review diff)
   │       │
   │       ▼
-  │     (proves the harness can detect failure modes)
+  │     (proves the new API works against a live Jekyll server)
   │
   ▼
-T3 (RED→GREEN retry test: mock npm fails 2x, succeeds 3rd → harness exits 0)
+T3 (navigation.spec.ts:96 + :460 → add `// element-scoped: …` rationale comments)
   │
   ▼
-T4 (migrate 7 call-sites in test-quality.yml)
+T4 (.github/skills/jekyll-qa/SKILL.md line 40 → ^1.60.0 + test.abort() note)
   │
   ▼
-T5 (local verification: YAML parses, no other workflows touched, retry harness still green)
+T5 (local full sweep: npx playwright test against bundle exec jekyll serve; AC-8 boundary check)
   │
   ▼
-CHECKPOINT-A — local gate (composite action works, all 7 sites migrated, AC-8 boundary clean)
+CHECKPOINT-A — local gate (all 5 files modified within scope, full Playwright suite green locally)
   │
   ▼
-T6 (/review pass via code-reviewer agent)
+T6 (/review via code-reviewer agent — focus on snapshot diff legibility, AC-3 rationale soundness)
   │
   ▼
-T7 (apply any /review revisions; commit)
+T7 (apply review revisions; commit)
   │
   ▼
-T8 (push branch + open PR with retry-test output, baseline counts, AC-8 confirmation)
+T8 (push branch; close Dependabot PR #959 with supersede comment; open PR with snapshot-diff narrative + AC-7 narrative)
   │
   ▼
-T9 (CI passes — note that THIS PR runs against the OLD workflow + a NEW workflow; the renamed steps may invalidate cached results; tolerate one rerun if Chrome flake hits during transition)
+T9 (CI passes — test-quality.yml all shards green; one puppeteer-cache retry tolerated, zero Playwright-shaped retries)
   │
   ▼
-T10 (admin-merge after CI green)
-  │
-  ▼
-T11 (post-merge: open a tiny follow-up PR to verify `Cache restored from key:` logs appear for puppeteer — confirms AC-5 in real CI)
+T10 (admin-merge after CI green; sync local main)
 ```
 
-T1–T3 deliver the composite action with local proof of the retry behavior. T4 activates it. T5 is the local gate. T6 closes the lifecycle's review-phase gap. T11 is the **AC-5 verification** that can only happen post-merge.
+T1 is the prerequisite for everything (the new API surface only exists post-bump). T2 is the only behavior-changing edit; the rest is documentation + comments. T5 is the local gate. T6 is the lifecycle review-phase requirement. There is no post-merge verification task — unlike #958 (which needed real-CI cache logs), all #947 ACs are observable on the PR itself.
 
 ---
 
-## Phase 1 — Composite action
+## Phase 1 — Version bump
 
-### T1 — Write `action.yml` + `_retry-test.sh` scaffolds
+### T1 — Bump `@playwright/test` to `^1.60.0`
 
-**ACs satisfied:** AC-1 (interface), AC-2 (steps shape — verified by inspection), AC-9 (YAML well-formed)
-**Touches:** `.github/actions/setup-node-with-puppeteer-cache/action.yml` (new), `.github/actions/setup-node-with-puppeteer-cache/_retry-test.sh` (new)
+**ACs satisfied:** AC-1 (pin), AC-2 (lockfile regen)
+**Touches:** `package.json`, `package-lock.json`
 
 **Steps:**
 
-1. `mkdir -p .github/actions/setup-node-with-puppeteer-cache`
-2. Write `action.yml` per SPEC §6 verbatim — pinned `actions/setup-node@v6`, `actions/cache@v4`, inline shell retry loop with `for attempt in 1 2 3` + 10s `sleep` between attempts, `::warning::` / `::error::` log syntax.
-3. Write `_retry-test.sh` as the local harness. It must:
-   - Create a temp dir, write a fake `npm` script that reads a counter file, fails N times, then succeeds
-   - Extract the retry-loop shell code from `action.yml` (or duplicate it in the harness — see T2/T3 decision below)
-   - Assert exit codes and log-line counts for the two scenarios in T2 and T3
-4. Decision: **duplicate the retry-loop code** in `_retry-test.sh` rather than extract from YAML. Reason: parsing the inline shell script out of YAML is fragile; duplication keeps the harness honest about what it's testing. The two copies must stay in sync — `_retry-test.sh` header carries a comment naming `action.yml` as the source of truth and instructing future editors to update both.
+1. From a clean working tree, branch off `main`: `git switch -c feat/playwright-1.60-aria-snapshots`. (Branch name follows the prefix convention of recent PRs: `feat/…`, `chore/…`.)
+2. Edit `package.json`: change the `"@playwright/test": "^1.59.1"` line to `"@playwright/test": "^1.60.0"`. Do not touch any other field.
+3. Run `npm install` (not `npm ci` — the lockfile is mid-regeneration). Confirm `node_modules/@playwright/test/package.json` reports `"version": "1.60.x"`.
+4. Run `npm ls @playwright/test` → expect a `1.60.x` line. No `UNMET` or peer-dep warnings introduced.
+5. Verify the lockfile diff is bounded: `git diff --stat package-lock.json` should show changes confined to `@playwright/test` and its hoisted deps (playwright core, playwright-core). Any drift outside that subtree gets investigated before T2 — a broader lockfile rewrite indicates an npm version mismatch with whoever last regenerated the lockfile, and we'd want a clean `--prefer-offline` re-install to match.
 
-**Verify (mechanical):** `python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup-node-with-puppeteer-cache/action.yml'))"` exits 0; `bash -n .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh` exits 0.
-
----
-
-### T2 — RED retry test (mock npm fails 3 times)
-
-**ACs satisfied:** AC-6 (partial — proves the harness can detect failure)
-**Touches:** none beyond T1
-
-**Steps:**
-
-1. Run `bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh fail-fail-fail`
-2. Expect: exit code **1**, stdout contains 3 attempt-failure log lines, ends with `npm ci failed after 3 attempts`
-3. **This is the RED proof** — the retry loop genuinely surfaces failures rather than swallowing them.
-
-**Verify:** assert exit 1, count log lines, no false positives.
+**Verify (mechanical):**
+- `grep -c '"@playwright/test": "\^1.60' package.json` → `1`
+- `npm ls @playwright/test 2>&1 | grep -c '1\.60\.'` → `≥ 1`
+- `git diff --stat | head -3` reports two files: `package.json` (+1/-1), `package-lock.json` (modest diff).
 
 ---
 
-### T3 — GREEN retry test (mock npm fails twice, succeeds on 3rd)
+## Phase 2 — Snapshot migration
 
-**ACs satisfied:** AC-6 (full)
-**Touches:** none beyond T1
-
-**Steps:**
-
-1. Run `bash .github/actions/setup-node-with-puppeteer-cache/_retry-test.sh fail-fail-succeed`
-2. Expect: exit code **0**, stdout contains 2 retry-warning lines, ends with `npm ci succeeded on attempt 3`
-
-**Verify:** assert exit 0, 2 retry-warning lines, no `::error::` lines.
-
----
-
-## Phase 2 — Migrate call-sites
-
-### T4 — Replace 7 `setup-node + npm ci` pairs in `test-quality.yml`
+### T2 — Migrate `homepage.spec.ts:192` to page-level snapshot
 
 **ACs satisfied:** AC-3 (full)
-**Touches:** `.github/workflows/test-quality.yml`
+**Touches:** `tests/playwright-agents/homepage.spec.ts`
 
-**Migration pattern (per SPEC §7) — every call-site:**
+**Steps:**
 
-Before:
-```yaml
-- name: Setup Node.js
-  uses: actions/setup-node@v6
-  with:
-    node-version: '20'
-    cache: 'npm'
+1. Open `tests/playwright-agents/homepage.spec.ts` to the "Homepage main landmark matches ARIA smoke snapshot" test (line ~188-216).
+2. Replace `await expect(page.locator('main').first()).toMatchAriaSnapshot(...)` with `await expect(page).toMatchAriaSnapshot(...)`.
+3. Update the test title to reflect the new scope: `'Homepage page-level landmarks match ARIA smoke snapshot'` (so a future reader knows the scope is page, not `main`). Tag preservation: do not change `@content @navigation Homepage Redesign @REQ-CONTENT-01 @REQ-VISUAL-01` — those tags are how the shard 1 selector finds this test.
+4. Start `bundle exec jekyll serve --config _config.yml,_config_dev.yml` in a background terminal (port 4000). Wait for `Server running... press ctrl-c to stop.`
+5. Run `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks" --update-snapshots`. This rewrites the inline template literal in place with the page's full accessibility tree.
+6. **Manual diff review** of the regenerated snapshot — this is the load-bearing human-judgment step:
+   - Should include `banner` (header), `navigation` (already in the old snapshot's parent), original `main` block, `contentinfo` (footer), and possibly `complementary` if newsletter landmark spans outside `main`.
+   - Watch for dynamic content leaking in: build-date footers, copyright year, post-count badges, anything keyed on `site.time`. Replace each with the existing `/.+/` regex placeholder pattern (already used at line 194-196 for the heading).
+   - Watch for screen-reader-only text becoming visible in the snapshot — accessibility tree includes `aria-label` content, so a label like `aria-label="Skip to main content"` will appear as `link "Skip to main content"`.
+7. Re-run without `--update-snapshots` to confirm stability: `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks"`. Must exit `0` with no diff prompt.
 
-- name: Install dependencies
-  run: npm ci
-```
+**Verify (mechanical):**
+- `grep -c "expect(page).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `1`
+- `grep -c "expect(page.locator('main').first()).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `0`
+- Test passes against a live server, without `--update-snapshots`, on two consecutive runs (proves the snapshot is stable, not a one-shot capture).
 
-After:
-```yaml
-- name: Setup Node + cache + install deps
-  uses: ./.github/actions/setup-node-with-puppeteer-cache
-```
-
-Apply to all 7 jobs listed in "Anchors confirmed" above. The substitution is pure — no input overrides needed because every call-site uses the default values (`node-version: '20'`, `cache: 'npm'`).
-
-**Verify (per-job, after each substitution):**
-- The job's step list is shorter by 6 lines (2 steps × 4 / 3 lines minus the new 2-line step)
-- The job's YAML still parses
-
-**Verify (after all 7 are done):**
-- `grep -c "setup-node@v6" .github/workflows/test-quality.yml` → **0**
-- `grep -c "uses: ./.github/actions/setup-node-with-puppeteer-cache" .github/workflows/test-quality.yml` → **7**
-- `grep -c "^      - name: Install dependencies$" .github/workflows/test-quality.yml` → drops from 7 to 0
-- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-quality.yml'))"` exits 0
+**Risk:** if the page-level snapshot picks up unstable content that resists `/.+/` placeholders, narrow it back — keep the `expect(page)` form but use a `boxes: false` option or wrap a single template literal with strategic `/.*/` placeholders. **Do not revert to element-scoped.** If narrowing fails, escalate to spec amendment (the migration would then move to follow-up work).
 
 ---
 
-## Phase 3 — Local verification
+### T3 — Annotate the two element-scoped sites with `// element-scoped:` rationale
 
-### T5 — AC-8 boundary check + re-run retry harness
+**ACs satisfied:** AC-3 (rationale-comment portion)
+**Touches:** `tests/playwright-agents/navigation.spec.ts`
 
-**ACs satisfied:** AC-8 (boundary), AC-6 (re-confirm post-migration)
+**Steps:**
+
+1. Above the snapshot at `navigation.spec.ts:96`, insert a one-line comment:
+   `// element-scoped: deliberately narrow to the article landmark — page-level would balloon the snapshot with site chrome (#947).`
+2. Above the snapshot at `navigation.spec.ts:460`, insert a one-line comment:
+   `// element-scoped: mobile-nav-open assertion checks the nav landmark in its open state; page-level would dilute the assertion (#947).`
+3. Do not modify the snapshot template literals themselves.
+
+**Verify (mechanical):**
+- `grep -cE "^\s*// element-scoped:" tests/playwright-agents/navigation.spec.ts` → `2`
+- `npx playwright test tests/playwright-agents/navigation.spec.ts -g "ARIA smoke snapshot"` still passes (the comments are no-ops at runtime; this just guards against accidental edits).
+
+---
+
+## Phase 3 — Docs
+
+### T4 — Update `.github/skills/jekyll-qa/SKILL.md`
+
+**ACs satisfied:** AC-6
+**Touches:** `.github/skills/jekyll-qa/SKILL.md`
+
+**Steps:**
+
+1. Open `.github/skills/jekyll-qa/SKILL.md`. Locate line 40: `` - `@playwright/test ^1.59.1` ``.
+2. Replace the version: `` - `@playwright/test ^1.60.0` `` (bumped from ^1.59.1 in #947 — adds page-level `expect(page).toMatchAriaSnapshot()`, `test.abort()`, HAR-on-tracing, `locator.drop()`)
+3. Below this line, add a sub-bullet:
+   `` - `test.abort()` (Playwright 1.60+) is available for "tests must not call X" guardrails (issue #947) ``
+4. Do not edit any other line, do not introduce trailing whitespace, do not reflow surrounding bullets.
+
+**Verify (mechanical):**
+- `grep -n '@playwright/test \^1' .github/skills/jekyll-qa/SKILL.md` → exactly one match, reading `^1.60.0`.
+- `grep -n 'test.abort()' .github/skills/jekyll-qa/SKILL.md` → at least one match referencing #947.
+- `git diff --stat .github/skills/jekyll-qa/SKILL.md` → small diff, single hunk.
+
+---
+
+## Phase 4 — Local verification
+
+### T5 — Full Playwright sweep + scope-guard boundary check
+
+**ACs satisfied:** AC-4 (test-quality side, see Spec Amendment Proposal above), AC-5 (full local sweep), AC-8 (file boundary)
 **Touches:** none (read-only verification)
 
 **Steps:**
 
-1. `git diff --stat .github/workflows/` — expect ONLY `.github/workflows/test-quality.yml` modified.
-2. `git diff --stat .github/actions/` — expect TWO new files under `.github/actions/setup-node-with-puppeteer-cache/`.
-3. `git diff --stat` (whole repo) — expect 3 files total (2 new + 1 modified). No `_posts/`, `_layouts/`, `_sass/`, `package.json`, `package-lock.json`, etc.
-4. Re-run `_retry-test.sh` in both modes (`fail-fail-fail`, `fail-fail-succeed`). Both still pass.
+1. With `bundle exec jekyll serve --config _config.yml,_config_dev.yml` still running on `:4000`:
+   - `npm run test:playwright:shard1` — Navigation & Mobile (covers the `navigation.spec.ts` element-scoped snapshots)
+   - `npm run test:playwright:shard2` — Content, Search & Links (covers the migrated `homepage.spec.ts` snapshot, since `homepage.spec.ts` carries `@REQ-CONTENT-01`)
+   - `npm run test:playwright:shard3` — Accessibility, Visual & Performance
+2. Full sweep as a tiebreaker: `npx playwright test`. Must exit `0`.
+3. AC-8 boundary check: `git diff --name-only main...HEAD` returns **only**:
+   ```
+   .github/skills/jekyll-qa/SKILL.md
+   package-lock.json
+   package.json
+   tests/playwright-agents/homepage.spec.ts
+   tests/playwright-agents/navigation.spec.ts
+   ```
+   5 files exactly. Zero entries under `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`.
+4. **No new files created.** `git status --short` shows only `M` markers (and the existing untracked `specs/copilot-skills-agents-redesign-spec.md`, unrelated).
 
 ---
 
@@ -188,102 +211,94 @@ Apply to all 7 jobs listed in "Anchors confirmed" above. The substitution is pur
 
 **Gate criteria (all must be true before T6):**
 
-- [ ] T1 deliverables exist; YAML and bash both parse cleanly
-- [ ] T2 RED test produces exit 1 with 3 failure log lines
-- [ ] T3 GREEN test produces exit 0 with 2 retry-warning lines + success line
-- [ ] T4 substitutions complete (grep counts match: 0 `setup-node@v6`, 7 composite-action references)
-- [ ] T5 AC-8 boundary check clean (exactly 3 files modified)
-- [ ] `git status --short` shows only the 3 expected files
+- [ ] T1: `package.json` pinned at `^1.60.0`; `npm ls @playwright/test` reports `1.60.x`.
+- [ ] T2: `homepage.spec.ts:192` uses `expect(page).toMatchAriaSnapshot` and passes twice consecutively without `--update-snapshots`.
+- [ ] T3: Two `// element-scoped:` rationale comments present in `navigation.spec.ts`.
+- [ ] T4: `SKILL.md` line ~40 reads `^1.60.0`; `test.abort()` note recorded.
+- [ ] T5: All three Playwright shards pass; full sweep passes; AC-8 boundary is exactly the 5 expected files.
 
 ---
 
-## Phase 4 — REVIEW pass
+## Phase 5 — REVIEW
 
 ### T6 — `/review` via code-reviewer agent
 
-**ACs satisfied:** lifecycle requirement, not a specific spec AC
+**ACs satisfied:** lifecycle requirement (not a specific spec AC)
 **Touches:** none (read-only review)
 
 **Brief the reviewer on:**
-- The composite action's interface and step ordering (cache step **before** npm ci to populate the cache directory before puppeteer reads it)
-- `actions/cache@v4` key strategy — `${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}` with restore-key fallback
-- The retry loop's exit handling — does the wrapper genuinely fail-fast when npm ci returns non-zero, vs. silently retrying forever?
-- AC-3 substitution fidelity — 7 jobs migrated, defaults preserved
-- Whether `_retry-test.sh` is a real test or a placeholder
+- The AC-3 judgment call — 1 of 3 snapshots migrated; the other two kept element-scoped with rationale comments. Reviewer's job is to validate the rationale, not the mechanical change.
+- The regenerated page-level snapshot text in `homepage.spec.ts` — is it stable, are the `/.+/` placeholders covering the right dynamic content, is the test name still accurate?
+- AC-4 spec amendment (auto-regression doesn't run on PRs / doesn't install Playwright) — does the reviewer agree the inspection-based verification is sufficient?
+- That `test.abort()` is documented but not adopted in any test (intentional — separate authoring work).
+- The branch superseding Dependabot PR #959 — call out the closing strategy (close at T8, not earlier).
 
-**Expected findings shape:** Major (cache-key correctness, step ordering, retry-exit-handling), Minor (action.yml descriptive prose, _retry-test.sh hygiene), Nit (commit-message hygiene).
-
-### T7 — Apply revisions; commit any post-review changes
-
-**ACs satisfied:** finishes any open AC items raised by /review
-**Touches:** depends on review findings
+**Expected findings shape:** Major (snapshot stability / placeholder coverage), Minor (rationale comment wording, test rename), Nit (commit-message hygiene).
 
 ---
 
-## Phase 5 — Ship
+### T7 — Apply review revisions
 
-### T8 — Push branch + open PR
+**ACs satisfied:** finishes any open AC items raised by /review.
+**Touches:** depends on review findings; expect at most the same 5 files.
 
-**ACs satisfied:** DoD bullet 4 (PR description includes test output, counts, AC-8 confirmation)
-**Touches:** git remote.
-
-**Commit structure on branch `chore/958-puppeteer-cache-and-retry`:**
-- **Commit A** (T1): `chore(ci): add setup-node-with-puppeteer-cache composite action (#958)` — action.yml + _retry-test.sh; no callers yet (no behaviour change to any workflow).
-- **Commit B** (T4): `chore(ci): migrate 7 test-quality.yml jobs to use puppeteer-cache composite action (#958)` — pure substitution; closes #958.
-- **Commit C** (T7, if any): `chore(ci): apply /review revisions (#958)` — only if revisions were applied.
-
-PR body includes:
-- The 7 affected jobs listed by name
-- Verbatim output of both `_retry-test.sh` runs (3-fail and 2-fail-succeed)
-- `git diff --stat` output showing the AC-8 boundary
-- Note that AC-4 / AC-5 (cache miss + cache hit) verification happens post-merge in CI logs
-
-**Labels:** no `agent:*` label (the PR touches `.github/actions/` and `.github/workflows/` — both are QA scope under `agent:qa-gatekeeper`'s `FORBIDDEN_PATTERN` of `^_sass/|^_layouts/|^_posts/|^_config\.yml$`, so `agent:qa-gatekeeper` is **valid** and should be applied). No `governance-update` (workflows aren't in `.github/skills/` or `.github/instructions/`).
-
-### T9 — CI passes
-
-**Note:** This PR's CI run will execute the **new** composite action against itself (the workflow file changes apply to this PR's own run). Two outcomes possible:
-
-- **Best case:** cache is empty on first run → puppeteer downloads → cache populates → next run uses it. Single CI cycle.
-- **Same-flake case:** Chrome 146 download flake hits the cold-cache install. Retry loop's job is to absorb it. If the retry loop fails (e.g., 3 attempts × 10s isn't enough for a wide CDN outage), one rerun should fix it just like #957's first run.
-
-Tolerate one rerun if the Chrome flake hits during this transition PR; the cache will be primed for subsequent runs.
-
-### T10 — Admin-merge after green
-
-**ACs satisfied:** AC-3 (final, in `main`)
-**Touches:** git remote (merge).
-
-`gh pr merge <N> --admin --squash --delete-branch` once CI green. Sync local `main`. Verify the composite action file and migrated workflow both made it.
+**Hard rule:** if `/review` asks for changes that would push the diff beyond the 5-file scope, stop and escalate to spec amendment rather than silently expanding scope.
 
 ---
 
-### T11 — Post-merge AC-5 verification
+## Phase 6 — Ship
 
-**ACs satisfied:** AC-5 (cache hit observed in real CI)
-**Touches:** open a tiny follow-up PR (e.g., a docs typo fix or whitespace edit) to trigger a fresh CI run.
+### T8 — Push branch; close #959; open PR
+
+**ACs satisfied:** AC-7 (PR description content)
+**Touches:** git remote, GitHub PR state.
 
 **Steps:**
 
-1. Open a trivial PR (any small change) on `main` after #958 merges.
-2. Inspect the CI logs for one of the 7 affected jobs.
-3. Look for `Cache restored from key: <runner-os>-puppeteer-<hash>` near the start of the install step.
-4. If found: AC-5 satisfied, close the trivial PR with a comment linking to the cache-hit log.
-5. If not found: investigate immediately — cache misses on a known key indicate a key-mismatch bug.
+1. `git push -u origin feat/playwright-1.60-aria-snapshots`.
+2. `gh pr create --repo oviney/blog --label "agent:qa-gatekeeper" --title "feat(tests): bump @playwright/test to ^1.60.0 + page-level ARIA snapshot on homepage (#947)"` with body containing:
+   - Closes #947
+   - Supersedes #959 (Dependabot lockfile-only bump)
+   - Spec amendment note for AC-4 (auto-regression workflow trigger surface)
+   - Rationale for keeping 2 of 3 ARIA snapshots element-scoped (one paragraph per call-site)
+   - Snapshot diff narrative — what new landmarks the page-level snapshot picked up, what `/.+/` placeholders were added
+   - Local verification evidence (3 shards + full sweep, all green)
+3. **Then** close #959: `gh pr close 959 --repo oviney/blog --comment "Superseded by PR #<new> — single atomic bundle of lockfile, snapshot migration, and skill doc update per SPEC #947."`
 
-**Justification for the trivial PR:** AC-5 can only be observed in real CI, not local. Without the post-merge check, AC-5 remains unverified. A small follow-up PR is the cheapest way to observe cache-hit behavior without waiting for an unrelated future change.
+**Order matters:** open the new PR first, then close #959. The opposite order leaves the repo with no open bump PR for the window between commands.
 
 ---
 
-## Risk register
+### T9 — CI passes
 
-| Risk | Mitigation |
-|---|---|
-| `actions/cache@v4` is not available or API changed | Pin to `@v4` (current stable major); if unavailable, fall back to `@v3` with a comment. Confirm at runtime via CI logs. |
-| Cache key collision between Node versions or OS variants | Key includes `${{ runner.os }}-puppeteer-…`; restore-keys fallback to OS-prefix. Different Node versions on the same OS share the puppeteer dir, which is correct (Chrome binary is OS+arch-dependent, not Node-dependent). |
-| Retry loop swallows a genuine, non-transient failure | Loop preserves npm ci's exit code on the third attempt; `::error::` log line on terminal failure makes it visible in the workflow run summary. Reviewer should confirm. |
-| Composite action's relative-path reference (`./.github/actions/...`) doesn't resolve when called from a workflow | This is the standard GitHub Actions convention for in-repo composite actions; works as long as `actions/checkout@v6` runs before the composite-action call (verified in all 7 affected jobs at baseline). |
-| First post-merge run still hits the Chrome flake before cache populates | Acceptable — the retry loop absorbs it; if even the retry exhausts, one manual rerun (same pattern we paid twice today). Once cache is primed, subsequent runs skip the download. |
-| One of the 7 jobs has a subtly different setup-node configuration that the composite action's defaults don't match | Verified at baseline: all 7 use `node-version: '20'` + `cache: 'npm'` verbatim. T4's grep checks would flag any drift mid-migration. |
-| The reviewer raises a "use third-party retry action" objection | Documented in SPEC §9 boundaries (chose inline shell loop for fewer deps). Reviewer is free to disagree; absent strong evidence, defer to the SPEC's decision. |
-| AC-5 verification PR (T11) doesn't trigger the right jobs (e.g., change-based test selection skips them) | If `select-tests` skips the affected jobs, manually `gh workflow run test-quality.yml` against the branch to force a full run. Documented as a fallback in T11. |
+**ACs satisfied:** AC-4 (test-quality side)
+**Touches:** none.
+
+**Steps:**
+
+1. Wait for Quality Tests workflow (Playwright shards 1+2+3) to complete on the PR.
+2. **Retry policy:** zero Playwright-shaped retries. One puppeteer Chrome-cache retry is tolerated only if the failure stack matches the pattern from #958 (the composite action's retry-wrapped `npm ci` should make this nearly impossible after the first run, but if cold-cache hits and the retry-loop genuinely fires, that's a tolerated outcome — log it in the PR comments).
+3. If any Playwright-shaped failure occurs: do **not** retry. Investigate the diff, fix locally, push a follow-up commit.
+
+---
+
+### T10 — Admin-merge
+
+**ACs satisfied:** none new — closes the lifecycle.
+**Touches:** main branch.
+
+**Steps:**
+
+1. `gh pr merge <new-PR> --repo oviney/blog --admin --squash --delete-branch`.
+2. `git switch main && git pull origin main`. Confirm local `main` carries the merge commit and `git status` is clean.
+3. Archive the lifecycle artifacts: `mkdir -p tasks/archive/2026-05-17-playwright-1.60-947 && git mv SPEC.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/plan.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/todo.md tasks/archive/2026-05-17-playwright-1.60-947/` (in a one-line cleanup commit on a follow-up branch, or in the same PR if archive-on-ship is the convention — confirm with maintainer; #958's lifecycle artifacts were archived in the next session, not the same PR).
+
+---
+
+## Definition of Done
+
+- [ ] All 8 SPEC §3 ACs satisfied (AC-4 satisfied per the amended wording proposed above, assuming the user accepts the amendment).
+- [ ] PR description records the AC-7 narrative (snapshot rationale, #959 supersedure, #944 unblock).
+- [ ] `gh pr view <new> --json statusCheckRollup` shows all required checks green; merged via admin-squash.
+- [ ] Local `main` synced post-merge; lifecycle artifacts archived (in this PR or a follow-up cleanup commit).
+- [ ] No follow-up issue needed — `test.abort()` adoption and HAR tracing are explicitly deferred in SPEC §10 and require no tracking issue beyond what's already in #902 (Watch list).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9,20 +9,20 @@
 - [x] **A1** AC-4 amendment accepted by user 2026-05-17 — `auto-regression.yml` verified by inspection (no Playwright runtime; `issues: labeled` trigger only). SPEC §3 AC-4 updated in place.
 
 ## Phase 1 — Version bump
-- [ ] **T1** Branch `feat/playwright-1.60-aria-snapshots` from clean `main`; edit `package.json` to `"@playwright/test": "^1.60.0"`; `npm install`; confirm `npm ls @playwright/test` reports `1.60.x`; confirm `package-lock.json` diff is bounded to the `@playwright/test` subtree.
+- [x] **T1** ✅ Branch `feat/playwright-1.60-aria-snapshots` created. `package.json` pinned at `^1.60.0`. `npm install` clean (`changed 3 packages, 0 vulnerabilities`). `npm ls @playwright/test` → `1.60.0`; `playwright@1.60.0`; `playwright-core@1.60.0`. Lockfile diff bounded to the 3-package subtree (matches Dependabot #959 shape). Commit `3174891`.
 
 ## Phase 2 — Snapshot migration
-- [ ] **T2** Rewrite `homepage.spec.ts:192` snapshot to `expect(page).toMatchAriaSnapshot(...)`; update test title to "Homepage page-level landmarks…"; `--update-snapshots` against live Jekyll server; manually review regenerated snapshot for dynamic-content drift, add `/.+/` placeholders as needed; re-run twice without `--update-snapshots` to confirm stability.
-- [ ] **T3** Add two `// element-scoped: …` rationale comments above `navigation.spec.ts:96` and `:460`; do not modify the snapshot literals; re-run nav spec to confirm comments are benign.
+- [x] **T2** ✅ `homepage.spec.ts:192` migrated to `expect(page).toMatchAriaSnapshot()`. Snapshot reduced to `- banner / - main / - contentinfo` landmark-presence smoke check. Navigation deliberately excluded (collapses to hamburger button on mobile; nav coverage stays in `navigation.spec.ts`). Inline comment documents trade-offs. Verified on Desktop/Mobile/Tablet Chrome + Desktop Firefox (Safari blocked locally by missing libwoff1/libavif16; CI has them). Full homepage.spec.ts: 11/11 pass on Desktop Chrome. Commit `73d0d8f`.
+- [x] **T3** ✅ Two `// element-scoped: …` rationale comments added above `navigation.spec.ts:99` (article snapshot) and `:466` (mobile-nav-open snapshot). Both tests still pass. Commit `530b611`.
 
 ## Phase 3 — Docs
-- [ ] **T4** Edit `.github/skills/jekyll-qa/SKILL.md` line 40: `@playwright/test ^1.59.1` → `^1.60.0`; add `test.abort()` availability sub-bullet referencing #947.
+- [x] **T4** ✅ SKILL.md line 40 bumped to `^1.60.0` with release-feature summary; `test.abort()` availability sub-bullet added (line 41). Commit `6943275`.
 
 ## Phase 4 — Local verification
-- [ ] **T5** `bundle exec jekyll serve` running; run shards 1, 2, 3 individually; run full `npx playwright test`; confirm AC-8 boundary — `git diff --name-only main...HEAD` returns exactly the 5 expected files.
+- [x] **T5** ✅ Three Playwright shards green on 4 projects (Safari skipped locally — missing libwoff1/libavif16 system libs; CI has them): Shard 1 70/70, Shard 2 44/44, Shard 3 38/38. Full Desktop Chrome sweep 105/105. AC-8 boundary clean: 5 feature files modified (SKILL.md, package.json, package-lock.json, homepage.spec.ts, navigation.spec.ts) + 6 lifecycle files (1 SPEC.md modified, 2 new tasks/*, 3 archived #958 artifacts) — none in the protected set (`_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
 
 ## CHECKPOINT-A — Local gate before /review
-- [ ] All T1–T5 ACs satisfied. Stable working tree. No protected files touched.
+- [x] ✅ All T1–T5 ACs satisfied. Working tree clean (only `specs/copilot-skills-agents-redesign-spec.md` untracked, unrelated). No protected files touched. Branch `feat/playwright-1.60-aria-snapshots` at HEAD `6943275` ready for /review.
 
 ## Phase 5 — /review pass
 - [ ] **T6** Code-reviewer agent brief: AC-3 rationale (2-of-3 element-scoped), page-level snapshot stability, AC-4 amendment, `test.abort()` documented-but-unused.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,46 +1,47 @@
-# TODO — Puppeteer Chrome-Download Flake Mitigation (#958)
+# TODO — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Plan SHA:** `b965ddb` · 3 files (2 new + 1 modified) · 7 jobs to migrate
+**Plan SHA:** `6480f00` · 5 files (0 new + 5 modified) · 1 snapshot migration + 2 rationale comments
 
 ---
 
-## Phase 1 — Composite action
-- [x] **T1** Created `.github/actions/setup-node-with-puppeteer-cache/action.yml` + `_retry-test.sh`. YAML parses; bash syntax-checks clean.
-- [x] **T2** RED retry test passed: `_retry-test.sh fail-fail-fail` → exit 1, 2 `::warning::` + 1 `::error::` lines.
-- [x] **T3** GREEN retry test passed: `_retry-test.sh fail-fail-succeed` → exit 0, 2 `::warning::` + success-on-attempt-3 line.
+## Spec amendment to confirm before BUILD
+- [x] **A1** AC-4 amendment accepted by user 2026-05-17 — `auto-regression.yml` verified by inspection (no Playwright runtime; `issues: labeled` trigger only). SPEC §3 AC-4 updated in place.
 
-## Phase 2 — Migrate call-sites
-- [x] **T4** Replaced 7 call-sites in `test-quality.yml`. Grep counts verified (0 `setup-node@v6`, 7 composite-action references). YAML still parses.
+## Phase 1 — Version bump
+- [ ] **T1** Branch `feat/playwright-1.60-aria-snapshots` from clean `main`; edit `package.json` to `"@playwright/test": "^1.60.0"`; `npm install`; confirm `npm ls @playwright/test` reports `1.60.x`; confirm `package-lock.json` diff is bounded to the `@playwright/test` subtree.
 
-## Phase 3 — Local verification
-- [x] **T5** AC-8 boundary clean (3 files total: 2 new under `.github/actions/`, 1 modified workflow). Retry harness re-runs green post-migration.
+## Phase 2 — Snapshot migration
+- [ ] **T2** Rewrite `homepage.spec.ts:192` snapshot to `expect(page).toMatchAriaSnapshot(...)`; update test title to "Homepage page-level landmarks…"; `--update-snapshots` against live Jekyll server; manually review regenerated snapshot for dynamic-content drift, add `/.+/` placeholders as needed; re-run twice without `--update-snapshots` to confirm stability.
+- [ ] **T3** Add two `// element-scoped: …` rationale comments above `navigation.spec.ts:96` and `:460`; do not modify the snapshot literals; re-run nav spec to confirm comments are benign.
+
+## Phase 3 — Docs
+- [ ] **T4** Edit `.github/skills/jekyll-qa/SKILL.md` line 40: `@playwright/test ^1.59.1` → `^1.60.0`; add `test.abort()` availability sub-bullet referencing #947.
+
+## Phase 4 — Local verification
+- [ ] **T5** `bundle exec jekyll serve` running; run shards 1, 2, 3 individually; run full `npx playwright test`; confirm AC-8 boundary — `git diff --name-only main...HEAD` returns exactly the 5 expected files.
 
 ## CHECKPOINT-A — Local gate before /review
-- [x] All T1–T5 ACs satisfied. Commits A (`5924993`) + B (`901c95b`) on branch.
+- [ ] All T1–T5 ACs satisfied. Stable working tree. No protected files touched.
 
-## Phase 4 — /review pass
-- [x] **T6** Code-reviewer agent verdict: **Approve**, no blockers. 2 Majors + 2 minor revisions identified.
-- [x] **T7** Applied all 4 revisions in Commit C (`5c72a7a`): M2 cache-key salts on Node version; M1 tightened sync-comment in both files (retry SHAPE not byte-identical); m1 set-uo-pipefail rationale comment; n1 RETRY-TEST PASS/FAIL banner prefix. Harness still green post-revision.
+## Phase 5 — /review pass
+- [ ] **T6** Code-reviewer agent brief: AC-3 rationale (2-of-3 element-scoped), page-level snapshot stability, AC-4 amendment, `test.abort()` documented-but-unused.
+- [ ] **T7** Apply review revisions; commit. Hard rule: if revisions push the diff beyond 5 files, escalate to spec amendment rather than expand scope silently.
 
-## Phase 5 — Ship
-- [ ] **T8** Push branch; `gh pr create` with retry-test outputs + 7-job list + AC-8 diff stat; label `agent:qa-gatekeeper`.
-- [ ] **T9** CI passes — tolerate one Chrome-flake rerun during transition (cache priming on first run).
-- [ ] **T10** `gh pr merge --admin --squash --delete-branch` once green; sync local main.
-
-## Phase 6 — Post-merge verification
-- [ ] **T11** Open a trivial follow-up PR (any small change) to trigger fresh CI; inspect logs for `Cache restored from key:` on at least one of the 7 affected jobs (AC-5 verification — only observable in real CI)
+## Phase 6 — Ship
+- [ ] **T8** `git push -u origin feat/playwright-1.60-aria-snapshots`; `gh pr create` with snapshot-diff narrative, AC-7 content (rationale + #959 supersedure + #944 unblock), `agent:qa-gatekeeper` label; **then** close Dependabot PR #959 with supersede comment.
+- [ ] **T9** CI green — zero Playwright-shaped retries; one puppeteer Chrome-cache retry tolerated per #958 pattern (and only if stack matches).
+- [ ] **T10** `gh pr merge --admin --squash --delete-branch` once green; `git switch main && git pull`; archive lifecycle artifacts under `tasks/archive/2026-05-17-playwright-1.60-947/`.
 
 ---
 
 ## Acceptance criteria checklist (mirrors SPEC §3)
 
-- [ ] **AC-1** Composite action exists with documented `node-version` (default `'20'`) and `npm-cache` (default `'npm'`) inputs
-- [ ] **AC-2** Steps order: setup-node, cache puppeteer dir, retry-wrapped npm ci
-- [ ] **AC-3** 7 jobs in `test-quality.yml` use composite action; no `setup-node@v6 + npm ci` pair remains outside it
-- [ ] **AC-4** First post-merge run logs cache miss + cache save (verified via CI logs at T11)
-- [ ] **AC-5** Subsequent run logs cache restored from key, ≥ 20s install-step time savings vs cold (T11)
-- [ ] **AC-6** `_retry-test.sh` passes both RED (3-fail) and GREEN (2-fail-succeed) cases
-- [ ] **AC-7** All 11 other test-quality.yml jobs continue passing
-- [ ] **AC-8** `git diff --stat .github/workflows/` shows only `test-quality.yml` modified
-- [ ] **AC-9** `action.yml` parses as valid composite-action YAML
+- [ ] **AC-1** `package.json` pins `@playwright/test ^1.60.0`
+- [ ] **AC-2** `package-lock.json` regenerated, `npm ls @playwright/test` reports `1.60.x`
+- [ ] **AC-3** `homepage.spec.ts:192` migrated to page-level; `navigation.spec.ts:96` + `:460` carry `// element-scoped:` rationale comments
+- [ ] **AC-4** *(amended)* `test-quality.yml` passes green on a single PR run; `auto-regression.yml` verified by inspection (no Playwright runtime)
+- [ ] **AC-5** `npx playwright test` exits `0` locally with live Jekyll server
+- [ ] **AC-6** `.github/skills/jekyll-qa/SKILL.md` line 40 → `^1.60.0` + `test.abort()` availability note
+- [ ] **AC-7** PR description records snapshot rationale, #959 closure, #944 unblock
+- [ ] **AC-8** `git diff --name-only main...HEAD` returns exactly 5 files (no protected-file diffs)

--- a/tests/playwright-agents/homepage.spec.ts
+++ b/tests/playwright-agents/homepage.spec.ts
@@ -185,30 +185,22 @@ test.describe('@content @navigation Homepage Redesign @REQ-CONTENT-01 @REQ-VISUA
     expect(currentUrl).not.toBe('http://localhost:4000/');
   });
 
-  test('Homepage main landmark matches ARIA smoke snapshot', async ({ page }) => {
+  test('Homepage page-level landmarks match ARIA smoke snapshot', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.locator('main').first()).toMatchAriaSnapshot(`
-      - main:
-        - region "Site introduction"
-        - heading /Latest post:.+/ [level=1]
-        - region "Browse by Topic":
-          - heading "Browse by Topic" [level=2]
-        - region "From the Blog":
-          - heading "From the Blog" [level=2]
-          - article
-          - article
-          - article
-        - region "About the author":
-          - heading [level=2]
-          - link "About me"
-          - link /LinkedIn/
-          - link /GitHub/
-          - link "RSS Feed"
-        - complementary:
-          - heading "Stay informed" [level=3]
-          - link "Subscribe via RSS →"
+    // Page-level smoke snapshot — asserts the three structural landmarks
+    // (banner, main, contentinfo) exist at top level on every viewport.
+    // Navigation is deliberately not asserted here: at mobile widths the
+    // primary nav collapses into a "Open navigation menu" button and is no
+    // longer a top-level <nav> landmark, so a snapshot that included nav
+    // would fail on Mobile/Tablet Chrome. Detailed nav assertions live in
+    // navigation.spec.ts (desktop) and the mobile-nav tests there. See #947
+    // for migration context.
+    await expect(page).toMatchAriaSnapshot(`
+      - banner
+      - main
+      - contentinfo
     `);
   });
 

--- a/tests/playwright-agents/navigation.spec.ts
+++ b/tests/playwright-agents/navigation.spec.ts
@@ -93,6 +93,9 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
     await page.goto(TESTING_TIMES);
     await page.waitForLoadState('networkidle');
 
+    // element-scoped: deliberately narrow to the article landmark — page-level
+    // would balloon the snapshot with site chrome and create review noise on
+    // every layout tweak (#947).
     await expect(page.locator('main article').first()).toMatchAriaSnapshot(`
       - article:
         - link /.+/
@@ -457,6 +460,9 @@ test.describe('@navigation Mobile Navigation Specific Tests @REQ-NAV-01 @REQ-NAV
     await expect(toggle).toBeVisible();
     await toggle.click();
 
+    // element-scoped: mobile-nav-open assertion checks the nav landmark in its
+    // open state; page-level would dilute the assertion by including the rest
+    // of the page (#947).
     await expect(page.locator('#site-navigation')).toMatchAriaSnapshot(`
       - navigation:
         - list:


### PR DESCRIPTION
## Summary

- Bumps `@playwright/test` from `^1.59.1` to `^1.60.0`. Lockfile diff is bounded to the 3-package playwright subtree (`@playwright/test`, `playwright`, `playwright-core`), matching Dependabot PR #959's footprint exactly.
- Migrates one of three `toMatchAriaSnapshot` call-sites — `tests/playwright-agents/homepage.spec.ts:188` — to the new Playwright 1.60 page-level form (`expect(page).toMatchAriaSnapshot()`). The other two call-sites in `navigation.spec.ts` stay element-scoped with rationale comments.
- Updates `.github/skills/jekyll-qa/SKILL.md` to reflect the new pin and document that `test.abort()` is now available for "tests must not call X" guardrails.

Closes #947.

## Issue lineage

- **Spawned from:** Research Sweep #902.
- **Blocked by:** #944 (closed 2026-05-17 — pa11y-ci 4.1.1 lockfile alignment shipped first to avoid a double lockfile regeneration).
- **Supersedes:** Dependabot PR #959 (lockfile-only bump of the same 3-package subtree). I will close #959 with a supersede comment as soon as this PR opens.

## AC-3 — the migration judgment call (read this part)

`SPEC.md` §3 AC-3 calls for migrating `homepage.spec.ts:188` to page-level and keeping `navigation.spec.ts:96` and `:463` element-scoped with rationale comments. The implementation matches that, but the **migrated snapshot is meaningfully narrower than the original** and that needs reviewer eyes.

Original element-scoped snapshot validated 5 specific ARIA regions inside \`main\` (Site introduction, Browse by Topic with category headings, From the Blog with article count, About the author with named links, complementary newsletter). Migrated page-level snapshot validates only that three landmarks (\`banner\`, \`main\`, \`contentinfo\`) exist.

**Why I narrowed it:** Playwright's \`toMatchAriaSnapshot\` is strict about partially-declared children — once a node has \`:\` declared, the child list must match exhaustively. The homepage \`main\` block contains drift-prone content (latest post title, post excerpts, per-category post counts like \"5 posts\") that would force constant rebaselining or an extensive \`/.+/\`-placeholder snapshot. A landmark-presence smoke check is a better fit for the role this test plays.

**Why \`navigation\` is not in the page-level snapshot:** At mobile widths the primary nav collapses to a hamburger button and is no longer a top-level \`<nav>\` landmark. Including nav would fail on Mobile/Tablet Chrome. Detailed nav coverage stays in \`navigation.spec.ts\`.

**Coverage delta:** Tests 1–6 in \`homepage.spec.ts\` (lines 16, 41, 86, 114, 142, 153) cover the same regions via CSS-selector assertions. That's not identical to ARIA-tree validation, but the region-by-region coverage exists.

**If the reviewer wants the original detail preserved**, the cleanest pivot is to keep the existing element-scoped \`main\` snapshot AND add the new page-level landmark-presence test as a second test in the same describe block — recovers all coverage at the cost of one extra test.

## AC-4 — spec amendment accepted during PLAN

Original AC-4 required \`auto-regression.yml\` to pass green on the PR run. That workflow triggers on \`issues: labeled\` events only — it physically cannot fire on a PR — and it does not install or run Playwright at runtime (it only writes test scaffolding files). AC-4 was amended to require \`test-quality.yml\` green only, with \`auto-regression.yml\` verified by inspection. See \`SPEC.md\` §3 AC-4 and \`tasks/plan.md\` §\"Spec Amendment Proposal\".

## Local verification

- \`npm ls @playwright/test\` → \`1.60.0\`; \`playwright@1.60.0\`; \`playwright-core@1.60.0\`.
- Lockfile diff bounded: only \`@playwright/test\`, \`playwright\`, \`playwright-core\` versions changed (12 lines added / 12 removed).
- Three Playwright shards green across 4 projects (Desktop Chrome, Desktop Firefox, Mobile Chrome, Tablet Chrome):
  - Shard 1 (Navigation & Mobile, \`@REQ-NAV-01|@REQ-NAV-02\`): **70/70**
  - Shard 2 (Content, Search & Links, \`@REQ-CONTENT-01|@REQ-CONTENT-02|@REQ-LINKS-01\`): **44/44**
  - Shard 3 (A11y, Visual & Performance, \`@REQ-A11Y-02|@REQ-VISUAL-01|@REQ-PERF-01\`): **38/38**
- Full Desktop Chrome sweep: **105/105**.
- Desktop Safari was skipped locally — missing \`libwoff1\`/\`libavif16\` host packages. CI has them, so Safari coverage runs there.
- Reminder for reviewers who pull this branch locally: \`npx playwright install\` is required after the version bump (the cached browser binaries are pinned per Playwright minor).

## File scope (AC-8)

Five feature files modified — none in the protected set (\`_config.yml\`, \`Gemfile\`, \`Gemfile.lock\`, \`.github/CODEOWNERS\`, \`.github/copilot-instructions.md\`):

- \`package.json\` (+1/-1)
- \`package-lock.json\` (+12/-12)
- \`tests/playwright-agents/homepage.spec.ts\` (+13/-21)
- \`tests/playwright-agents/navigation.spec.ts\` (+6/-0)
- \`.github/skills/jekyll-qa/SKILL.md\` (+2/-1)

Plus 6 lifecycle artifacts on the branch (new \`SPEC.md\`/\`tasks/plan.md\`/\`tasks/todo.md\` for #947, and the archived #958 trio under \`tasks/archive/2026-05-17-puppeteer-chrome-cache-958/\`). 11 files total — under the 15-file scope-explosion cap; no \`bulk-content\` label needed.

## Test plan

- [ ] Quality Tests workflow (Playwright shards 1+2+3) green
- [ ] No Playwright-shaped retries during CI (one puppeteer Chrome-cache retry tolerated per #958 pattern)
- [ ] Reviewer confirms the AC-3 narrowing trade-off (or requests pivot to two-test approach)
- [ ] Close Dependabot PR #959 with supersede comment after this PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)