### PR TITLE
test(cards): add byline regression coverage

### DIFF
--- a/tests/playwright-agents/byline-regression.spec.ts
+++ b/tests/playwright-agents/byline-regression.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' });
+
+test.describe('@content Byline regression coverage', () => {
+  test('blog cards and post headers render a visible byline', async ({ page }) => {
+    await page.goto('/blog/');
+    await page.waitForLoadState('networkidle');
+
+    const firstCard = page.locator('.econ-article-card').first();
+    await expect(firstCard).toBeVisible();
+
+    const cardByline = firstCard.getByText(/^By /).first();
+    await expect(cardByline).toBeVisible();
+
+    const postLink = firstCard.locator('h2 a').first();
+    await expect(postLink).toBeVisible();
+
+    const postHref = await postLink.getAttribute('href');
+    expect(postHref).toBeTruthy();
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto(postHref!);
+    await page.waitForLoadState('networkidle');
+
+    const articleHeader = page.locator('.article-header').first();
+    await expect(articleHeader).toBeVisible();
+
+    const postByline = articleHeader.getByText(/^By /).first();
+    await expect(postByline).toBeVisible();
+
+    const box = await postByline.boundingBox();
+    const viewport = page.viewportSize();
+
+    expect(box).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+  });
+});

--- a/tests/playwright-agents/byline-regression.spec.ts
+++ b/tests/playwright-agents/byline-regression.spec.ts
@@ -10,8 +10,12 @@ test.describe('@content Byline regression coverage', () => {
     const firstCard = page.locator('.econ-article-card').first();
     await expect(firstCard).toBeVisible();
 
-    const cardByline = firstCard.getByText(/^By /).first();
+    const cardByline = firstCard.getByText(/^By\s+\S/).first();
     await expect(cardByline).toBeVisible();
+    const cardBylineText = (await cardByline.textContent())?.trim();
+
+    expect(cardBylineText).toBeTruthy();
+    expect(cardBylineText).toMatch(/^By\s+\S.+$/);
 
     const postLink = firstCard.locator('h2 a').first();
     await expect(postLink).toBeVisible();
@@ -26,8 +30,9 @@ test.describe('@content Byline regression coverage', () => {
     const articleHeader = page.locator('.article-header').first();
     await expect(articleHeader).toBeVisible();
 
-    const postByline = articleHeader.getByText(/^By /).first();
+    const postByline = articleHeader.getByText(/^By\s+\S/).first();
     await expect(postByline).toBeVisible();
+    await expect(postByline).toHaveText(cardBylineText!);
 
     const box = await postByline.boundingBox();
     const viewport = page.viewportSize();

--- a/tests/playwright-agents/byline-regression.spec.ts
+++ b/tests/playwright-agents/byline-regression.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' });
 
-test.describe('@content Byline regression coverage', () => {
+test.describe('@content Byline regression coverage @REQ-CONTENT-01 @REQ-CONTENT-02', () => {
   test('blog cards and post headers render a visible byline', async ({ page }) => {
     await page.goto('/blog/');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- add Playwright regression coverage for bylines on a discovery card and the linked post header
- require a real author name and the same byline text on the card and article surfaces
- tag the spec with `@REQ-CONTENT-01` and `@REQ-CONTENT-02` so shard 2 includes it

## Validation
- `bundle exec jekyll build`
- `CI=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:4200 npx playwright test tests/playwright-agents/byline-regression.spec.ts --project="Mobile Chrome" --project="Tablet Chrome" --project="Desktop Chrome"`
- `PR_LABELS=agent:qa-gatekeeper bash scripts/check-pr-scope.sh`

Closes #968.