### PR TITLE
docs(#946): make AGENTS.md handoff targets explicit + Mermaid graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ bash scripts/validate-posts.sh --all
 | **Domain** | Design, CSS, UI, layouts, responsive behaviour |
 | **May touch** | `_sass/`, `_layouts/`, `assets/css/`, `assets/images/`, `assets/charts/`, `favicon.*` |
 | **Must not touch** | `.github/workflows/`, `tests/`, `scripts/`, `_config.yml`, `_posts/` |
+| **Valid handoff targets** | [Editorial Chief](#3-editorial-chief), [QA Gatekeeper](#2-qa-gatekeeper) |
 
 **Responsibilities**: Maintains visual consistency with The Economist design language. Owns the `_sass/economist-theme.scss` design system (600+ lines). Ensures WCAG AA contrast, responsive breakpoints (320px / 768px / 1024px), and typography hierarchy.
 
@@ -66,6 +67,7 @@ bash scripts/validate-posts.sh --all
 | **Domain** | Testing, CI/CD, bugs, accessibility, performance |
 | **May touch** | `.github/workflows/`, `tests/`, `specs/`, `scripts/`, `playwright.config.ts`, `backstop.json`, `.pa11yci.json`, `lighthouserc.json`, `package.json` |
 | **Must not touch** | `_sass/`, `_layouts/`, `_posts/`, `_config.yml` |
+| **Valid handoff targets** | [Creative Director](#1-creative-director), [Editorial Chief](#3-editorial-chief) |
 
 **Responsibilities**: Reviews PRs, monitors GitHub Actions pipelines, runs visual regression (BackstopJS), accessibility (Pa11y), and performance (Lighthouse) checks. Closes verified issues. Provides bug templates when users report defects.
 
@@ -82,6 +84,7 @@ bash scripts/validate-posts.sh --all
 | **Domain** | Content, blog posts, SEO, writing, documentation |
 | **May touch** | `_posts/`, `_drafts/`, `docs/`, `*.md` (root level), `blog.html`, `search.html`, `search.json` |
 | **Must not touch** | `_sass/`, `_layouts/`, `.github/workflows/`, `tests/`, `scripts/`, `_config.yml` |
+| **Valid handoff targets** | [Creative Director](#1-creative-director), [QA Gatekeeper](#2-qa-gatekeeper) |
 
 **Responsibilities**: Writes and edits blog posts using The Economist's editorial voice. Ensures SEO front-matter (title, description, categories, author). Normalises categories to exactly four values: `Quality Engineering`, `Software Engineering`, `Test Automation`, `Security`.
 
@@ -98,6 +101,7 @@ bash scripts/validate-posts.sh --all
 | **Domain** | Audience research, UX, usability, reader journey |
 | **May touch** | `docs/`, `references/`, `*.md` (root level) |
 | **Must not touch** | `_posts/`, `_sass/`, `_layouts/`, `.github/workflows/`, `tests/`, `scripts/`, `_config.yml` |
+| **Valid handoff targets** | [Creative Director](#1-creative-director), [Editorial Chief](#3-editorial-chief), [QA Gatekeeper](#2-qa-gatekeeper) |
 
 **Responsibilities**: Investigates how the blog feels to readers across homepage, archive, search, post pages, and mobile navigation. Converts vague "make it more appealing" requests into evidence-backed recommendations and routes the resulting implementation work to design, editorial, or QA.
 
@@ -114,6 +118,7 @@ bash scripts/validate-posts.sh --all
 | **Domain** | Documentation, refactoring, miscellaneous |
 | **May touch** | Any file except the protected list below |
 | **Must not touch** | `_config.yml`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `Gemfile`, `Gemfile.lock` |
+| **Valid handoff targets** | _(terminal — handles work end-to-end)_ |
 
 **Responsibilities**: Handles cross-cutting concerns (e.g., shared memory files like this one), refactoring, and tasks that do not belong to a single specialised agent.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,26 @@ bash scripts/validate-posts.sh --all
 
 ---
 
+## Handoff Graph
+
+The directed graph below visualises the **Valid handoff targets** rows above. It is derived from — and must stay consistent with — the per-persona `**Handoff triggers**:` prose. Adding a new persona means adding a new node *and* declaring its targets in both places. The General Agent is terminal: it handles cross-cutting work end-to-end and does not transfer ownership.
+
+```mermaid
+graph LR
+    CD[Creative Director] --> EC[Editorial Chief]
+    CD --> QA[QA Gatekeeper]
+    QA --> CD
+    QA --> EC
+    EC --> CD
+    EC --> QA
+    AR[Audience Researcher] --> CD
+    AR --> EC
+    AR --> QA
+    GA(["General Agent (terminal)"])
+```
+
+---
+
 ## Protected Files (all agents)
 
 The following files require human review and must **never** be modified by any agent:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ bash scripts/validate-posts.sh --all
 
 ## Handoff Graph
 
-The directed graph below visualises the **Valid handoff targets** rows above. It is derived from — and must stay consistent with — the per-persona `**Handoff triggers**:` prose. Adding a new persona means adding a new node *and* declaring its targets in both places. The General Agent is terminal: it handles cross-cutting work end-to-end and does not transfer ownership.
+The directed graph below visualises the per-persona handoff target rows above. It is derived from — and must stay consistent with — the per-persona `**Handoff triggers**:` prose. Adding a new persona means adding a new node *and* declaring its targets in both places. The General Agent is terminal: it handles cross-cutting work end-to-end and does not transfer ownership.
 
 ```mermaid
 graph LR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,9 @@ bash scripts/validate-posts.sh --all
 
 ## Handoff Graph
 
-The directed graph below visualises the per-persona handoff target rows above. It is derived from — and must stay consistent with — the per-persona `**Handoff triggers**:` prose. Adding a new persona means adding a new node *and* declaring its targets in both places. The General Agent is terminal: it handles cross-cutting work end-to-end and does not transfer ownership.
+The directed graph below visualises the per-persona handoff target rows above. It is derived from — and must stay consistent with — the per-persona `**Handoff triggers**:` prose. Adding a new persona means adding a new node *and* declaring its targets in both the persona's property table row and the Mermaid block below. The General Agent is terminal: it handles cross-cutting work end-to-end and does not transfer ownership.
+
+The diagram is a visual aid. Screen-reader users can rely on the per-persona rows above and the prose triggers for each persona — those are the canonical source of truth.
 
 ```mermaid
 graph LR

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,39 +1,32 @@
-# SPEC — Mobile Thumb-Zone Bottom Navigation (#953)
+# SPEC — Make AGENTS.md handoff targets explicit + Mermaid graph (#946)
 
 **Status:** Draft — awaiting approval
-**Issue:** [#953](https://github.com/oviney/blog/issues/953)
-**Labels:** `agent:creative-director`
+**Issue:** [#946](https://github.com/oviney/blog/issues/946)
+**Labels:** `agent:qa-gatekeeper`
 **Date:** 2026-05-24
 **Lifecycle phase:** DEFINE
-**Spawned from:** Research Sweep [#943](https://github.com/oviney/blog/issues/943) (2026-05-15)
+**Spawned from:** Research Sweep [#902](https://github.com/oviney/blog/issues/902) (2026-05-01)
 
 ---
 
 ## 1. Situation
 
-Mobile navigation on viney.ca relies exclusively on a top-left hamburger menu (`_layouts/default.html` lines 32–49). On modern tall phones the hamburger sits well outside the natural thumb-reach zone — a documented friction point for high-priority destinations (Home, Blog, Search). The existing top nav stays; this spec adds a complementary fixed bottom nav that surfaces only at mobile widths.
+`AGENTS.md` documents five personas and references handoffs in prose (`**Handoff triggers**:` lines on Creative Director, QA Gatekeeper, Editorial Chief, Audience Researcher) but does not enumerate which personas may transfer to which others. The General Agent block has no handoff prose at all.
 
-The repo already ships every destination the bottom nav needs:
+LangGraph 1.0 (GA 2025-10) and the OpenAI Agents SDK April 2026 evolution have both standardised **Handoffs** as an explicit primitive — agents transfer control with carried context and a declared list of valid handoff targets. Making the handoff graph explicit and machine-readable lets future automation (and human reviewers) detect when a new persona is added without wiring up its routing.
 
-- `/` — home (`index.md`)
-- `/blog/` — blog index
-- `/search/` — search page (`search.html`)
+The handoff *topology* is already implicit in the existing prose; this spec promotes it to a structured row on each persona plus a Mermaid diagram.
 
-Design-system context (audited at HEAD `c5eabc5`):
+**File at HEAD `f07e15de`:**
+- `AGENTS.md` — 226 lines; persona blocks at lines 44, 60, 76, 92, 108; `## Cross-Agent Conventions` at line 134.
 
-- Mobile breakpoint pattern in `_sass/economist-theme.scss` is **`max-width: 768px`** (used in 14+ rules; `768px` is the de facto boundary).
-- Spacing tokens: `$spacing-xs … $spacing-xl` in `_sass/economist-theme.scss`.
-- Fonts: `$font-sans`, `$font-serif` in `_sass/economist-theme.scss`.
-- Theme color: `#E3120B` (Economist red, declared in `_layouts/default.html` line 17 as `meta name="theme-color"` — promote to a `$brand-red` variable as part of this work *only if* one does not already exist; otherwise reuse).
-- Existing nav rules live at `_sass/economist-theme.scss:70` (`.page-header`), `:104` (`.site-nav`), `:157` (`.nav-toggle`).
-
-The issue body anticipates JS may not be needed — confirmed: a CSS-only media-query implementation satisfies every AC, so no new JS ships in this PR.
+Mermaid rendering: the repo already supports Mermaid code fences in Markdown (confirmed via existing Mermaid usage; Jekyll's mermaid-jekyll plugin is loaded). Verify with `bundle exec jekyll build` + a local dev server preview.
 
 ---
 
 ## 2. Objective
 
-Add a fixed bottom navigation bar that appears only at viewports `≤ 767px`, surfacing **Home / Blog / Search** with stacked icon + label, an active-state highlight for the current section, and proper iOS safe-area handling — without altering the existing top hamburger nav or touching protected files. Ship as one atomic PR routed to `agent:creative-director` (Copilot Coding Agent).
+Make the persona handoff graph explicit and machine-checkable in `AGENTS.md` by (a) adding a `**Valid handoff targets:**` row to each of the five persona blocks and (b) adding a top-level `## Handoff Graph` section rendering the targets as a Mermaid `graph LR` diagram. Single-file change, no governance surface touched, no functional behaviour change.
 
 ---
 
@@ -41,147 +34,149 @@ Add a fixed bottom navigation bar that appears only at viewports `≤ 767px`, su
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Visual treatment | **Stacked SVG icon + text label** | Standard mobile bottom-nav pattern; more scannable in thumb zone than icon-only or text-only. |
-| Active state | **Yes — via Liquid `page.url` match** | Pure CSS class toggle at render time; no JS, no client-side routing logic. |
-| Scope | **Every page at mobile widths** | Rendered in `_layouts/default.html` so home, blog, post, and topic pages all get it. |
-| Visibility logic | **CSS-only media query** | No new JS file; consistent with issue's "or pure CSS media query if no JS needed" preference. |
-| iOS safe-area | **Respect `env(safe-area-inset-bottom)`** | Standard bottom-nav requirement on iPhones with home indicator. Adds bottom padding inside the nav so labels don't sit under the indicator. |
-| Z-index | **Above main content, below modal overlays** | Use a single SCSS variable (e.g. `$z-bottom-nav: 50`) introduced alongside the partial. |
-| Breakpoint | **`max-width: 767px`** (matches `min-width: 768px` desktop boundary used elsewhere) | Aligns with the codebase's de facto mobile breakpoint, not the `641px` example in the issue. |
+| Topology source | **Derive from existing `**Handoff triggers**` prose** (lines 56, 72, 88, 104) | Single source of truth; no new routing decisions invented in this PR. |
+| General Agent topology | **Terminal — `_(terminal — handles work end-to-end)_`** | General Agent is the cross-cutting / refactor catch-all; once it owns work, it ships it. Keeps the graph minimal. |
+| Section placement | **New top-level `## Handoff Graph` between `## Agent Roster` and `## Protected Files`** | Adjacent to the personas it describes; readers see the graph immediately after meeting the personas. |
+| Row placement inside each persona | **Add as a new row in the existing property table** (above `**Handoff triggers**` prose where present) | Keeps structured info in the table; prose paragraph below explains *when* the transfer happens. |
+| Diagram syntax | **`graph LR` Mermaid block** | Per issue AC; horizontal layout reads better at typical viewing widths than `graph TD` for a 5-node graph. |
+| Diagram node labels | **Short persona names** ("Creative Director", "QA Gatekeeper", etc.) — no labels/abbreviations | Matches the persona headings; avoids a separate legend. |
+| Terminal node visual | **Distinct node shape** `GeneralAgent(["General Agent"])` (rounded rectangle) vs default rectangle for others | Visually signals terminal status without needing a legend; falls back gracefully if shape is unsupported. |
 
 ---
 
-## 4. Acceptance Criteria
+## 4. Handoff Topology (derived from existing prose)
 
-- [ ] **AC-1** At a 375×667 viewport, every page renders a fixed bottom `<nav class="bottom-nav" aria-label="Primary mobile navigation">` containing Home / Blog / Search.
-- [ ] **AC-2** At a 1024×768 viewport, `.bottom-nav` is `display: none` (asserted via Playwright computed-style check, not just visual).
-- [ ] **AC-3** Each link is icon + label stacked vertically; tap-target is **≥ 44×44 px** (WCAG 2.5.8 target size minimum). Icons are inline SVG with `aria-hidden="true"`; the link's accessible name comes from the text label.
-- [ ] **AC-4** When the current page matches a nav destination (`page.url == '/'`, starts with `/blog/`, or starts with `/search/`), that link receives `class="is-active"` and is styled with brand-red accent + `aria-current="page"`.
-- [ ] **AC-5** iOS safe-area: the nav uses `padding-bottom: max($spacing-xs, env(safe-area-inset-bottom))` so labels clear the home indicator on notched iPhones.
-- [ ] **AC-6** All colours, spacing, typography, and the new `$z-bottom-nav` variable come from `_sass/economist-theme.scss` (or `_sass/variables.scss`). **Zero hardcoded hex codes, px values, or font-family strings** in the new `.bottom-nav` rules.
-- [ ] **AC-7** `pa11y-ci` passes on `/` and `/blog/` at mobile viewport. No new violations introduced.
-- [ ] **AC-8** Lighthouse mobile score on `/` does not regress vs. the most recent baseline run on `main`. Performance category specifically must not drop more than 1 point.
-- [ ] **AC-9** A new Playwright spec at `tests/playwright-agents/bottom-nav.spec.ts` covers: (a) visible at 375×667 with all three links present and correctly labelled, (b) hidden at 1024×768, (c) `is-active` + `aria-current="page"` applied when on `/blog/`, (d) tap-target ≥ 44×44 px on each link.
-- [ ] **AC-10** `bundle exec jekyll build` exits 0.
-- [ ] **AC-11** *(amended 2026-05-24 during BUILD — see Risks §10 row "Existing nav-locator regression")* Scope-guard boundary: `git diff --name-only main...HEAD` is — `_layouts/default.html`, `_sass/economist-theme.scss`, `tests/playwright-agents/bottom-nav.spec.ts`, `tests/playwright-agents/responsive.spec.ts` (one-line locator fix), and this `SPEC.md`. Five files. Zero changes to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`. No new JS file.
+| From | To | Source line in AGENTS.md |
+|---|---|---|
+| Creative Director | Editorial Chief | line 56 ("design change requires content edits") |
+| Creative Director | QA Gatekeeper | line 56 ("visual change requires CI/test updates") |
+| QA Gatekeeper | Creative Director | line 72 ("failing tests stem from a design regression") |
+| QA Gatekeeper | Editorial Chief | line 72 ("content error is caught in CI") |
+| Editorial Chief | Creative Director | line 88 ("post requires a new layout or styling") |
+| Editorial Chief | QA Gatekeeper | line 88 ("published post causes a build failure") |
+| Audience Researcher | Creative Director | line 104 ("layout or visual hierarchy changes") |
+| Audience Researcher | Editorial Chief | line 104 ("copy, headline, SEO, or internal-link improvements") |
+| Audience Researcher | QA Gatekeeper | line 104 ("accessibility, interaction, or regression-proofing work") |
+| General Agent | — (terminal) | No existing handoff prose; confirmed terminal 2026-05-24 |
+
+**Mermaid sketch:**
+
+```
+graph LR
+    CD[Creative Director] --> EC[Editorial Chief]
+    CD --> QA[QA Gatekeeper]
+    QA --> CD
+    QA --> EC
+    EC --> CD
+    EC --> QA
+    AR[Audience Researcher] --> CD
+    AR --> EC
+    AR --> QA
+    GA(["General Agent (terminal)"])
+```
 
 ---
 
-## 5. Commands
+## 5. Acceptance Criteria
+
+- [ ] **AC-1** Each of the five persona blocks (`### 1. Creative Director` through `### 5. General Agent`) gains a `**Valid handoff targets:**` row.
+- [ ] **AC-2** `grep -c "Valid handoff targets" AGENTS.md` returns exactly `5`.
+- [ ] **AC-3** A new top-level `## Handoff Graph` section exists between `## Agent Roster` and `## Protected Files`, containing a Mermaid `graph LR` code fence.
+- [ ] **AC-4** The Mermaid graph encodes exactly the 9 edges in §4 plus the terminal General Agent node.
+- [ ] **AC-5** General Agent's row reads `**Valid handoff targets:** _(terminal — handles work end-to-end)_` — no empty target sets.
+- [ ] **AC-6** `bundle exec jekyll build` exits 0.
+- [ ] **AC-7** The Mermaid diagram renders on the local dev server (visual check at `http://localhost:4000/agents/` or wherever AGENTS.md is exposed; if AGENTS.md is not rendered as a Jekyll page, confirm Markdown renders correctly on GitHub by viewing the PR diff).
+- [ ] **AC-8** No persona's existing `**Handoff triggers**:` prose paragraph is removed — the new row supplements, not replaces, the prose.
+
+---
+
+## 6. Files to Change
+
+| File | Change |
+|---|---|
+| `AGENTS.md` | (a) Insert `**Valid handoff targets:**` row into each of the five persona property tables. (b) Insert new `## Handoff Graph` section after line ~120 (end of roster) with the Mermaid block. |
+
+**Total scope:** 1 file, ≈ 25 line insertions (5 rows + ~20-line Mermaid section).
+
+---
+
+## 7. Commands
 
 ```bash
-# Inspect baseline
-grep -n "site-nav\|nav-toggle\|page-header" _layouts/default.html
-grep -nE "@media.*(min-width|max-width)" _sass/economist-theme.scss | head
-grep -nE "\$spacing-|\$font-|\$z-" _sass/economist-theme.scss | head
+# Validation (run before opening PR)
+bundle exec jekyll build              # AC-6
+grep -c "Valid handoff targets" AGENTS.md  # AC-2: expect 5
+grep -c "## Handoff Graph" AGENTS.md       # expect 1
 
-# Local dev loop
-bundle exec jekyll serve --config _config.yml,_config_dev.yml &
-
-# Visual verification at mobile + desktop
-open "http://localhost:4000/"           # then DevTools → iPhone SE (375×667)
-open "http://localhost:4000/blog/"      # confirm active-state on /blog/
-
-# Tests
-npx playwright test tests/playwright-agents/bottom-nav.spec.ts
-npx playwright test                      # full sweep — confirm no regression
-npm run test:a11y                        # pa11y-ci on / and /blog/
-
-# Build gate
-bundle exec jekyll build
+# Local preview (AC-7)
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
+# Open http://localhost:4000/ — confirm no build regressions
 ```
 
 ---
 
-## 6. Project Structure (touched files)
+## 8. Code Style
 
-```
-_layouts/default.html                              # M — add <nav class="bottom-nav"> block after </main> or before </body>
-_sass/economist-theme.scss                         # M — append .bottom-nav rules; introduce $z-bottom-nav variable
-tests/playwright-agents/bottom-nav.spec.ts         # A — new spec covering AC-2, AC-3, AC-4, AC-9
-```
-
-No new SCSS partial files (the issue notes a "new `.bottom-nav` partial" but the repo's convention is one `economist-theme.scss` monolith — append, don't split). No new JS file. No new asset files (SVG icons are inline in the template).
+- **No prose deletion** from existing persona blocks — the new row supplements the existing `**Handoff triggers**:` paragraph.
+- **Match existing table format** — each persona's property table uses `| Property | Value |` headers; add `**Valid handoff targets:**` as a new row with comma-separated linked persona names.
+- **Cross-link with anchor refs** where possible — e.g., `[Editorial Chief](#3-editorial-chief)` to make the row navigable.
+- **Mermaid code fence** uses ```` ```mermaid ```` (Jekyll's mermaid-jekyll plugin convention).
+- **No new variables, no `_config.yml` changes**, no governance surface (`.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`) touched.
 
 ---
 
-## 7. Code Style
+## 9. Testing Strategy
 
-- **SCSS:** Append the `.bottom-nav` block at the bottom of `_sass/economist-theme.scss` (the file is monolithic by convention). Wrap mobile-only rules in `@media (max-width: 767px) { ... }`; the default state of `.bottom-nav` outside the query is `display: none`.
-- **Variables only:** every colour, spacing, font, and z-index value comes from a `$variable`. If a needed token does not exist (e.g. `$z-bottom-nav`), add it at the top of the file in the same `// Z-index` section as any existing z-index tokens (or create the section if none exists).
-- **HTML:** the new `<nav>` lives in `_layouts/default.html`, inserted **after** the `<footer>` close (line 89) and **before** the navigation `<script>` block (line 90). Use 2-space indentation matching the surrounding template.
-- **Liquid active-state pattern:**
-  ```liquid
-  {% assign p = page.url %}
-  <a href="{{ '/' | relative_url }}"
-     class="bottom-nav__link{% if p == '/' %} is-active{% endif %}"
-     {% if p == '/' %}aria-current="page"{% endif %}>
-  ```
-  Apply the equivalent `contains` check for `/blog/` and `/search/`.
-- **Inline SVG icons:** match the style of the existing RSS icon at `_layouts/default.html:47` (24×24 viewBox, `currentColor`, `aria-hidden="true"`). Source from Heroicons outline set (MIT licensed) — Home `home`, Blog `newspaper`, Search `magnifying-glass`. Inline the SVG; do not link external icon files.
-- **Comments:** one short `<!-- Mobile bottom nav (#953) -->` marker before the `<nav>` block. No multi-paragraph comments. No commit refs.
+| Layer | Check |
+|---|---|
+| Static | `grep -c "Valid handoff targets" AGENTS.md` == 5 (AC-2) |
+| Static | `grep -c "## Handoff Graph" AGENTS.md` == 1 |
+| Build | `bundle exec jekyll build` exits 0 (AC-6) |
+| Visual | Local dev server preview confirms Mermaid renders without errors (AC-7) |
+| Cross-check | Each edge in the Mermaid graph is reflected by existing `**Handoff triggers**:` prose (AC-4, AC-8) |
+
+No new Playwright spec required — this is a docs-only change with no runtime UI surface. CI will exercise existing build + accessibility + Lighthouse gates on the change.
 
 ---
 
-## 8. Testing Strategy
+## 10. Boundaries
 
-1. **Local Playwright first.** Run `tests/playwright-agents/bottom-nav.spec.ts` standalone, then the full sweep against `bundle exec jekyll serve`. Both must exit 0 before pushing.
-2. **Viewport assertions are computed-style based, not visual.** Avoid screenshot baselines for this spec — they're brittle at the breakpoint boundary and we already have visual coverage from existing Playwright shard 3. Assert `display: none` vs `display: flex` (or whatever the implementation uses) via `evaluate(el => getComputedStyle(el).display)`.
-3. **Active-state coverage:** test the `/blog/` route specifically; that's the path most likely to regress because of the `contains` prefix match (must match `/blog/` and `/blog/some-post/` but **not** `/blog-archive/` if that path is ever added).
-4. **Tap-target measurement:** use Playwright `boundingBox()` and assert `width >= 44 && height >= 44`. Done per-link, not once for the nav container.
-5. **pa11y-ci is a hard gate** — any new violation at `/` or `/blog/` at mobile viewport fails the AC. Run locally before pushing if there's any doubt.
-6. **Lighthouse regression check is a one-time manual gate** — the most recent main-branch Lighthouse run is the baseline; compare via the CI report on the PR.
-7. **No unit tests** — this is template + SCSS + one integration spec. No business logic to unit-test.
+**Always:**
+- Derive the handoff topology from existing prose; don't invent new routing rules.
+- Preserve existing `**Handoff triggers**:` prose paragraphs verbatim.
+- Run `bundle exec jekyll build` before pushing.
 
----
+**Ask first about:**
+- Adding any new handoff edge not implied by existing prose.
+- Changing the General Agent terminal status (currently confirmed terminal).
+- Moving the `## Handoff Graph` section to a different location than between `## Agent Roster` and `## Protected Files`.
 
-## 9. Boundaries
-
-**Always do:**
-- Use design-system variables for every value (AC-6 is non-negotiable).
-- Keep diff at ≤ 3 files (AC-11).
-- Test active-state on `/blog/` specifically.
-- Match `aria-current="page"` to the `.is-active` class — they must always agree.
-- Respect `env(safe-area-inset-bottom)` on iOS (AC-5).
-
-**Ask first:**
-- If a needed design token doesn't exist and you're tempted to inline a value — propose the new variable and where it should live before adding it.
-- If the Lighthouse mobile baseline regresses by more than 1 performance point — investigate root cause before re-baselining.
-- If the existing top hamburger nav needs any tweak (it shouldn't — but if e.g. `body` padding-bottom collides with bottom nav at mobile, surface it).
-- If a fourth touched file becomes necessary, surface the reason in the PR description and reassess scope.
-
-**Never do:**
-- Modify `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`.
-- Add a new JS file or extend `_layouts/default.html`'s existing `<script>` block — CSS-only is the agreed implementation.
-- Change the top hamburger nav's markup, styles, or behaviour.
-- Add analytics tracking to bottom-nav clicks (out of scope per issue).
-- Add a "Recently viewed" or personalisation slot to the nav (Watch item in #943).
-- Add a feature flag in `_config.yml` to gate rollout (protected file). If rollout caution is needed, gate via an SCSS feature class instead.
-- Use icon-only links (worse accessibility — confirmed during design decision).
-- Use `--no-verify` or otherwise skip hooks.
-- Use the `bulk-content` or `governance-update` label (this PR is neither).
+**Never:**
+- Modify the persona roster itself (additions, removals, renames). [Out of scope per #946]
+- Modify handoff *triggers* — only document the graph, not the conditions. [Out of scope per #946]
+- Touch `.github/skills/`, `.github/instructions/`, or `.github/copilot-instructions.md` — those are governance surfaces under `governance-update` label conventions. [Out of scope per #946]
+- Add cross-repo or cross-org A2A protocol integration. [No-op in #902]
+- Touch any protected file (`_config.yml`, `.github/CODEOWNERS`, `Gemfile`, `Gemfile.lock`).
 
 ---
 
-## 10. Risks & Mitigations
+## 11. Risks
 
-| Risk | Likelihood | Mitigation |
-|---|---|---|
-| Bottom nav overlaps last paragraph of long posts on mobile | High | Add `padding-bottom` to `.main-content` at mobile widths equal to bottom-nav height + safe-area inset. Verify on a long post like the devops-defences article. |
-| Active-state prefix match collides with a future `/blog-archive/`-style route | Low | Match `/blog/` with a trailing-slash-aware check (`p == '/blog/' or p contains '/blog/'`) not a loose `contains '/blog'`. |
-| pa11y-ci flags contrast on the active-state accent | Medium | Use `$brand-red` (or equivalent existing token) for accent and verify WCAG AA contrast against the nav background colour before pushing. |
-| Inline SVG icons inflate `default.html` page weight noticeably | Low | Three 24×24 outline SVGs ≈ 0.5 KB total; well below Lighthouse perf-budget noise floor. |
-| Lighthouse mobile drops because of layout shift introduced by the fixed nav | Low-medium | Reserve nav height via `height` + `min-height` on the element from the first paint — do not animate in. CLS budget is 0.1. |
-| Existing tests use an over-broad `nav` locator that now resolves to multiple elements | **Realised 2026-05-24** | `responsive.spec.ts:145` "Navigation menu adapts to viewport size" failed via Playwright strict-mode after the second `<nav>` landed. Fixed by scoping the locator to `.site-nav` (the test was always intended for the top hamburger nav). AC-11 amended to include the test fix + this SPEC.md as a 4th and 5th touched file. |
+| Risk | Mitigation |
+|---|---|
+| Mermaid plugin not actually loaded → diagram renders as a code block, not a graph | Verify with `bundle exec jekyll serve` locally before pushing; if unsupported, fall back to a plain Markdown table representing the edges (AC-3/AC-4 would need amending). |
+| AGENTS.md table format varies across personas (verified in §1 — five tables share `\| Property \| Value \|` header) | Audit each table during BUILD; if any deviates, normalise as part of this PR scope. |
+| Reviewer requests `graph TD` instead of `graph LR` | Trivial swap; ack and update. |
+| Future persona added without updating the graph | Out of scope for this PR — but the new structured row makes the gap detectable by a future grep-based CI check (potential follow-up). |
 
 ---
 
-## 11. Out of Scope (deferred)
+## 12. Out of Scope
 
-- Top-nav hamburger redesign — leave the existing top nav untouched.
-- Adding analytics tracking to bottom-nav clicks (separate decision).
-- Personalisation / "Recently viewed" — Watch item in [#943](https://github.com/oviney/blog/issues/943).
-- Feature flag in `_config.yml` — protected file; gate via SCSS class if rollout caution is later needed.
-- Changing what destinations live in the bottom nav (Home / Blog / Search is the agreed initial set).
-- Adding hide-on-scroll behaviour — adds JS, contradicts CSS-only decision.
-- Migrating `_sass/economist-theme.scss` into smaller partials — separate refactor.
+Per issue #946:
+
+- Changing the persona roster (additions, removals, renames)
+- Modifying handoff *triggers* (only documenting the graph, not the conditions)
+- Touching `.github/skills/`, `.github/instructions/`, or `.github/copilot-instructions.md`
+- Cross-repo or cross-org A2A protocol integration (No-op in #902)
+- A CI check that lints the handoff graph against the prose (a sensible follow-up, but not in this PR)

--- a/tasks/archive/2026-05-24-playwright-947/plan.md
+++ b/tasks/archive/2026-05-24-playwright-947/plan.md
@@ -1,0 +1,304 @@
+# Plan — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
+
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#947](https://github.com/oviney/blog/issues/947)
+**Date:** 2026-05-17
+**Lifecycle phase:** PLAN
+**Plan SHA:** `6480f00`
+
+---
+
+## Anchors confirmed at this SHA
+
+- **Current pin:** `package.json` line referencing `"@playwright/test": "^1.59.1"` (devDependencies section).
+- **ARIA-snapshot call-sites:** exactly 3, audited via `grep -rn "toMatchAriaSnapshot" tests/`.
+  - `tests/playwright-agents/homepage.spec.ts:192` — `page.locator('main').first()` → **migrate to page-level** (per SPEC §1 table).
+  - `tests/playwright-agents/navigation.spec.ts:96` — `page.locator('main article').first()` → **keep element-scoped**, add rationale comment.
+  - `tests/playwright-agents/navigation.spec.ts:460` — `page.locator('#site-navigation')` → **keep element-scoped**, add rationale comment.
+- **Skill doc edit point:** `.github/skills/jekyll-qa/SKILL.md:40` reads `` - `@playwright/test ^1.59.1` ``. Surrounding lines 41-43 list `pa11y-ci`, `lighthouse`, `lodash override` — the `test.abort()` note belongs after line 40 as a sub-bullet.
+- **Open Dependabot PR #959** mutates exactly `package.json` (+1/-1) and `package-lock.json` (+12/-12). CI is **green** on its current head. We will close it as part of T8 once our PR opens — not earlier (per SPEC §10 "ask first / never do" — closing late avoids a window with no PR open for the bump).
+- **No `tests/playwright-agents/footer.spec.ts` exists** — `ls tests/playwright-agents/*footer*` returns nothing. SPEC §1 already records this. No new file is added by this PR.
+- **`.github/workflows/auto-regression.yml`** triggers on `issues: labeled` (line 3-5) and does **not** run `npm ci` or `npx playwright test` (only `git add tests/playwright-agents/regression/` at line 147). See **Spec Amendment Proposal** below.
+
+---
+
+## Spec Amendment Proposal — AC-4 (raise before BUILD)
+
+**SPEC §3 AC-4 currently reads:** *"`.github/workflows/test-quality.yml` AND `.github/workflows/auto-regression.yml` pass green on a single PR run."*
+
+**Problem:** `auto-regression.yml` triggers exclusively on `issues: labeled` events (specifically when `production` or `bug` is applied to an issue already carrying the other label). It does not run on `pull_request` or `push` — it physically cannot fire on this PR. It also does not install or invoke Playwright; it only generates new test scaffolding files and commits them. The Playwright minor bump has **zero runtime impact** on this workflow.
+
+**Proposed amendment to AC-4:** *"`.github/workflows/test-quality.yml` passes green on a single PR run. `auto-regression.yml` is verified by inspection (it does not install or run Playwright at runtime; it only writes test files that depend on the lockfile-installed version, which is exercised by test-quality.yml shards). No retry tolerated for Playwright-shaped failures; one retry tolerated for the puppeteer Chrome-cache flake pattern from #958."*
+
+**Decision needed before BUILD:** confirm this amendment, or specify an alternate verification path (e.g., labeling a sentinel issue post-merge to fire the workflow once). My recommendation: accept the amendment — adding `workflow_dispatch` to `auto-regression.yml` would be scope creep, and labeling a sentinel issue produces a real PR that we'd then have to clean up.
+
+---
+
+## Context
+
+5 files net at most (per SPEC AC-8): `package.json`, `package-lock.json`, `tests/playwright-agents/homepage.spec.ts`, `tests/playwright-agents/navigation.spec.ts`, `.github/skills/jekyll-qa/SKILL.md`. Well under the 15-file scope-explosion limit; **no `bulk-content` label needed**.
+
+The risk profile is dominated by **snapshot drift on the migrated test**. Element-scoped `main` snapshot today is 22 lines; page-level will include `banner`, `navigation`, and `contentinfo` landmarks above and below the existing `main` block. The exact text is something Playwright generates via `--update-snapshots` and we review. The plan accommodates a non-trivial diff in `homepage.spec.ts:192` — that's the expected outcome, not a regression.
+
+There is no separate baseline file to manage; ARIA snapshots are **inline template literals** in the spec file. `--update-snapshots` rewrites the literal in place. Git diff carries the entire change.
+
+The migration is one-directional (page-level is strictly more inclusive than element-scoped); if the new snapshot is unstable we narrow it back rather than reverting the API form.
+
+---
+
+## Dependency graph
+
+```
+T1 (bump @playwright/test ^1.60.0 in package.json + regenerate package-lock.json)
+  │
+  ├──► T2 (homepage.spec.ts:192 → page-level snapshot, regenerate baseline, review diff)
+  │       │
+  │       ▼
+  │     (proves the new API works against a live Jekyll server)
+  │
+  ▼
+T3 (navigation.spec.ts:96 + :460 → add `// element-scoped: …` rationale comments)
+  │
+  ▼
+T4 (.github/skills/jekyll-qa/SKILL.md line 40 → ^1.60.0 + test.abort() note)
+  │
+  ▼
+T5 (local full sweep: npx playwright test against bundle exec jekyll serve; AC-8 boundary check)
+  │
+  ▼
+CHECKPOINT-A — local gate (all 5 files modified within scope, full Playwright suite green locally)
+  │
+  ▼
+T6 (/review via code-reviewer agent — focus on snapshot diff legibility, AC-3 rationale soundness)
+  │
+  ▼
+T7 (apply review revisions; commit)
+  │
+  ▼
+T8 (push branch; close Dependabot PR #959 with supersede comment; open PR with snapshot-diff narrative + AC-7 narrative)
+  │
+  ▼
+T9 (CI passes — test-quality.yml all shards green; one puppeteer-cache retry tolerated, zero Playwright-shaped retries)
+  │
+  ▼
+T10 (admin-merge after CI green; sync local main)
+```
+
+T1 is the prerequisite for everything (the new API surface only exists post-bump). T2 is the only behavior-changing edit; the rest is documentation + comments. T5 is the local gate. T6 is the lifecycle review-phase requirement. There is no post-merge verification task — unlike #958 (which needed real-CI cache logs), all #947 ACs are observable on the PR itself.
+
+---
+
+## Phase 1 — Version bump
+
+### T1 — Bump `@playwright/test` to `^1.60.0`
+
+**ACs satisfied:** AC-1 (pin), AC-2 (lockfile regen)
+**Touches:** `package.json`, `package-lock.json`
+
+**Steps:**
+
+1. From a clean working tree, branch off `main`: `git switch -c feat/playwright-1.60-aria-snapshots`. (Branch name follows the prefix convention of recent PRs: `feat/…`, `chore/…`.)
+2. Edit `package.json`: change the `"@playwright/test": "^1.59.1"` line to `"@playwright/test": "^1.60.0"`. Do not touch any other field.
+3. Run `npm install` (not `npm ci` — the lockfile is mid-regeneration). Confirm `node_modules/@playwright/test/package.json` reports `"version": "1.60.x"`.
+4. Run `npm ls @playwright/test` → expect a `1.60.x` line. No `UNMET` or peer-dep warnings introduced.
+5. Verify the lockfile diff is bounded: `git diff --stat package-lock.json` should show changes confined to `@playwright/test` and its hoisted deps (playwright core, playwright-core). Any drift outside that subtree gets investigated before T2 — a broader lockfile rewrite indicates an npm version mismatch with whoever last regenerated the lockfile, and we'd want a clean `--prefer-offline` re-install to match.
+
+**Verify (mechanical):**
+- `grep -c '"@playwright/test": "\^1.60' package.json` → `1`
+- `npm ls @playwright/test 2>&1 | grep -c '1\.60\.'` → `≥ 1`
+- `git diff --stat | head -3` reports two files: `package.json` (+1/-1), `package-lock.json` (modest diff).
+
+---
+
+## Phase 2 — Snapshot migration
+
+### T2 — Migrate `homepage.spec.ts:192` to page-level snapshot
+
+**ACs satisfied:** AC-3 (full)
+**Touches:** `tests/playwright-agents/homepage.spec.ts`
+
+**Steps:**
+
+1. Open `tests/playwright-agents/homepage.spec.ts` to the "Homepage main landmark matches ARIA smoke snapshot" test (line ~188-216).
+2. Replace `await expect(page.locator('main').first()).toMatchAriaSnapshot(...)` with `await expect(page).toMatchAriaSnapshot(...)`.
+3. Update the test title to reflect the new scope: `'Homepage page-level landmarks match ARIA smoke snapshot'` (so a future reader knows the scope is page, not `main`). Tag preservation: do not change `@content @navigation Homepage Redesign @REQ-CONTENT-01 @REQ-VISUAL-01` — those tags are how the shard 1 selector finds this test.
+4. Start `bundle exec jekyll serve --config _config.yml,_config_dev.yml` in a background terminal (port 4000). Wait for `Server running... press ctrl-c to stop.`
+5. Run `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks" --update-snapshots`. This rewrites the inline template literal in place with the page's full accessibility tree.
+6. **Manual diff review** of the regenerated snapshot — this is the load-bearing human-judgment step:
+   - Should include `banner` (header), `navigation` (already in the old snapshot's parent), original `main` block, `contentinfo` (footer), and possibly `complementary` if newsletter landmark spans outside `main`.
+   - Watch for dynamic content leaking in: build-date footers, copyright year, post-count badges, anything keyed on `site.time`. Replace each with the existing `/.+/` regex placeholder pattern (already used at line 194-196 for the heading).
+   - Watch for screen-reader-only text becoming visible in the snapshot — accessibility tree includes `aria-label` content, so a label like `aria-label="Skip to main content"` will appear as `link "Skip to main content"`.
+7. Re-run without `--update-snapshots` to confirm stability: `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks"`. Must exit `0` with no diff prompt.
+
+**Verify (mechanical):**
+- `grep -c "expect(page).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `1`
+- `grep -c "expect(page.locator('main').first()).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `0`
+- Test passes against a live server, without `--update-snapshots`, on two consecutive runs (proves the snapshot is stable, not a one-shot capture).
+
+**Risk:** if the page-level snapshot picks up unstable content that resists `/.+/` placeholders, narrow it back — keep the `expect(page)` form but use a `boxes: false` option or wrap a single template literal with strategic `/.*/` placeholders. **Do not revert to element-scoped.** If narrowing fails, escalate to spec amendment (the migration would then move to follow-up work).
+
+---
+
+### T3 — Annotate the two element-scoped sites with `// element-scoped:` rationale
+
+**ACs satisfied:** AC-3 (rationale-comment portion)
+**Touches:** `tests/playwright-agents/navigation.spec.ts`
+
+**Steps:**
+
+1. Above the snapshot at `navigation.spec.ts:96`, insert a one-line comment:
+   `// element-scoped: deliberately narrow to the article landmark — page-level would balloon the snapshot with site chrome (#947).`
+2. Above the snapshot at `navigation.spec.ts:460`, insert a one-line comment:
+   `// element-scoped: mobile-nav-open assertion checks the nav landmark in its open state; page-level would dilute the assertion (#947).`
+3. Do not modify the snapshot template literals themselves.
+
+**Verify (mechanical):**
+- `grep -cE "^\s*// element-scoped:" tests/playwright-agents/navigation.spec.ts` → `2`
+- `npx playwright test tests/playwright-agents/navigation.spec.ts -g "ARIA smoke snapshot"` still passes (the comments are no-ops at runtime; this just guards against accidental edits).
+
+---
+
+## Phase 3 — Docs
+
+### T4 — Update `.github/skills/jekyll-qa/SKILL.md`
+
+**ACs satisfied:** AC-6
+**Touches:** `.github/skills/jekyll-qa/SKILL.md`
+
+**Steps:**
+
+1. Open `.github/skills/jekyll-qa/SKILL.md`. Locate line 40: `` - `@playwright/test ^1.59.1` ``.
+2. Replace the version: `` - `@playwright/test ^1.60.0` `` (bumped from ^1.59.1 in #947 — adds page-level `expect(page).toMatchAriaSnapshot()`, `test.abort()`, HAR-on-tracing, `locator.drop()`)
+3. Below this line, add a sub-bullet:
+   `` - `test.abort()` (Playwright 1.60+) is available for "tests must not call X" guardrails (issue #947) ``
+4. Do not edit any other line, do not introduce trailing whitespace, do not reflow surrounding bullets.
+
+**Verify (mechanical):**
+- `grep -n '@playwright/test \^1' .github/skills/jekyll-qa/SKILL.md` → exactly one match, reading `^1.60.0`.
+- `grep -n 'test.abort()' .github/skills/jekyll-qa/SKILL.md` → at least one match referencing #947.
+- `git diff --stat .github/skills/jekyll-qa/SKILL.md` → small diff, single hunk.
+
+---
+
+## Phase 4 — Local verification
+
+### T5 — Full Playwright sweep + scope-guard boundary check
+
+**ACs satisfied:** AC-4 (test-quality side, see Spec Amendment Proposal above), AC-5 (full local sweep), AC-8 (file boundary)
+**Touches:** none (read-only verification)
+
+**Steps:**
+
+1. With `bundle exec jekyll serve --config _config.yml,_config_dev.yml` still running on `:4000`:
+   - `npm run test:playwright:shard1` — Navigation & Mobile (covers the `navigation.spec.ts` element-scoped snapshots)
+   - `npm run test:playwright:shard2` — Content, Search & Links (covers the migrated `homepage.spec.ts` snapshot, since `homepage.spec.ts` carries `@REQ-CONTENT-01`)
+   - `npm run test:playwright:shard3` — Accessibility, Visual & Performance
+2. Full sweep as a tiebreaker: `npx playwright test`. Must exit `0`.
+3. AC-8 boundary check: `git diff --name-only main...HEAD` returns **only**:
+   ```
+   .github/skills/jekyll-qa/SKILL.md
+   package-lock.json
+   package.json
+   tests/playwright-agents/homepage.spec.ts
+   tests/playwright-agents/navigation.spec.ts
+   ```
+   5 files exactly. Zero entries under `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`.
+4. **No new files created.** `git status --short` shows only `M` markers (and the existing untracked `specs/copilot-skills-agents-redesign-spec.md`, unrelated).
+
+---
+
+### CHECKPOINT-A — Local gate before /review
+
+**Gate criteria (all must be true before T6):**
+
+- [ ] T1: `package.json` pinned at `^1.60.0`; `npm ls @playwright/test` reports `1.60.x`.
+- [ ] T2: `homepage.spec.ts:192` uses `expect(page).toMatchAriaSnapshot` and passes twice consecutively without `--update-snapshots`.
+- [ ] T3: Two `// element-scoped:` rationale comments present in `navigation.spec.ts`.
+- [ ] T4: `SKILL.md` line ~40 reads `^1.60.0`; `test.abort()` note recorded.
+- [ ] T5: All three Playwright shards pass; full sweep passes; AC-8 boundary is exactly the 5 expected files.
+
+---
+
+## Phase 5 — REVIEW
+
+### T6 — `/review` via code-reviewer agent
+
+**ACs satisfied:** lifecycle requirement (not a specific spec AC)
+**Touches:** none (read-only review)
+
+**Brief the reviewer on:**
+- The AC-3 judgment call — 1 of 3 snapshots migrated; the other two kept element-scoped with rationale comments. Reviewer's job is to validate the rationale, not the mechanical change.
+- The regenerated page-level snapshot text in `homepage.spec.ts` — is it stable, are the `/.+/` placeholders covering the right dynamic content, is the test name still accurate?
+- AC-4 spec amendment (auto-regression doesn't run on PRs / doesn't install Playwright) — does the reviewer agree the inspection-based verification is sufficient?
+- That `test.abort()` is documented but not adopted in any test (intentional — separate authoring work).
+- The branch superseding Dependabot PR #959 — call out the closing strategy (close at T8, not earlier).
+
+**Expected findings shape:** Major (snapshot stability / placeholder coverage), Minor (rationale comment wording, test rename), Nit (commit-message hygiene).
+
+---
+
+### T7 — Apply review revisions
+
+**ACs satisfied:** finishes any open AC items raised by /review.
+**Touches:** depends on review findings; expect at most the same 5 files.
+
+**Hard rule:** if `/review` asks for changes that would push the diff beyond the 5-file scope, stop and escalate to spec amendment rather than silently expanding scope.
+
+---
+
+## Phase 6 — Ship
+
+### T8 — Push branch; close #959; open PR
+
+**ACs satisfied:** AC-7 (PR description content)
+**Touches:** git remote, GitHub PR state.
+
+**Steps:**
+
+1. `git push -u origin feat/playwright-1.60-aria-snapshots`.
+2. `gh pr create --repo oviney/blog --label "agent:qa-gatekeeper" --title "feat(tests): bump @playwright/test to ^1.60.0 + page-level ARIA snapshot on homepage (#947)"` with body containing:
+   - Closes #947
+   - Supersedes #959 (Dependabot lockfile-only bump)
+   - Spec amendment note for AC-4 (auto-regression workflow trigger surface)
+   - Rationale for keeping 2 of 3 ARIA snapshots element-scoped (one paragraph per call-site)
+   - Snapshot diff narrative — what new landmarks the page-level snapshot picked up, what `/.+/` placeholders were added
+   - Local verification evidence (3 shards + full sweep, all green)
+3. **Then** close #959: `gh pr close 959 --repo oviney/blog --comment "Superseded by PR #<new> — single atomic bundle of lockfile, snapshot migration, and skill doc update per SPEC #947."`
+
+**Order matters:** open the new PR first, then close #959. The opposite order leaves the repo with no open bump PR for the window between commands.
+
+---
+
+### T9 — CI passes
+
+**ACs satisfied:** AC-4 (test-quality side)
+**Touches:** none.
+
+**Steps:**
+
+1. Wait for Quality Tests workflow (Playwright shards 1+2+3) to complete on the PR.
+2. **Retry policy:** zero Playwright-shaped retries. One puppeteer Chrome-cache retry is tolerated only if the failure stack matches the pattern from #958 (the composite action's retry-wrapped `npm ci` should make this nearly impossible after the first run, but if cold-cache hits and the retry-loop genuinely fires, that's a tolerated outcome — log it in the PR comments).
+3. If any Playwright-shaped failure occurs: do **not** retry. Investigate the diff, fix locally, push a follow-up commit.
+
+---
+
+### T10 — Admin-merge
+
+**ACs satisfied:** none new — closes the lifecycle.
+**Touches:** main branch.
+
+**Steps:**
+
+1. `gh pr merge <new-PR> --repo oviney/blog --admin --squash --delete-branch`.
+2. `git switch main && git pull origin main`. Confirm local `main` carries the merge commit and `git status` is clean.
+3. Archive the lifecycle artifacts: `mkdir -p tasks/archive/2026-05-17-playwright-1.60-947 && git mv SPEC.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/plan.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/todo.md tasks/archive/2026-05-17-playwright-1.60-947/` (in a one-line cleanup commit on a follow-up branch, or in the same PR if archive-on-ship is the convention — confirm with maintainer; #958's lifecycle artifacts were archived in the next session, not the same PR).
+
+---
+
+## Definition of Done
+
+- [ ] All 8 SPEC §3 ACs satisfied (AC-4 satisfied per the amended wording proposed above, assuming the user accepts the amendment).
+- [ ] PR description records the AC-7 narrative (snapshot rationale, #959 supersedure, #944 unblock).
+- [ ] `gh pr view <new> --json statusCheckRollup` shows all required checks green; merged via admin-squash.
+- [ ] Local `main` synced post-merge; lifecycle artifacts archived (in this PR or a follow-up cleanup commit).
+- [ ] No follow-up issue needed — `test.abort()` adoption and HAR tracing are explicitly deferred in SPEC §10 and require no tracking issue beyond what's already in #902 (Watch list).

--- a/tasks/archive/2026-05-24-playwright-947/todo.md
+++ b/tasks/archive/2026-05-24-playwright-947/todo.md
@@ -1,0 +1,47 @@
+# TODO — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Plan SHA:** `6480f00` · 5 files (0 new + 5 modified) · 1 snapshot migration + 2 rationale comments
+
+---
+
+## Spec amendment to confirm before BUILD
+- [x] **A1** AC-4 amendment accepted by user 2026-05-17 — `auto-regression.yml` verified by inspection (no Playwright runtime; `issues: labeled` trigger only). SPEC §3 AC-4 updated in place.
+
+## Phase 1 — Version bump
+- [x] **T1** ✅ Branch `feat/playwright-1.60-aria-snapshots` created. `package.json` pinned at `^1.60.0`. `npm install` clean (`changed 3 packages, 0 vulnerabilities`). `npm ls @playwright/test` → `1.60.0`; `playwright@1.60.0`; `playwright-core@1.60.0`. Lockfile diff bounded to the 3-package subtree (matches Dependabot #959 shape). Commit `3174891`.
+
+## Phase 2 — Snapshot migration
+- [x] **T2** ✅ `homepage.spec.ts:192` migrated to `expect(page).toMatchAriaSnapshot()`. Snapshot reduced to `- banner / - main / - contentinfo` landmark-presence smoke check. Navigation deliberately excluded (collapses to hamburger button on mobile; nav coverage stays in `navigation.spec.ts`). Inline comment documents trade-offs. Verified on Desktop/Mobile/Tablet Chrome + Desktop Firefox (Safari blocked locally by missing libwoff1/libavif16; CI has them). Full homepage.spec.ts: 11/11 pass on Desktop Chrome. Commit `73d0d8f`.
+- [x] **T3** ✅ Two `// element-scoped: …` rationale comments added above `navigation.spec.ts:99` (article snapshot) and `:466` (mobile-nav-open snapshot). Both tests still pass. Commit `530b611`.
+
+## Phase 3 — Docs
+- [x] **T4** ✅ SKILL.md line 40 bumped to `^1.60.0` with release-feature summary; `test.abort()` availability sub-bullet added (line 41). Commit `6943275`.
+
+## Phase 4 — Local verification
+- [x] **T5** ✅ Three Playwright shards green on 4 projects (Safari skipped locally — missing libwoff1/libavif16 system libs; CI has them): Shard 1 70/70, Shard 2 44/44, Shard 3 38/38. Full Desktop Chrome sweep 105/105. AC-8 boundary clean: 5 feature files modified (SKILL.md, package.json, package-lock.json, homepage.spec.ts, navigation.spec.ts) + 6 lifecycle files (1 SPEC.md modified, 2 new tasks/*, 3 archived #958 artifacts) — none in the protected set (`_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
+
+## CHECKPOINT-A — Local gate before /review
+- [x] ✅ All T1–T5 ACs satisfied. Working tree clean (only `specs/copilot-skills-agents-redesign-spec.md` untracked, unrelated). No protected files touched. Branch `feat/playwright-1.60-aria-snapshots` at HEAD `6943275` ready for /review.
+
+## Phase 5 — /review pass
+- [ ] **T6** Code-reviewer agent brief: AC-3 rationale (2-of-3 element-scoped), page-level snapshot stability, AC-4 amendment, `test.abort()` documented-but-unused.
+- [ ] **T7** Apply review revisions; commit. Hard rule: if revisions push the diff beyond 5 files, escalate to spec amendment rather than expand scope silently.
+
+## Phase 6 — Ship
+- [ ] **T8** `git push -u origin feat/playwright-1.60-aria-snapshots`; `gh pr create` with snapshot-diff narrative, AC-7 content (rationale + #959 supersedure + #944 unblock), `agent:qa-gatekeeper` label; **then** close Dependabot PR #959 with supersede comment.
+- [ ] **T9** CI green — zero Playwright-shaped retries; one puppeteer Chrome-cache retry tolerated per #958 pattern (and only if stack matches).
+- [ ] **T10** `gh pr merge --admin --squash --delete-branch` once green; `git switch main && git pull`; archive lifecycle artifacts under `tasks/archive/2026-05-17-playwright-1.60-947/`.
+
+---
+
+## Acceptance criteria checklist (mirrors SPEC §3)
+
+- [ ] **AC-1** `package.json` pins `@playwright/test ^1.60.0`
+- [ ] **AC-2** `package-lock.json` regenerated, `npm ls @playwright/test` reports `1.60.x`
+- [ ] **AC-3** `homepage.spec.ts:192` migrated to page-level; `navigation.spec.ts:96` + `:460` carry `// element-scoped:` rationale comments
+- [ ] **AC-4** *(amended)* `test-quality.yml` passes green on a single PR run; `auto-regression.yml` verified by inspection (no Playwright runtime)
+- [ ] **AC-5** `npx playwright test` exits `0` locally with live Jekyll server
+- [ ] **AC-6** `.github/skills/jekyll-qa/SKILL.md` line 40 → `^1.60.0` + `test.abort()` availability note
+- [ ] **AC-7** PR description records snapshot rationale, #959 closure, #944 unblock
+- [ ] **AC-8** `git diff --name-only main...HEAD` returns exactly 5 files (no protected-file diffs)

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,304 +1,174 @@
-# Plan — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
+# Plan — Make AGENTS.md handoff targets explicit + Mermaid graph (#946)
 
 **Spec:** [../SPEC.md](../SPEC.md)
-**Issue:** [#947](https://github.com/oviney/blog/issues/947)
-**Date:** 2026-05-17
+**Issue:** [#946](https://github.com/oviney/blog/issues/946)
+**Date:** 2026-05-24
+**Label:** `agent:qa-gatekeeper`
+**Branch:** `docs/946-agents-handoff-graph` (to be created)
 **Lifecycle phase:** PLAN
-**Plan SHA:** `6480f00`
 
 ---
 
-## Anchors confirmed at this SHA
+## Scope summary
 
-- **Current pin:** `package.json` line referencing `"@playwright/test": "^1.59.1"` (devDependencies section).
-- **ARIA-snapshot call-sites:** exactly 3, audited via `grep -rn "toMatchAriaSnapshot" tests/`.
-  - `tests/playwright-agents/homepage.spec.ts:192` — `page.locator('main').first()` → **migrate to page-level** (per SPEC §1 table).
-  - `tests/playwright-agents/navigation.spec.ts:96` — `page.locator('main article').first()` → **keep element-scoped**, add rationale comment.
-  - `tests/playwright-agents/navigation.spec.ts:460` — `page.locator('#site-navigation')` → **keep element-scoped**, add rationale comment.
-- **Skill doc edit point:** `.github/skills/jekyll-qa/SKILL.md:40` reads `` - `@playwright/test ^1.59.1` ``. Surrounding lines 41-43 list `pa11y-ci`, `lighthouse`, `lodash override` — the `test.abort()` note belongs after line 40 as a sub-bullet.
-- **Open Dependabot PR #959** mutates exactly `package.json` (+1/-1) and `package-lock.json` (+12/-12). CI is **green** on its current head. We will close it as part of T8 once our PR opens — not earlier (per SPEC §10 "ask first / never do" — closing late avoids a window with no PR open for the bump).
-- **No `tests/playwright-agents/footer.spec.ts` exists** — `ls tests/playwright-agents/*footer*` returns nothing. SPEC §1 already records this. No new file is added by this PR.
-- **`.github/workflows/auto-regression.yml`** triggers on `issues: labeled` (line 3-5) and does **not** run `npm ci` or `npx playwright test` (only `git add tests/playwright-agents/regression/` at line 147). See **Spec Amendment Proposal** below.
-
----
-
-## Spec Amendment Proposal — AC-4 (raise before BUILD)
-
-**SPEC §3 AC-4 currently reads:** *"`.github/workflows/test-quality.yml` AND `.github/workflows/auto-regression.yml` pass green on a single PR run."*
-
-**Problem:** `auto-regression.yml` triggers exclusively on `issues: labeled` events (specifically when `production` or `bug` is applied to an issue already carrying the other label). It does not run on `pull_request` or `push` — it physically cannot fire on this PR. It also does not install or invoke Playwright; it only generates new test scaffolding files and commits them. The Playwright minor bump has **zero runtime impact** on this workflow.
-
-**Proposed amendment to AC-4:** *"`.github/workflows/test-quality.yml` passes green on a single PR run. `auto-regression.yml` is verified by inspection (it does not install or run Playwright at runtime; it only writes test files that depend on the lockfile-installed version, which is exercised by test-quality.yml shards). No retry tolerated for Playwright-shaped failures; one retry tolerated for the puppeteer Chrome-cache flake pattern from #958."*
-
-**Decision needed before BUILD:** confirm this amendment, or specify an alternate verification path (e.g., labeling a sentinel issue post-merge to fire the workflow once). My recommendation: accept the amendment — adding `workflow_dispatch` to `auto-regression.yml` would be scope creep, and labeling a sentinel issue produces a real PR that we'd then have to clean up.
-
----
-
-## Context
-
-5 files net at most (per SPEC AC-8): `package.json`, `package-lock.json`, `tests/playwright-agents/homepage.spec.ts`, `tests/playwright-agents/navigation.spec.ts`, `.github/skills/jekyll-qa/SKILL.md`. Well under the 15-file scope-explosion limit; **no `bulk-content` label needed**.
-
-The risk profile is dominated by **snapshot drift on the migrated test**. Element-scoped `main` snapshot today is 22 lines; page-level will include `banner`, `navigation`, and `contentinfo` landmarks above and below the existing `main` block. The exact text is something Playwright generates via `--update-snapshots` and we review. The plan accommodates a non-trivial diff in `homepage.spec.ts:192` — that's the expected outcome, not a regression.
-
-There is no separate baseline file to manage; ARIA snapshots are **inline template literals** in the spec file. `--update-snapshots` rewrites the literal in place. Git diff carries the entire change.
-
-The migration is one-directional (page-level is strictly more inclusive than element-scoped); if the new snapshot is unstable we narrow it back rather than reverting the API form.
+Single-file docs change to `AGENTS.md` (lines 44–122 region). ~25 line insertions total. No code, no governance surface, no protected files. Two atomic commits split by concern: structured per-persona data first, cross-cutting visualisation second.
 
 ---
 
 ## Dependency graph
 
 ```
-T1 (bump @playwright/test ^1.60.0 in package.json + regenerate package-lock.json)
-  │
-  ├──► T2 (homepage.spec.ts:192 → page-level snapshot, regenerate baseline, review diff)
-  │       │
-  │       ▼
-  │     (proves the new API works against a live Jekyll server)
-  │
-  ▼
-T3 (navigation.spec.ts:96 + :460 → add `// element-scoped: …` rationale comments)
-  │
-  ▼
-T4 (.github/skills/jekyll-qa/SKILL.md line 40 → ^1.60.0 + test.abort() note)
-  │
-  ▼
-T5 (local full sweep: npx playwright test against bundle exec jekyll serve; AC-8 boundary check)
-  │
-  ▼
-CHECKPOINT-A — local gate (all 5 files modified within scope, full Playwright suite green locally)
-  │
-  ▼
-T6 (/review via code-reviewer agent — focus on snapshot diff legibility, AC-3 rationale soundness)
-  │
-  ▼
-T7 (apply review revisions; commit)
-  │
-  ▼
-T8 (push branch; close Dependabot PR #959 with supersede comment; open PR with snapshot-diff narrative + AC-7 narrative)
-  │
-  ▼
-T9 (CI passes — test-quality.yml all shards green; one puppeteer-cache retry tolerated, zero Playwright-shaped retries)
-  │
-  ▼
-T10 (admin-merge after CI green; sync local main)
+Phase 1 (rows) ──► Checkpoint A ──► Phase 2 (graph) ──► Checkpoint B ──► Phase 3 (ship)
 ```
 
-T1 is the prerequisite for everything (the new API surface only exists post-bump). T2 is the only behavior-changing edit; the rest is documentation + comments. T5 is the local gate. T6 is the lifecycle review-phase requirement. There is no post-merge verification task — unlike #958 (which needed real-CI cache logs), all #947 ACs are observable on the PR itself.
+Phase 1 and Phase 2 touch different regions of `AGENTS.md` so they're file-level independent, but conceptually ordered: rows establish the canonical per-persona target sets; the Mermaid graph visualises those same sets and must agree with them. Building rows first lets Checkpoint A lock the topology before Phase 2 commits it visually.
 
 ---
 
-## Phase 1 — Version bump
+## Vertical slices
 
-### T1 — Bump `@playwright/test` to `^1.60.0`
+### Phase 1 — Per-persona handoff rows
+*One atomic commit. Each row is a complete unit of value (a single persona becomes machine-readable).*
 
-**ACs satisfied:** AC-1 (pin), AC-2 (lockfile regen)
-**Touches:** `package.json`, `package-lock.json`
+| Task | Target | Insertion | New row |
+|---|---|---|---|
+| 1.1 | `AGENTS.md` Creative Director table (line ~52, after `**Must not touch**`) | New row | `\| **Valid handoff targets** \| [Editorial Chief](#3-editorial-chief), [QA Gatekeeper](#2-qa-gatekeeper) \|` |
+| 1.2 | `AGENTS.md` QA Gatekeeper table (line ~68) | New row | `\| **Valid handoff targets** \| [Creative Director](#1-creative-director), [Editorial Chief](#3-editorial-chief) \|` |
+| 1.3 | `AGENTS.md` Editorial Chief table (line ~84) | New row | `\| **Valid handoff targets** \| [Creative Director](#1-creative-director), [QA Gatekeeper](#2-qa-gatekeeper) \|` |
+| 1.4 | `AGENTS.md` Audience Researcher table (line ~100) | New row | `\| **Valid handoff targets** \| [Creative Director](#1-creative-director), [Editorial Chief](#3-editorial-chief), [QA Gatekeeper](#2-qa-gatekeeper) \|` |
+| 1.5 | `AGENTS.md` General Agent table (line ~116) | New row | `\| **Valid handoff targets** \| _(terminal — handles work end-to-end)_ \|` |
 
-**Steps:**
+**Phase 1 ACs covered:** AC-1, AC-2, AC-5, AC-8 (prose untouched), AC-6 (build).
 
-1. From a clean working tree, branch off `main`: `git switch -c feat/playwright-1.60-aria-snapshots`. (Branch name follows the prefix convention of recent PRs: `feat/…`, `chore/…`.)
-2. Edit `package.json`: change the `"@playwright/test": "^1.59.1"` line to `"@playwright/test": "^1.60.0"`. Do not touch any other field.
-3. Run `npm install` (not `npm ci` — the lockfile is mid-regeneration). Confirm `node_modules/@playwright/test/package.json` reports `"version": "1.60.x"`.
-4. Run `npm ls @playwright/test` → expect a `1.60.x` line. No `UNMET` or peer-dep warnings introduced.
-5. Verify the lockfile diff is bounded: `git diff --stat package-lock.json` should show changes confined to `@playwright/test` and its hoisted deps (playwright core, playwright-core). Any drift outside that subtree gets investigated before T2 — a broader lockfile rewrite indicates an npm version mismatch with whoever last regenerated the lockfile, and we'd want a clean `--prefer-offline` re-install to match.
+**Phase 1 verification:**
+```bash
+grep -c "Valid handoff targets" AGENTS.md         # expect 5
+grep -c "_(terminal — handles work end-to-end)_" AGENTS.md  # expect 1
+bundle exec jekyll build                          # exit 0
+```
 
-**Verify (mechanical):**
-- `grep -c '"@playwright/test": "\^1.60' package.json` → `1`
-- `npm ls @playwright/test 2>&1 | grep -c '1\.60\.'` → `≥ 1`
-- `git diff --stat | head -3` reports two files: `package.json` (+1/-1), `package-lock.json` (modest diff).
-
----
-
-## Phase 2 — Snapshot migration
-
-### T2 — Migrate `homepage.spec.ts:192` to page-level snapshot
-
-**ACs satisfied:** AC-3 (full)
-**Touches:** `tests/playwright-agents/homepage.spec.ts`
-
-**Steps:**
-
-1. Open `tests/playwright-agents/homepage.spec.ts` to the "Homepage main landmark matches ARIA smoke snapshot" test (line ~188-216).
-2. Replace `await expect(page.locator('main').first()).toMatchAriaSnapshot(...)` with `await expect(page).toMatchAriaSnapshot(...)`.
-3. Update the test title to reflect the new scope: `'Homepage page-level landmarks match ARIA smoke snapshot'` (so a future reader knows the scope is page, not `main`). Tag preservation: do not change `@content @navigation Homepage Redesign @REQ-CONTENT-01 @REQ-VISUAL-01` — those tags are how the shard 1 selector finds this test.
-4. Start `bundle exec jekyll serve --config _config.yml,_config_dev.yml` in a background terminal (port 4000). Wait for `Server running... press ctrl-c to stop.`
-5. Run `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks" --update-snapshots`. This rewrites the inline template literal in place with the page's full accessibility tree.
-6. **Manual diff review** of the regenerated snapshot — this is the load-bearing human-judgment step:
-   - Should include `banner` (header), `navigation` (already in the old snapshot's parent), original `main` block, `contentinfo` (footer), and possibly `complementary` if newsletter landmark spans outside `main`.
-   - Watch for dynamic content leaking in: build-date footers, copyright year, post-count badges, anything keyed on `site.time`. Replace each with the existing `/.+/` regex placeholder pattern (already used at line 194-196 for the heading).
-   - Watch for screen-reader-only text becoming visible in the snapshot — accessibility tree includes `aria-label` content, so a label like `aria-label="Skip to main content"` will appear as `link "Skip to main content"`.
-7. Re-run without `--update-snapshots` to confirm stability: `npx playwright test tests/playwright-agents/homepage.spec.ts -g "page-level landmarks"`. Must exit `0` with no diff prompt.
-
-**Verify (mechanical):**
-- `grep -c "expect(page).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `1`
-- `grep -c "expect(page.locator('main').first()).toMatchAriaSnapshot" tests/playwright-agents/homepage.spec.ts` → `0`
-- Test passes against a live server, without `--update-snapshots`, on two consecutive runs (proves the snapshot is stable, not a one-shot capture).
-
-**Risk:** if the page-level snapshot picks up unstable content that resists `/.+/` placeholders, narrow it back — keep the `expect(page)` form but use a `boxes: false` option or wrap a single template literal with strategic `/.*/` placeholders. **Do not revert to element-scoped.** If narrowing fails, escalate to spec amendment (the migration would then move to follow-up work).
+**Commit:** `docs(#946): add Valid handoff targets row to each persona`
 
 ---
 
-### T3 — Annotate the two element-scoped sites with `// element-scoped:` rationale
+### Checkpoint A — Topology lock
 
-**ACs satisfied:** AC-3 (rationale-comment portion)
-**Touches:** `tests/playwright-agents/navigation.spec.ts`
+Before starting Phase 2, cross-check every edge in the Phase 1 rows against the existing `**Handoff triggers**:` prose:
 
-**Steps:**
+| From | To | Existing prose line |
+|---|---|---|
+| Creative Director | Editorial Chief | line 56 |
+| Creative Director | QA Gatekeeper | line 56 |
+| QA Gatekeeper | Creative Director | line 72 |
+| QA Gatekeeper | Editorial Chief | line 72 |
+| Editorial Chief | Creative Director | line 88 |
+| Editorial Chief | QA Gatekeeper | line 88 |
+| Audience Researcher | Creative Director | line 104 |
+| Audience Researcher | Editorial Chief | line 104 |
+| Audience Researcher | QA Gatekeeper | line 104 |
+| General Agent | — (terminal) | n/a (no prose) |
 
-1. Above the snapshot at `navigation.spec.ts:96`, insert a one-line comment:
-   `// element-scoped: deliberately narrow to the article landmark — page-level would balloon the snapshot with site chrome (#947).`
-2. Above the snapshot at `navigation.spec.ts:460`, insert a one-line comment:
-   `// element-scoped: mobile-nav-open assertion checks the nav landmark in its open state; page-level would dilute the assertion (#947).`
-3. Do not modify the snapshot template literals themselves.
-
-**Verify (mechanical):**
-- `grep -cE "^\s*// element-scoped:" tests/playwright-agents/navigation.spec.ts` → `2`
-- `npx playwright test tests/playwright-agents/navigation.spec.ts -g "ARIA smoke snapshot"` still passes (the comments are no-ops at runtime; this just guards against accidental edits).
-
----
-
-## Phase 3 — Docs
-
-### T4 — Update `.github/skills/jekyll-qa/SKILL.md`
-
-**ACs satisfied:** AC-6
-**Touches:** `.github/skills/jekyll-qa/SKILL.md`
-
-**Steps:**
-
-1. Open `.github/skills/jekyll-qa/SKILL.md`. Locate line 40: `` - `@playwright/test ^1.59.1` ``.
-2. Replace the version: `` - `@playwright/test ^1.60.0` `` (bumped from ^1.59.1 in #947 — adds page-level `expect(page).toMatchAriaSnapshot()`, `test.abort()`, HAR-on-tracing, `locator.drop()`)
-3. Below this line, add a sub-bullet:
-   `` - `test.abort()` (Playwright 1.60+) is available for "tests must not call X" guardrails (issue #947) ``
-4. Do not edit any other line, do not introduce trailing whitespace, do not reflow surrounding bullets.
-
-**Verify (mechanical):**
-- `grep -n '@playwright/test \^1' .github/skills/jekyll-qa/SKILL.md` → exactly one match, reading `^1.60.0`.
-- `grep -n 'test.abort()' .github/skills/jekyll-qa/SKILL.md` → at least one match referencing #947.
-- `git diff --stat .github/skills/jekyll-qa/SKILL.md` → small diff, single hunk.
+**Pass criteria:** every edge in Phase 1's rows has a matching prose sentence; every prose sentence is reflected as an edge. Mismatch → halt and reconcile before Phase 2.
 
 ---
 
-## Phase 4 — Local verification
+### Phase 2 — `## Handoff Graph` section
+*One atomic commit. Pure additive — new top-level section.*
 
-### T5 — Full Playwright sweep + scope-guard boundary check
+| Task | Action |
+|---|---|
+| 2.1 | Insert new `## Handoff Graph` section immediately before `## Protected Files (all agents)` (currently at line 122) |
+| 2.2 | Brief intro paragraph (1–2 sentences) explaining the diagram source-of-truth status |
+| 2.3 | Mermaid code fence (` ```mermaid `) with `graph LR` content encoding exactly the 9 edges from Checkpoint A plus the terminal General Agent node |
 
-**ACs satisfied:** AC-4 (test-quality side, see Spec Amendment Proposal above), AC-5 (full local sweep), AC-8 (file boundary)
-**Touches:** none (read-only verification)
+**Mermaid content (final):**
 
-**Steps:**
+````markdown
+```mermaid
+graph LR
+    CD[Creative Director] --> EC[Editorial Chief]
+    CD --> QA[QA Gatekeeper]
+    QA --> CD
+    QA --> EC
+    EC --> CD
+    EC --> QA
+    AR[Audience Researcher] --> CD
+    AR --> EC
+    AR --> QA
+    GA(["General Agent (terminal)"])
+```
+````
 
-1. With `bundle exec jekyll serve --config _config.yml,_config_dev.yml` still running on `:4000`:
-   - `npm run test:playwright:shard1` — Navigation & Mobile (covers the `navigation.spec.ts` element-scoped snapshots)
-   - `npm run test:playwright:shard2` — Content, Search & Links (covers the migrated `homepage.spec.ts` snapshot, since `homepage.spec.ts` carries `@REQ-CONTENT-01`)
-   - `npm run test:playwright:shard3` — Accessibility, Visual & Performance
-2. Full sweep as a tiebreaker: `npx playwright test`. Must exit `0`.
-3. AC-8 boundary check: `git diff --name-only main...HEAD` returns **only**:
-   ```
-   .github/skills/jekyll-qa/SKILL.md
-   package-lock.json
-   package.json
-   tests/playwright-agents/homepage.spec.ts
-   tests/playwright-agents/navigation.spec.ts
-   ```
-   5 files exactly. Zero entries under `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`.
-4. **No new files created.** `git status --short` shows only `M` markers (and the existing untracked `specs/copilot-skills-agents-redesign-spec.md`, unrelated).
+**Phase 2 ACs covered:** AC-3, AC-4, AC-6 (build), AC-7 (render).
 
----
+**Phase 2 verification:**
+```bash
+grep -c "## Handoff Graph" AGENTS.md              # expect 1
+grep -c "^graph LR" AGENTS.md                     # expect 1
+grep -cE "(CD|QA|EC|AR|GA)" AGENTS.md             # ≥ 10 (5 declarations + edges)
+bundle exec jekyll build                          # exit 0
+```
 
-### CHECKPOINT-A — Local gate before /review
+**Visual verification (AC-7):**
+```bash
+bundle exec jekyll serve --config _config.yml,_config_dev.yml &
+# Open http://localhost:4000/ — confirm the site still builds and Mermaid renders if AGENTS.md is exposed as a page.
+# If AGENTS.md is not rendered as a Jekyll page, fall back to GitHub PR diff preview (Mermaid renders natively on github.com).
+```
 
-**Gate criteria (all must be true before T6):**
-
-- [ ] T1: `package.json` pinned at `^1.60.0`; `npm ls @playwright/test` reports `1.60.x`.
-- [ ] T2: `homepage.spec.ts:192` uses `expect(page).toMatchAriaSnapshot` and passes twice consecutively without `--update-snapshots`.
-- [ ] T3: Two `// element-scoped:` rationale comments present in `navigation.spec.ts`.
-- [ ] T4: `SKILL.md` line ~40 reads `^1.60.0`; `test.abort()` note recorded.
-- [ ] T5: All three Playwright shards pass; full sweep passes; AC-8 boundary is exactly the 5 expected files.
-
----
-
-## Phase 5 — REVIEW
-
-### T6 — `/review` via code-reviewer agent
-
-**ACs satisfied:** lifecycle requirement (not a specific spec AC)
-**Touches:** none (read-only review)
-
-**Brief the reviewer on:**
-- The AC-3 judgment call — 1 of 3 snapshots migrated; the other two kept element-scoped with rationale comments. Reviewer's job is to validate the rationale, not the mechanical change.
-- The regenerated page-level snapshot text in `homepage.spec.ts` — is it stable, are the `/.+/` placeholders covering the right dynamic content, is the test name still accurate?
-- AC-4 spec amendment (auto-regression doesn't run on PRs / doesn't install Playwright) — does the reviewer agree the inspection-based verification is sufficient?
-- That `test.abort()` is documented but not adopted in any test (intentional — separate authoring work).
-- The branch superseding Dependabot PR #959 — call out the closing strategy (close at T8, not earlier).
-
-**Expected findings shape:** Major (snapshot stability / placeholder coverage), Minor (rationale comment wording, test rename), Nit (commit-message hygiene).
+**Commit:** `docs(#946): add Handoff Graph section with Mermaid diagram`
 
 ---
 
-### T7 — Apply review revisions
+### Checkpoint B — Pre-PR final check
 
-**ACs satisfied:** finishes any open AC items raised by /review.
-**Touches:** depends on review findings; expect at most the same 5 files.
+Run the full AC battery one more time:
 
-**Hard rule:** if `/review` asks for changes that would push the diff beyond the 5-file scope, stop and escalate to spec amendment rather than silently expanding scope.
+| AC | Check |
+|----|---|
+| AC-1 | `grep -E '^\| \*\*Valid handoff targets\*\*' AGENTS.md \| wc -l` → 5 |
+| AC-2 | `grep -c "Valid handoff targets" AGENTS.md` → 5 |
+| AC-3 | `grep -c "## Handoff Graph" AGENTS.md` → 1 |
+| AC-4 | Cross-read Mermaid block against Checkpoint A table |
+| AC-5 | `grep "_(terminal" AGENTS.md` → present on General Agent |
+| AC-6 | `bundle exec jekyll build` → exit 0 |
+| AC-7 | Local dev preview OR GitHub PR diff renders Mermaid |
+| AC-8 | `grep -c "Handoff triggers" AGENTS.md` → still 4 (unchanged) |
 
----
-
-## Phase 6 — Ship
-
-### T8 — Push branch; close #959; open PR
-
-**ACs satisfied:** AC-7 (PR description content)
-**Touches:** git remote, GitHub PR state.
-
-**Steps:**
-
-1. `git push -u origin feat/playwright-1.60-aria-snapshots`.
-2. `gh pr create --repo oviney/blog --label "agent:qa-gatekeeper" --title "feat(tests): bump @playwright/test to ^1.60.0 + page-level ARIA snapshot on homepage (#947)"` with body containing:
-   - Closes #947
-   - Supersedes #959 (Dependabot lockfile-only bump)
-   - Spec amendment note for AC-4 (auto-regression workflow trigger surface)
-   - Rationale for keeping 2 of 3 ARIA snapshots element-scoped (one paragraph per call-site)
-   - Snapshot diff narrative — what new landmarks the page-level snapshot picked up, what `/.+/` placeholders were added
-   - Local verification evidence (3 shards + full sweep, all green)
-3. **Then** close #959: `gh pr close 959 --repo oviney/blog --comment "Superseded by PR #<new> — single atomic bundle of lockfile, snapshot migration, and skill doc update per SPEC #947."`
-
-**Order matters:** open the new PR first, then close #959. The opposite order leaves the repo with no open bump PR for the window between commands.
+**Pass criteria:** all 8 ACs green.
 
 ---
 
-### T9 — CI passes
+### Phase 3 — Ship
+*Standard `/ship` flow per `.github/skills/git-operations/SKILL.md`.*
 
-**ACs satisfied:** AC-4 (test-quality side)
-**Touches:** none.
-
-**Steps:**
-
-1. Wait for Quality Tests workflow (Playwright shards 1+2+3) to complete on the PR.
-2. **Retry policy:** zero Playwright-shaped retries. One puppeteer Chrome-cache retry is tolerated only if the failure stack matches the pattern from #958 (the composite action's retry-wrapped `npm ci` should make this nearly impossible after the first run, but if cold-cache hits and the retry-loop genuinely fires, that's a tolerated outcome — log it in the PR comments).
-3. If any Playwright-shaped failure occurs: do **not** retry. Investigate the diff, fix locally, push a follow-up commit.
-
----
-
-### T10 — Admin-merge
-
-**ACs satisfied:** none new — closes the lifecycle.
-**Touches:** main branch.
-
-**Steps:**
-
-1. `gh pr merge <new-PR> --repo oviney/blog --admin --squash --delete-branch`.
-2. `git switch main && git pull origin main`. Confirm local `main` carries the merge commit and `git status` is clean.
-3. Archive the lifecycle artifacts: `mkdir -p tasks/archive/2026-05-17-playwright-1.60-947 && git mv SPEC.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/plan.md tasks/archive/2026-05-17-playwright-1.60-947/ && git mv tasks/todo.md tasks/archive/2026-05-17-playwright-1.60-947/` (in a one-line cleanup commit on a follow-up branch, or in the same PR if archive-on-ship is the convention — confirm with maintainer; #958's lifecycle artifacts were archived in the next session, not the same PR).
+| Task | Action |
+|---|---|
+| 3.1 | Push branch `docs/946-agents-handoff-graph` |
+| 3.2 | Open PR with `Closes #946` |
+| 3.3 | No labels needed (`AGENTS.md` is not in `.github/skills/` or `.github/instructions/`, so no `governance-update` label) |
+| 3.4 | Wait for CI green (or admin-merge if blocked by phantom `build` check + 1-reviewer rule, matching #953 precedent) |
+| 3.5 | Merge `--squash --delete-branch` |
+| 3.6 | Post-merge: confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on the merge commit |
+| 3.7 | Comment on #946 with production verification notes |
 
 ---
 
-## Definition of Done
+## Risks (from SPEC §11, re-evaluated)
 
-- [ ] All 8 SPEC §3 ACs satisfied (AC-4 satisfied per the amended wording proposed above, assuming the user accepts the amendment).
-- [ ] PR description records the AC-7 narrative (snapshot rationale, #959 supersedure, #944 unblock).
-- [ ] `gh pr view <new> --json statusCheckRollup` shows all required checks green; merged via admin-squash.
-- [ ] Local `main` synced post-merge; lifecycle artifacts archived (in this PR or a follow-up cleanup commit).
-- [ ] No follow-up issue needed — `test.abort()` adoption and HAR tracing are explicitly deferred in SPEC §10 and require no tracking issue beyond what's already in #902 (Watch list).
+| Risk | Realised? | Plan response |
+|---|---|---|
+| Mermaid plugin not loaded → diagram doesn't render in Jekyll output | Unknown until Phase 2 build | If `jekyll build` warns or the rendered HTML shows the raw code fence, fall back to a Markdown table representation; amend AC-3/AC-4 in SPEC.md to match |
+| Table format varies across personas | No — confirmed uniform `\| Property \| Value \|` in §1.5 (read 2026-05-24) | None needed |
+| Reviewer wants `graph TD` not `graph LR` | Unknown | Trivial swap; address in review |
+| Phantom `build` required check + 1-reviewer block | Yes — recurring | Admin-merge as maintainer (per #953 precedent and user memory) |
+
+---
+
+## Out of scope (locked, per SPEC §12)
+
+- Persona roster changes
+- Modifying `**Handoff triggers**:` prose
+- Touching `.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`
+- Cross-repo A2A integration
+- A CI lint that compares the graph against the prose (sensible follow-up, not this PR)

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -129,11 +129,11 @@ Run the full AC battery one more time:
 | AC-1 | `grep -E '^\| \*\*Valid handoff targets\*\*' AGENTS.md \| wc -l` → 5 |
 | AC-2 | `grep -c "Valid handoff targets" AGENTS.md` → 5 |
 | AC-3 | `grep -c "## Handoff Graph" AGENTS.md` → 1 |
-| AC-4 | Cross-read Mermaid block against Checkpoint A table |
+| AC-4 | Mermaid edge count: `awk '/^&#96;&#96;&#96;mermaid/{f=1;next} /^&#96;&#96;&#96;$/{f=0} f' AGENTS.md \| grep -c -- '-->'` → 9; terminal node: `grep -c 'GA(\["General Agent (terminal)"\])' AGENTS.md` → 1. Beware the naïve `awk '/^## Handoff Graph/,/^## /'` form — the range terminates on the opening header line and returns 0. |
 | AC-5 | `grep "_(terminal" AGENTS.md` → present on General Agent |
 | AC-6 | `bundle exec jekyll build` → exit 0 |
 | AC-7 | Local dev preview OR GitHub PR diff renders Mermaid |
-| AC-8 | `grep -c "Handoff triggers" AGENTS.md` → still 4 (unchanged) |
+| AC-8 | `grep -c "^\*\*Handoff triggers\*\*:" AGENTS.md` → 4 (strict; line-starting prose paragraphs only — the section intro mentions the phrase as inline code, which a naïve `grep -c "Handoff triggers"` would over-count to 5) |
 
 **Pass criteria:** all 8 ACs green.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,47 +1,56 @@
-# TODO — Bump @playwright/test to ^1.60.0 + Page-Level ARIA Snapshots (#947)
+# TODO — Make AGENTS.md handoff targets explicit + Mermaid graph (#946)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Plan SHA:** `6480f00` · 5 files (0 new + 5 modified) · 1 snapshot migration + 2 rationale comments
+**Branch:** `docs/946-agents-handoff-graph` (to create)
 
 ---
 
-## Spec amendment to confirm before BUILD
-- [x] **A1** AC-4 amendment accepted by user 2026-05-17 — `auto-regression.yml` verified by inspection (no Playwright runtime; `issues: labeled` trigger only). SPEC §3 AC-4 updated in place.
+## Phase 0 — Setup
 
-## Phase 1 — Version bump
-- [x] **T1** ✅ Branch `feat/playwright-1.60-aria-snapshots` created. `package.json` pinned at `^1.60.0`. `npm install` clean (`changed 3 packages, 0 vulnerabilities`). `npm ls @playwright/test` → `1.60.0`; `playwright@1.60.0`; `playwright-core@1.60.0`. Lockfile diff bounded to the 3-package subtree (matches Dependabot #959 shape). Commit `3174891`.
+- [ ] Create branch `docs/946-agents-handoff-graph` off `main` (post-#953-merge state)
 
-## Phase 2 — Snapshot migration
-- [x] **T2** ✅ `homepage.spec.ts:192` migrated to `expect(page).toMatchAriaSnapshot()`. Snapshot reduced to `- banner / - main / - contentinfo` landmark-presence smoke check. Navigation deliberately excluded (collapses to hamburger button on mobile; nav coverage stays in `navigation.spec.ts`). Inline comment documents trade-offs. Verified on Desktop/Mobile/Tablet Chrome + Desktop Firefox (Safari blocked locally by missing libwoff1/libavif16; CI has them). Full homepage.spec.ts: 11/11 pass on Desktop Chrome. Commit `73d0d8f`.
-- [x] **T3** ✅ Two `// element-scoped: …` rationale comments added above `navigation.spec.ts:99` (article snapshot) and `:466` (mobile-nav-open snapshot). Both tests still pass. Commit `530b611`.
+## Phase 1 — Per-persona handoff rows (one commit)
 
-## Phase 3 — Docs
-- [x] **T4** ✅ SKILL.md line 40 bumped to `^1.60.0` with release-feature summary; `test.abort()` availability sub-bullet added (line 41). Commit `6943275`.
+- [ ] 1.1 Add `**Valid handoff targets**` row to Creative Director table → `Editorial Chief, QA Gatekeeper`
+- [ ] 1.2 Add `**Valid handoff targets**` row to QA Gatekeeper table → `Creative Director, Editorial Chief`
+- [ ] 1.3 Add `**Valid handoff targets**` row to Editorial Chief table → `Creative Director, QA Gatekeeper`
+- [ ] 1.4 Add `**Valid handoff targets**` row to Audience Researcher table → `Creative Director, Editorial Chief, QA Gatekeeper`
+- [ ] 1.5 Add `**Valid handoff targets**` row to General Agent table → `_(terminal — handles work end-to-end)_`
+- [ ] Verify: `grep -c "Valid handoff targets" AGENTS.md` == 5
+- [ ] Verify: `bundle exec jekyll build` exits 0
+- [ ] Commit: `docs(#946): add Valid handoff targets row to each persona`
 
-## Phase 4 — Local verification
-- [x] **T5** ✅ Three Playwright shards green on 4 projects (Safari skipped locally — missing libwoff1/libavif16 system libs; CI has them): Shard 1 70/70, Shard 2 44/44, Shard 3 38/38. Full Desktop Chrome sweep 105/105. AC-8 boundary clean: 5 feature files modified (SKILL.md, package.json, package-lock.json, homepage.spec.ts, navigation.spec.ts) + 6 lifecycle files (1 SPEC.md modified, 2 new tasks/*, 3 archived #958 artifacts) — none in the protected set (`_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
+## Checkpoint A — Topology lock
 
-## CHECKPOINT-A — Local gate before /review
-- [x] ✅ All T1–T5 ACs satisfied. Working tree clean (only `specs/copilot-skills-agents-redesign-spec.md` untracked, unrelated). No protected files touched. Branch `feat/playwright-1.60-aria-snapshots` at HEAD `6943275` ready for /review.
+- [ ] Cross-read every Phase 1 row against existing `**Handoff triggers**:` prose (lines 56, 72, 88, 104)
+- [ ] Confirm 9 directed edges + 1 terminal node match exactly
 
-## Phase 5 — /review pass
-- [ ] **T6** Code-reviewer agent brief: AC-3 rationale (2-of-3 element-scoped), page-level snapshot stability, AC-4 amendment, `test.abort()` documented-but-unused.
-- [ ] **T7** Apply review revisions; commit. Hard rule: if revisions push the diff beyond 5 files, escalate to spec amendment rather than expand scope silently.
+## Phase 2 — `## Handoff Graph` section (one commit)
 
-## Phase 6 — Ship
-- [ ] **T8** `git push -u origin feat/playwright-1.60-aria-snapshots`; `gh pr create` with snapshot-diff narrative, AC-7 content (rationale + #959 supersedure + #944 unblock), `agent:qa-gatekeeper` label; **then** close Dependabot PR #959 with supersede comment.
-- [ ] **T9** CI green — zero Playwright-shaped retries; one puppeteer Chrome-cache retry tolerated per #958 pattern (and only if stack matches).
-- [ ] **T10** `gh pr merge --admin --squash --delete-branch` once green; `git switch main && git pull`; archive lifecycle artifacts under `tasks/archive/2026-05-17-playwright-1.60-947/`.
+- [ ] 2.1 Insert new `## Handoff Graph` section before `## Protected Files (all agents)` (currently line 122)
+- [ ] 2.2 Add 1–2 sentence intro positioning the graph as derived from per-persona rows
+- [ ] 2.3 Add Mermaid `graph LR` code fence with all 9 edges + terminal General Agent node
+- [ ] Verify: `grep -c "## Handoff Graph" AGENTS.md` == 1
+- [ ] Verify: `bundle exec jekyll build` exits 0
+- [ ] Verify (AC-7): start local dev server, confirm Mermaid renders (or confirm GitHub-side render via PR diff preview if AGENTS.md is not exposed as a Jekyll page)
+- [ ] Commit: `docs(#946): add Handoff Graph section with Mermaid diagram`
 
----
+## Checkpoint B — Pre-PR final check
 
-## Acceptance criteria checklist (mirrors SPEC §3)
+- [ ] AC-1 — all 5 personas have the row
+- [ ] AC-2 — `grep -c` returns 5
+- [ ] AC-3 — `## Handoff Graph` section exists between roster and Protected Files
+- [ ] AC-4 — Mermaid encodes the 9 edges + 1 terminal node from Checkpoint A
+- [ ] AC-5 — General Agent row reads `_(terminal — handles work end-to-end)_`
+- [ ] AC-6 — `bundle exec jekyll build` exit 0
+- [ ] AC-7 — Mermaid renders (local or GitHub)
+- [ ] AC-8 — `grep -c "Handoff triggers" AGENTS.md` == 4 (prose untouched)
 
-- [ ] **AC-1** `package.json` pins `@playwright/test ^1.60.0`
-- [ ] **AC-2** `package-lock.json` regenerated, `npm ls @playwright/test` reports `1.60.x`
-- [ ] **AC-3** `homepage.spec.ts:192` migrated to page-level; `navigation.spec.ts:96` + `:460` carry `// element-scoped:` rationale comments
-- [ ] **AC-4** *(amended)* `test-quality.yml` passes green on a single PR run; `auto-regression.yml` verified by inspection (no Playwright runtime)
-- [ ] **AC-5** `npx playwright test` exits `0` locally with live Jekyll server
-- [ ] **AC-6** `.github/skills/jekyll-qa/SKILL.md` line 40 → `^1.60.0` + `test.abort()` availability note
-- [ ] **AC-7** PR description records snapshot rationale, #959 closure, #944 unblock
-- [ ] **AC-8** `git diff --name-only main...HEAD` returns exactly 5 files (no protected-file diffs)
+## Phase 3 — Ship (`/ship` flow)
+
+- [ ] Push branch
+- [ ] Open PR with `Closes #946`; no `governance-update` label needed
+- [ ] CI green (or admin-merge as maintainer per #953 precedent if phantom `build` + 1-reviewer block)
+- [ ] Merge `--squash --delete-branch`
+- [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
+- [ ] Comment on #946 with production verification


### PR DESCRIPTION
## Summary

Promotes the implicit handoff topology in `AGENTS.md` into structured, machine-readable form by (a) adding a `**Valid handoff targets**` row to each of the five persona property tables and (b) adding a new top-level `## Handoff Graph` section rendering the routing as a Mermaid `graph LR` diagram.

Single-file substantive change; topology derived 1:1 from existing `**Handoff triggers**:` prose at lines 56/72/88/104 (now 57/74/91/108 after Phase 1's row insertions). General Agent is terminal — no existing prose implies a transfer, and its responsibility is to handle cross-cutting work end-to-end.

## Changes

- `AGENTS.md` — 5 new `**Valid handoff targets**` rows + new `## Handoff Graph` section with Mermaid block (~25 line insertions). Anchor-linked persona references; intro paragraph anchors source-of-truth (rows + prose canonical, graph derived). A11y note marks the diagram as a visual aid; the rows give screen-reader users the complete topology.
- `SPEC.md`, `tasks/plan.md`, `tasks/todo.md` — lifecycle artifacts for this PR.
- `tasks/archive/2026-05-24-playwright-947/{plan,todo}.md` — archived stale #947 lifecycle artifacts that were never moved during #953.

## Handoff topology (encoded in the graph)

| From | To |
|---|---|
| Creative Director | Editorial Chief, QA Gatekeeper |
| QA Gatekeeper | Creative Director, Editorial Chief |
| Editorial Chief | Creative Director, QA Gatekeeper |
| Audience Researcher | Creative Director, Editorial Chief, QA Gatekeeper |
| General Agent | — (terminal — handles work end-to-end) |

9 directed edges + 1 terminal node, exactly matching the existing `**Handoff triggers**:` prose.

## Testing

- [x] `grep -c "Valid handoff targets" AGENTS.md` → 5 (AC-2)
- [x] `grep -c "## Handoff Graph" AGENTS.md` → 1 (AC-3)
- [x] 9 `-->` edges in the Mermaid block + 1 `GA([...])` terminal node (AC-4)
- [x] General Agent row reads `_(terminal — handles work end-to-end)_` (AC-5)
- [x] `bundle exec jekyll build` exits 0 (AC-6)
- [x] `grep -c "^**Handoff triggers**:" AGENTS.md` → 4 — original prose paragraphs untouched (AC-8)
- [ ] AC-7 — Mermaid renders → **visually confirm on this PR's diff preview** (GitHub renders Mermaid natively; no Jekyll page exposes AGENTS.md so the GitHub-side preview is the verification path)

## /ship fan-out review

Pre-push parallel review across three personas (code-reviewer, security-auditor, test-engineer):

- **Code review:** LGTM. 0 Must Fix / 0 Should Fix / 2 Consider — both addressed in commit `dce306d` (clearer "in both places" wording + a11y note).
- **Security audit:** CLEAN. 0 findings. No governance surface touched; no boundary widening; no information disclosure.
- **Test coverage:** All 6 automated ACs pass on clean checkout. AC-7 covered by GitHub PR preview (industry standard for Mermaid docs PRs). Non-blocking follow-up filed: tightened plan.md verification commands (also in `dce306d`).

## Acceptance criteria (from #946)

- [x] Each persona block gains a `**Valid handoff targets**` row
- [x] New `## Handoff Graph` section with Mermaid `graph LR` diagram
- [x] `grep -c "Valid handoff targets" AGENTS.md` returns 5
- [x] `bundle exec jekyll build` succeeds
- [ ] Mermaid diagram renders → verify on this PR's diff preview
- [x] No persona left with an empty target set (General Agent explicitly terminal)

## Out of scope (per #946)

Persona roster changes; modifying `**Handoff triggers**:` prose; touching `.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`; cross-repo A2A integration. A CI lint comparing graph nodes against persona count is a sensible follow-up but not in this PR.

## Rollback plan

Docs-only, no migration. If the Mermaid block displays as a raw fenced code block on `main`, revert via `gh pr revert <this PR>`; recovery time < 5 min including GH Pages redeploy.

Closes #946