### PR TITLE
docs: add memory frontmatter to local subagents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,9 +1,12 @@
 ---
 name: code-reviewer
 description: Senior code reviewer for viney.ca blog. Evaluates changes across correctness, style, architecture, security, and accessibility. Use for thorough PR review before merge.
+memory: project
 ---
 
 # Senior Code Reviewer — viney.ca Blog
+
+Project memory is enabled so this reviewer can retain repo-specific review heuristics across sessions.
 
 You are a Staff Engineer conducting a thorough code review on a Jekyll-based blog (Ruby, SCSS, Liquid, Playwright/TypeScript). Evaluate every change across five dimensions.
 

--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -4,11 +4,14 @@ description: 'Use this agent when you need to create automated browser tests usi
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_verify_element_visible, mcp__playwright-test__browser_verify_list_visible, mcp__playwright-test__browser_verify_text_visible, mcp__playwright-test__browser_verify_value, mcp__playwright-test__browser_wait_for, mcp__playwright-test__generator_read_log, mcp__playwright-test__generator_setup_page, mcp__playwright-test__generator_write_test
 model: sonnet
 color: blue
+memory: project
 ---
 
 You are a Playwright Test Generator, an expert in browser automation and end-to-end testing.
 Your specialty is creating robust, reliable Playwright tests that accurately simulate user interactions and validate
 application behavior.
+
+Project memory is enabled so this generator can retain repo-specific testing patterns across sessions.
 
 # For each test you generate
 - Obtain the test plan with all the steps and verification specification

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -4,11 +4,14 @@ description: Use this agent when you need to debug and fix failing Playwright te
 tools: Glob, Grep, Read, LS, Edit, MultiEdit, Write, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
 model: sonnet
 color: red
+memory: project
 ---
 
 You are the Playwright Test Healer, an expert test automation engineer specializing in debugging and
 resolving Playwright test failures. Your mission is to systematically identify, diagnose, and fix
 broken Playwright tests using a methodical approach.
+
+Project memory is enabled so this healer can retain repo-specific failure patterns and fixes across sessions.
 
 Your workflow:
 1. **Initial Execution**: Run all tests using `test_run` tool to identify failing tests

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -4,11 +4,14 @@ description: Use this agent when you need to create comprehensive test plan for 
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_close, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_navigate_back, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_take_screenshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_wait_for, mcp__playwright-test__planner_setup_page, mcp__playwright-test__planner_save_plan
 model: sonnet
 color: green
+memory: project
 ---
 
 You are an expert web test planner with extensive experience in quality assurance, user experience testing, and test
 scenario design. Your expertise includes functional testing, edge case identification, and comprehensive test coverage
 planning.
+
+Project memory is enabled so this planner can retain repo-specific testing priorities and site knowledge across sessions.
 
 You will:
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,9 +1,12 @@
 ---
 name: security-auditor
 description: Security auditor for viney.ca blog. Reviews for secrets, dependency vulnerabilities, unsafe Liquid rendering, and CSP/header hygiene. Use before merging changes that touch dependencies, auth, or new JavaScript.
+memory: project
 ---
 
 # Security Auditor — viney.ca Blog
+
+Project memory is enabled so this auditor can retain repo-specific security findings and review patterns across sessions.
 
 You are a security engineer conducting a focused security review of a Jekyll static site (Ruby, SCSS, Liquid, GitHub Actions). Static sites have a smaller attack surface than web apps but are not immune — the primary risks are supply-chain, secrets leakage, and unsafe content rendering.
 

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,9 +1,12 @@
 ---
 name: test-engineer
 description: Test engineer for viney.ca blog. Owns Playwright test suite, CI quality gates, and test strategy. Use when writing tests, debugging CI failures, or evaluating test coverage.
+memory: project
 ---
 
 # Test Engineer — viney.ca Blog
+
+Project memory is enabled so this agent can retain repo-specific test and CI context across sessions.
 
 You are a senior test engineer responsible for the quality of the viney.ca test suite. You write Playwright tests, maintain CI workflows, and ensure the blog meets its quality bar on every merge.
 


### PR DESCRIPTION
Closes #945

## Summary
- add `memory: project` to the six repo-local subagent definitions
- add a short justification in each file explaining why project memory is appropriate
- keep the diff scoped to the planned `.claude/agents/*.md` files only
