### PR TITLE
feat(cards): standardise excerpt length and add author byline across discovery surfaces

### DIFF
--- a/_includes/byline.html
+++ b/_includes/byline.html
@@ -1,0 +1,6 @@
+{% assign byline_author = include.author | default: site.author.name %}
+{% assign byline_container_class = include.container_class | default: 'article-byline' %}
+{% assign byline_text_class = include.text_class | default: 'article-byline-text' %}
+<p class="{{ byline_container_class }}">
+  <span class="{{ byline_text_class }}">By {{ byline_author }}</span>
+</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,8 @@ layout: default
     <h2 class="article-subtitle">{{ page.subtitle }}</h2>
     {% endif %}
 
+    {% include byline.html author=page.author container_class="article-byline" text_class="article-byline-text" %}
+
     <!-- Action buttons (top) -->
     <div class="article-actions-top">
       <button class="action-btn" id="copy-link-btn-top" aria-label="Copy link to this article">

--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -1906,6 +1906,18 @@ table {
   margin: 0 0 8px 0;
 }
 
+.econ-card-author {
+  margin: 0 0 $spacing-xs 0;
+}
+
+.econ-card-author-name {
+  font-family: $font-sans;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: $text-secondary;
+  letter-spacing: 0.02em;
+}
+
 .econ-card-meta {
   font-family: $font-sans;
   font-size: 0.75rem;

--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -372,6 +372,18 @@ blockquote {
   }
 }
 
+.article-byline {
+  margin: 0 0 $spacing-md 0;
+}
+
+.article-byline-text {
+  font-family: $font-sans;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: $text-secondary;
+  letter-spacing: 0.02em;
+}
+
 // Action buttons (Save/Share)
 .article-actions-top,
 .article-actions-bottom {

--- a/blog/index.html
+++ b/blog/index.html
@@ -26,7 +26,9 @@ title: Quality Engineering
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       </h2>
 
-      <p class="econ-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 15 }}</p>
+      <p class="econ-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+
+      {% include byline.html author=post.author container_class="econ-card-author" text_class="econ-card-author-name" %}
 
       <div class="econ-card-meta">
         {% assign words = post.content | number_of_words %}

--- a/index.md
+++ b/index.md
@@ -43,6 +43,7 @@ title: Quality Engineering Insights
       <p class="hero-post-subtitle">{{ hero_post.subtitle }}</p>
       {% endif %}
 
+      <!-- Deliberately longer than discovery cards so the homepage hero stays distinct. -->
       <p class="hero-post-excerpt">{{ hero_post.excerpt | strip_html | truncatewords: 40 }}</p>
 
       <div class="hero-post-meta">
@@ -127,6 +128,7 @@ title: Quality Engineering Insights
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
           </h3>
           <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
           <div class="topic-card-meta">
             <span class="topic-meta-item">{{ post.date | date: "%B %-d, %Y" }}</span>
           </div>

--- a/security.md
+++ b/security.md
@@ -40,6 +40,7 @@ permalink: /security/
           </h2>
 
           <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">
             {% assign words = post.content | number_of_words %}

--- a/software-engineering.md
+++ b/software-engineering.md
@@ -42,6 +42,7 @@ permalink: /software-engineering/
           </h2>
 
           <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">
             {% assign words = post.content | number_of_words %}

--- a/test-automation.md
+++ b/test-automation.md
@@ -42,6 +42,7 @@ permalink: /test-automation/
           </h2>
 
           <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">
             {% assign words = post.content | number_of_words %}


### PR DESCRIPTION
## Summary
- add reusable card and article bylines across discovery surfaces and post pages
- standardise non-hero card excerpts to 20 words while keeping the homepage hero at 40 words
- keep the implementation limited to the Creative Director-owned UI files for #954

## Validation
- `bundle exec jekyll build`
- `npm run test:a11y`
- `PR_LABELS=agent:creative-director bash scripts/check-pr-scope.sh`
- manual quality workflow dispatch on refreshed branch head: https://github.com/oviney/blog/actions/runs/26068474369

Closes #954

QA follow-up remains in stacked PR #975.