### PR TITLE
fix(#987): anchor bulk-content / governance-update label greps via has_label() helper

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,65 +1,69 @@
-# SPEC — Scope-guard label exemption for legitimate AGENTS.md / ARCHITECTURE.md changes (#985)
+# SPEC — Anchor bulk-content / governance-update label greps + add drift guard (#987)
 
 **Status:** Draft — awaiting approval
-**Issue:** [#985](https://github.com/oviney/blog/issues/985)
+**Issue:** [#987](https://github.com/oviney/blog/issues/987)
 **Labels:** `agent:qa-gatekeeper`, `governance-update`
-**Date:** 2026-05-24
+**Date:** 2026-05-25
 **Lifecycle phase:** DEFINE
-**Spawned from:** PR [#984](https://github.com/oviney/blog/pull/984) (closed #946) admin-merge follow-up — `check-agent-scope` red against a legitimate issue-driven `AGENTS.md` change.
+**Spawned from:** PR [#988](https://github.com/oviney/blog/pull/988) (closed #985) /ship review — code-reviewer Critical scoped to `protected-file-update` only; security-auditor flagged same antipattern on `bulk-content` / `governance-update` as Info.
 
 ---
 
 ## 1. Situation
 
-`scripts/check-pr-scope.sh` Rule 1 (lines 75–80) loops over `PROTECTED_FILES` (lines 43–51) — `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `AGENTS.md`, `ARCHITECTURE.md` — and emits a `VIOLATION [protected-file]` for any one of them appearing in the diff. **Rule 1 has no `PR_LABELS` bypass**, unlike:
-- **Rule 2** (>15 files / scope-explosion) which respects the `bulk-content` label (lines 86–94)
-- **Rule 3** (`.github/skills/` or `.github/instructions/`) which respects the `governance-update` label (lines 100–109)
+`scripts/check-pr-scope.sh` uses unanchored substring greps for the `bulk-content` and `governance-update` labels:
 
-This means every PR that legitimately modifies `AGENTS.md` (a `governance-update`-relevant doc, but explicitly listed under Rule 1 not Rule 3) trips the guard. Most recent precedent: PR #984 / issue #946 (handoff-graph PR), admin-merged through the false-positive failure on 2026-05-24T22:33:33Z.
+- **line 110** — `if echo "${PR_LABELS:-}" | grep -q 'bulk-content'; then`
+- **line 124** — `if echo "${PR_LABELS:-}" | grep -q 'governance-update'; then`
 
-The protection itself is correct — accidental side-effect modifications to `AGENTS.md` *should* trip the guard. What's missing is a deliberate-intent escape hatch for the rare issue-driven case.
+Confusable label names (e.g. `not-bulk-content-foo`, `governance-update-experimental`) trip these bypasses. The `protected-file-update` label (added by #985 / PR #988) was originally written with the same antipattern; #988 caught and anchored it (`scripts/check-pr-scope.sh:96` post-merge) but deliberately scoped the fix to the new label per the user's "fix new grep only + Case D pin" decision during /ship review.
 
-`bulk-content` and `governance-update` are precedent: they signal deliberate intent and bypass a specific rule. The same pattern applies here.
+Security-auditor judged the remaining two unanchored greps **not currently exploitable** in this threat model:
+- Labels can only be applied by users with `triage`/`write` on `oviney/blog`.
+- Forked PRs cannot mutate labels.
+- An attacker with label-write privilege can apply the canonical label directly — the substring confusion variant adds no privilege.
 
-CI surface: the guard runs as the `check-agent-scope` job in `.github/workflows/test-build.yml:95-107`. No test currently exists for `scripts/check-pr-scope.sh`.
+The hole is **consistency debt**, not an active vulnerability. Closing it cleans up the antipattern globally, gives all three rule-level bypasses the same security posture, and adds regression-prevention via fixture cases that pin the anchored semantics.
+
+CI surface: `scripts/check-pr-scope.sh` runs in `.github/workflows/test-build.yml` `check-agent-scope` job (line 95–113 post-#988). The fixture harness `tests/scope-guard.sh` (added in #988) covers Rule 1 only — Rule 2 and Rule 3 currently have no automated tests.
 
 ---
 
 ## 2. Objective
 
-Add a label-based exemption to `scripts/check-pr-scope.sh` Rule 1 that lets a PR modifying `AGENTS.md` or `ARCHITECTURE.md` pass the guard when (and only when) the PR carries a new `protected-file-update` label. Other protected files (`_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`) **remain unbypassable** — they're load-bearing infra, not docs. Cover the change with a small fixture-based test (`tests/scope-guard.sh`) wired into the `test-build.yml` workflow.
+Anchor the `bulk-content` and `governance-update` label greps in `scripts/check-pr-scope.sh` to match the comma-joined `PR_LABELS` format exactly, using a single `has_label()` helper that DRYs all three rule-level bypass checks. Extend `tests/scope-guard.sh` to multi-file fixtures and add two new cases (E, F) pinning the anchored semantics so a future refactor can't silently re-introduce a substring match on either label. Single source of truth for the label check; consistent security posture across all three labels.
 
 ---
 
-## 3. Design Decisions (confirmed 2026-05-24)
+## 3. Design Decisions (confirmed 2026-05-25)
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Label name | **`protected-file-update`** | Parallels `bulk-content` and `governance-update`; intent is explicit ("this PR intentionally modifies a protected file"). |
-| Bypass scope | **Per-file allow-list** (`AGENTS.md`, `ARCHITECTURE.md` only) | Issue-driven docs work needs an escape hatch; infra files (`_config.yml`, `Gemfile*`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`) should always require a dedicated audit trail beyond a single label. Per-file design preserves that distinction. |
-| Bypass mechanism | **Two-tier check inside Rule 1**: per-file flag + label check, NOT an early-return at the top of Rule 1 | An all-or-nothing rule bypass (matching `governance-update`'s Rule 3 pattern) would expose infra files to the same label — undesirable. Two-tier keeps infra files always-protected. |
-| Bypass log line | `check-pr-scope: protected-file-update label present — bypassing protection for 'AGENTS.md'.` (one per bypassed file) | Mirrors existing skip-message style; explicit per-file logging makes the audit trail obvious in CI logs. |
-| Test strategy | **New `tests/scope-guard.sh` with 3 fixture cases** (temp-git-repo approach) | No production-script changes for testability; black-box test against the real script via env vars. Wired into `test-build.yml` as a new step. |
-| Test fixture mechanism | **Per-case temp git repo** (`mktemp -d` + `git init` + commit baseline + branch + modify) | Self-contained, no fixture files in the main repo, hermetic. ~30 lines of helper code. |
-| Documentation | **Update `scripts/check-pr-scope.sh` header docblock** (lines 21–29 already document `bulk-content` + `governance-update`) AND add a `protected-file-update` row to the label table in `CLAUDE.md` (alongside `bulk-content` and `governance-update`) | One source of truth (the script header) + one human-readable index (`CLAUDE.md`). No new doc file. |
+| Refactor approach | **Extract `has_label()` helper, call from Rules 1, 2, 3** | Single source of truth; eliminates the antipattern by construction so a fourth label can't copy the wrong pattern. Code-reviewer in #988 explicitly suggested this. |
+| Helper signature | **`has_label <label-name>`** — returns 0 if label is in `PR_LABELS`, 1 otherwise | Plain bash function; reads naturally at call sites (`if has_label 'bulk-content'; then …`). |
+| Helper implementation | **`printf '%s\n' "${PR_LABELS:-}" \| tr ',' '\n' \| grep -Fxq "$1"`** | Same anchored pattern #985 introduced for Rule 1. `-F` (fixed string), `-x` (whole-line), `-q` (quiet). |
+| Test fixture mechanics | **Extend `run_case` to accept newline-separated multi-file paths** | Cases E (Rule 2, 16+ files) and F (Rule 3, `.github/skills/`) need multi-file or path-prefixed setups. One helper, not two. Case A–D continue to work by passing a single path (existing call sites become `\$'AGENTS.md'`, unchanged). |
+| Test cases to add | **Case E (`bulk-content` substring pin), Case F (`governance-update` substring pin)** — no separate pin for `agent:` labels | The `agent:*` checks (lines 148–161) use prefix-match strings (`agent:creative-director` cannot be confused with a different `agent:*` label because each label starts with the full agent name). They are not the same antipattern; skip. |
+| Drift guard | **Out of scope** | The user's #987 issue body explicitly lists this as out of scope ("Adding a startup sanity check that asserts `PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES` … worth a separate issue"). Filed only if appetite arises. |
+| Documentation | **No CLAUDE.md change required** | The behavioural contract is unchanged from the user's perspective — both labels were intended to be exact-match all along. The docblock in `scripts/check-pr-scope.sh` will not need new examples either; existing PASS/FAIL examples still hold. |
+| `protected-file-update` Rule 1 grep | **Migrate to `has_label()` helper** for consistency | Currently inlined post-#988. Routing through the helper keeps all three labels symmetric. Cases A–D must continue to pass post-refactor (regression-prevent the helper extraction). |
 
 ---
 
 ## 4. Acceptance Criteria
 
-- [ ] **AC-1** `scripts/check-pr-scope.sh` Rule 1 (protected-file loop) gains a per-file label bypass for `AGENTS.md` and `ARCHITECTURE.md` only.
-- [ ] **AC-2** Bypass triggers only when `PR_LABELS` contains `protected-file-update`. Without the label, the guard still flags `AGENTS.md` / `ARCHITECTURE.md` modifications as `VIOLATION [protected-file]`.
-- [ ] **AC-3** Bypass does NOT apply to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, or `.github/copilot-instructions.md` — those still trip the guard even with the label.
-- [ ] **AC-4** New `tests/scope-guard.sh` test with three fixture cases:
-  - **Case A:** `AGENTS.md` modified, no `PR_LABELS` → guard fails (exit 1), output contains `VIOLATION [protected-file]: 'AGENTS.md'`.
-  - **Case B:** `AGENTS.md` modified, `PR_LABELS="protected-file-update"` → guard passes (exit 0), output contains `bypassing protection for 'AGENTS.md'`.
-  - **Case C:** `Gemfile` modified, `PR_LABELS="protected-file-update"` → guard fails (exit 1), output contains `VIOLATION [protected-file]: 'Gemfile'`.
-- [ ] **AC-5** `tests/scope-guard.sh` is invoked from `.github/workflows/test-build.yml` (new step or new job under the existing `check-agent-scope` workflow), exits 0 when all three cases pass.
-- [ ] **AC-6** `scripts/check-pr-scope.sh` header docblock (lines 21–29) is updated to document the new label alongside `bulk-content` and `governance-update`, including PASS/FAIL examples.
-- [ ] **AC-7** `CLAUDE.md` "Local Agent Labels" table (or wherever scope-guard labels are documented today) gains a row for `protected-file-update`.
-- [ ] **AC-8** Running the script locally with the live PR #984 diff state (replay) returns exit 0 when `PR_LABELS=protected-file-update` is set, and exit 1 when unset — manual replay check.
-- [ ] **AC-9** `bundle exec jekyll build` exits 0 (the change touches only `scripts/`, `tests/`, `.github/workflows/`, `CLAUDE.md`, and `scripts/check-pr-scope.sh` docblock; no Jekyll content surface).
-- [ ] **AC-10** *(amended 2026-05-24 during BUILD — original ≤ 7 omitted the archived prior-PR lifecycle carry-over)* Scope-guard boundary on this PR: `git diff --name-only main...HEAD` returns exactly — `scripts/check-pr-scope.sh`, `tests/scope-guard.sh` (new), `.github/workflows/test-build.yml`, `CLAUDE.md`, plus the lifecycle artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`), plus the carry-over archived #946 lifecycle artifacts (`tasks/archive/2026-05-24-handoff-graph-946/{plan,todo}.md`). Total **≤ 9 files** — the +2 vs. the original is the always-present prior-PR archive overhead now formalised so future SPECs can account for it from the start.
+- [ ] **AC-1** `scripts/check-pr-scope.sh` defines a `has_label()` shell function near the top of the rule section (after `CHANGED_FILES` definition, before Rule 1) that takes one argument (label name) and returns 0 iff that label is present in `PR_LABELS` as a comma-delimited exact-match entry.
+- [ ] **AC-2** Rule 1 (`protected-file-update` bypass), Rule 2 (`bulk-content` bypass), and Rule 3 (`governance-update` bypass) all call `has_label '<label>'` — no remaining `grep -q '<label-string>'` patterns in the rule bodies.
+- [ ] **AC-3** `tests/scope-guard.sh` `run_case` helper accepts newline-separated multi-file paths in its `<file_to_modify>` parameter. Each path is touched and staged.
+- [ ] **AC-4** New fixture cases in `tests/scope-guard.sh`:
+  - **Case E:** 21 unique unprotected files modified, `PR_LABELS="not-bulk-content-foo"` → guard fails (exit 1), output contains `VIOLATION [scope-explosion]`.
+  - **Case F:** `.github/skills/scope-guard-test/SKILL.md` created, `PR_LABELS="governance-update-experimental"` → guard fails (exit 1), output contains `VIOLATION [governance-surface]`.
+- [ ] **AC-5** Existing Cases A, B, C, D continue to pass post-refactor (Rule 1 still works via `has_label`).
+- [ ] **AC-6** `bash tests/scope-guard.sh` exits 0 with **6/6 PASS**.
+- [ ] **AC-7** Sanity replay against `main` HEAD: `bash scripts/check-pr-scope.sh` from the merged `main` state still PASSES (no protected file on `main`; no regression).
+- [ ] **AC-8** `bundle exec jekyll build` exits 0 (no Jekyll content surface touched).
+- [ ] **AC-9** Scope-guard boundary on this PR: `git diff --name-only main...HEAD` returns exactly — `scripts/check-pr-scope.sh`, `tests/scope-guard.sh`, plus lifecycle artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`), plus the carry-over archived #985 lifecycle artifacts (`tasks/archive/2026-05-24-scope-guard-985/{plan,todo}.md`). Total **≤ 7 files** (using the post-#988 ≤9 budget pattern minus 2 since this PR doesn't touch `CLAUDE.md` or `.github/workflows/test-build.yml`).
+- [ ] **AC-10** No regression of `bulk-content` / `governance-update` exact-match behaviour: `PR_LABELS="bulk-content"` against >15 files still passes (Rule 2 bypassed); `PR_LABELS="governance-update"` against `.github/skills/foo` still passes (Rule 3 bypassed). Verified via manual probe or two additional fixture cases — manual probe is acceptable since both labels are well-exercised by real PRs in the repo history.
 
 ---
 
@@ -67,17 +71,13 @@ Add a label-based exemption to `scripts/check-pr-scope.sh` Rule 1 that lets a PR
 
 ```bash
 # Local development loop
-bundle exec jekyll build                          # AC-9
-bash scripts/check-pr-scope.sh                    # baseline (expected: pass — no protected file in our diff today)
-bash tests/scope-guard.sh                         # AC-4 — runs all three fixture cases
+bundle exec jekyll build                          # AC-8
+bash scripts/check-pr-scope.sh                    # baseline (expected: PASS — no protected file in our diff)
+bash tests/scope-guard.sh                         # AC-6 — expect 6/6 PASS
 
-# Manual replay against #984's diff shape (AC-8)
-git checkout 4e22be8e^                            # parent of #984's merge commit
-bash scripts/check-pr-scope.sh                    # expected: FAIL on AGENTS.md (no label)
-PR_LABELS="protected-file-update" bash scripts/check-pr-scope.sh   # expected: PASS
-
-# CI verification
-gh pr checks <new PR>                              # check-agent-scope expected pass
+# Sanity-check existing labels still work as intended (AC-10)
+# Run inside a temp git repo with 16 unprotected files + bulk-content label → expect Rule 2 skipped
+# Or inspect the script's stdout for the new "bulk-content label present — skipping rule 2." line.
 ```
 
 ---
@@ -85,26 +85,25 @@ gh pr checks <new PR>                              # check-agent-scope expected 
 ## 6. Project Structure (touched files)
 
 ```
-scripts/check-pr-scope.sh         M   Rule 1 gains per-file label bypass; docblock updated
-tests/scope-guard.sh              A   New — three fixture cases (~80 lines)
-.github/workflows/test-build.yml  M   Add invocation of tests/scope-guard.sh
-CLAUDE.md                         M   Document protected-file-update label in scope-guard table
+scripts/check-pr-scope.sh         M   Define has_label(); refactor 3 label checks to use it
+tests/scope-guard.sh              M   Multi-file run_case + Cases E & F
 SPEC.md                           M   This file
-tasks/plan.md                     M   #985 plan
-tasks/todo.md                     M   #985 todo
+tasks/plan.md                     M   #987 plan
+tasks/todo.md                     M   #987 todo
+tasks/archive/2026-05-24-scope-guard-985/  A   Carry-over: archived #985 plan + todo
 ```
 
-No changes to `_config.yml`, `_layouts/`, `_sass/`, `_posts/`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, or `AGENTS.md`. The latter is deliberately untouched — this PR fixes the guard, not the doc.
+**Total scope:** 5 substantive lifecycle files + 2 archive carry-over files = **7 files**. No changes to `.github/workflows/`, `CLAUDE.md`, `AGENTS.md`, `ARCHITECTURE.md`, or any `_posts/`, `_sass/`, `_layouts/`, `_config.yml`.
 
 ---
 
 ## 7. Code Style
 
-- **Bash style** — match existing `scripts/check-pr-scope.sh` conventions: `set -euo pipefail`, lowercase `local` vars, `echo` for status, `||` fallbacks for portability. No new dependencies beyond `git` and `bash`.
-- **Label check** — reuse the existing `echo "${PR_LABELS:-}" | grep -q '<label>'` pattern (used by Rules 2 and 3 today). Don't introduce `[[ ]]` or `=~` matching — keep consistent.
-- **Bypass log line** — single line per bypass, prefixed `check-pr-scope:` for grep-ability in CI logs.
-- **Test script** — POSIX-friendly bash where possible; use `mktemp -d` for sandboxing; clean up temp dirs in a `trap`. No external test framework (no bats, no shellspec) — keep the dependency footprint minimal per the existing script's `git + bash only` constraint.
-- **Comments** — only where the *why* is non-obvious (e.g., explaining why the per-file bypass list is separate from `PROTECTED_FILES`). No restating what the code does.
+- **Bash function style** — define `has_label()` with `local` for any internal vars; single responsibility; no side effects beyond the grep exit code.
+- **Call-site readability** — `if has_label 'bulk-content'; then` reads as plain English; preserves the existing `if … ; then` structure of each rule.
+- **No comment churn at call sites** — the helper name documents intent; don't restate "this checks for the X label" at every call. Keep the existing surrounding context comments.
+- **Test harness style** — `run_case`'s multi-file parameter remains a single string param (positional-arg compatibility); the helper splits on newlines internally. Existing 4 call sites continue to pass a single path with no quoting change required.
+- **No new dependencies** — bash + git only, matching the existing constraint.
 
 ---
 
@@ -112,35 +111,34 @@ No changes to `_config.yml`, `_layouts/`, `_sass/`, `_posts/`, `Gemfile`, `Gemfi
 
 | Layer | Check |
 |---|---|
-| Unit/script | `tests/scope-guard.sh` cases A, B, C (AC-4) — black-box test against `check-pr-scope.sh` with three fixture diffs and PR_LABELS values |
-| Integration | `.github/workflows/test-build.yml` runs `tests/scope-guard.sh` on every PR push (AC-5) — guards against regression |
-| Manual | One-shot replay against #984's diff state (AC-8) — confirms the real-world false positive is now fixed |
-| Build | `bundle exec jekyll build` (AC-9) — sanity check that the change doesn't affect site builds |
+| Unit/script | `tests/scope-guard.sh` — 6 fixture cases covering Rule 1 (A–D, B+D pin label anchoring), Rule 2 (E pin substring antipattern fix), Rule 3 (F pin substring antipattern fix) |
+| Integration | `.github/workflows/test-build.yml` (no edits) — existing `check-agent-scope` job runs the harness; CI verifies 6/6 PASS on every PR |
+| Manual | One-shot replay of the original `bulk-content` and `governance-update` exact-match behaviour against fixture state (AC-10) |
+| Build | `bundle exec jekyll build` (AC-8) |
+| Refactor regression | Cases A–D unchanged in semantics post-helper-extraction (AC-5) |
 
-No Playwright spec — no UI surface touched.
+No Playwright spec — no runtime UI.
 
 ---
 
 ## 9. Boundaries
 
 **Always:**
-- Run `bash tests/scope-guard.sh` locally before pushing.
-- Run `bash scripts/check-pr-scope.sh` (without PR_LABELS) against the branch — expect PASS (no protected file in our diff today).
-- Use the existing label-check pattern (`echo "${PR_LABELS:-}" | grep -q '<label>'`).
-- Match existing bash style in `scripts/check-pr-scope.sh`.
+- Run `bash tests/scope-guard.sh` locally before pushing — expect 6/6 PASS.
+- Route all three rule-level label checks through `has_label()`. Don't leave any inline `grep -q '<label>'` patterns behind.
+- Match the existing `printf | tr | grep -Fxq` anchored pattern exactly — same `-Fxq` flags, same comma-split.
 
 **Ask first about:**
-- Adding any file to the `PROTECTED_FILE_UPDATE_BYPASS` allow-list beyond `AGENTS.md` and `ARCHITECTURE.md`.
-- Changing the label name from `protected-file-update` to anything else (would break docs and CLAUDE.md cross-refs).
-- Renaming or restructuring `scripts/check-pr-scope.sh` (out of scope; this is a targeted addition).
-- Introducing a test framework dependency (bats/shellspec) — the existing constraint is bash + git only.
+- Adding a fourth label-driven bypass (would require a separate issue and a new label-naming decision).
+- Touching the `agent:*` label checks at lines 148–161 (they use prefix-match strings, not the same antipattern; out of scope for #987).
+- Changing the helper's signature or name from `has_label`.
+- Adding the `PROTECTED_FILES ↔ PROTECTED_FILE_UPDATE_BYPASS` drift guard (out-of-scope per #987 issue body).
 
 **Never:**
-- Remove any file from `PROTECTED_FILES` (the existing protection list is intentional). [Out of scope per #985]
-- Make the bypass apply to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, or `.github/copilot-instructions.md`. [Out of scope per #985]
-- Extend the existing `governance-update` label to cover Rule 1. [Out of scope per #985 — conflates two distinct categories]
-- Touch any file under `_posts/`, `_sass/`, `_layouts/`, or `_config.yml`. [Boundary]
-- Modify `AGENTS.md` or `ARCHITECTURE.md` in this PR (they're the *test subject* of the new exemption, not the implementation target).
+- Modify `AGENTS.md`, `ARCHITECTURE.md`, `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, or `.github/copilot-instructions.md`. [Protected files; the PR carries `governance-update` only, not `protected-file-update`.]
+- Change the behaviour of the existing `bulk-content` / `governance-update` exact-match path. The refactor must be semantics-preserving for the canonical label; only the substring confusion path changes.
+- Touch `.github/workflows/test-build.yml` (no new CI step needed — existing `tests/scope-guard.sh` invocation already covers Cases E/F).
+- Add `bats`, `shellspec`, or any test framework. [Boundary inherited from #985 SPEC §9.]
 
 ---
 
@@ -148,22 +146,23 @@ No Playwright spec — no UI surface touched.
 
 | Risk | Mitigation |
 |---|---|
-| The bash label-check pattern `grep -q 'protected-file-update'` substring-matches inside another label like `protected-file-update-experimental` (false positive) | Add anchors: `grep -q '\bprotected-file-update\b'`. But the existing `bulk-content` / `governance-update` checks don't use anchors — match precedent and accept the substring risk (no other labels with this prefix exist today). Flag as a future hardening item if a confusable label is ever added. |
-| `tests/scope-guard.sh` creates temp git repos in CI — slow or flaky | Each case ~1s; three cases total. Negligible CI cost. If flakiness appears, debug via the `trap` cleanup logging. |
-| `.github/workflows/test-build.yml` change touches a workflow file — could trip the scope guard itself when CI re-runs on this PR (Rule 4 forbids `agent:qa-gatekeeper` from touching `.github/workflows/` only if the agent label is set in PR_LABELS) | This PR carries `agent:qa-gatekeeper` + `governance-update`. Rule 4 for `agent:qa-gatekeeper` *allows* `.github/workflows/` (line 67 in AGENTS.md / line 128 in the script). No conflict. |
-| Script change breaks the existing `check-agent-scope` job for non-#985 PRs in flight | Run `bash scripts/check-pr-scope.sh` against the current branch with no protected files in diff → expect PASS. Run with `AGENTS.md` modified + no label → expect FAIL. Both behaviours unchanged. Verified by Cases A and C in the new test. |
-| Manual replay (AC-8) requires checking out a historical SHA — workflow risk | The replay is documented as an offline verification step, not in CI. Don't commit anything from the replay checkout. Use a worktree or detached HEAD. |
+| Helper refactor breaks Rule 1 (existing protected-file-update path). | Cases A–D in `tests/scope-guard.sh` will fail loudly if so. AC-5 explicitly guards this. |
+| `has_label` mis-implementation accepts an empty label argument and matches an empty `PR_LABELS` line. | Add a defensive `[ -z "$1" ] && return 1` guard at the top of `has_label`. Document in code style. |
+| Case E's 16-file fixture creates files that themselves trip another rule (e.g., one happens to match a protected name). | Use clearly-distinct paths: `tests-e-1.txt` through `tests-e-21.txt` under a sandbox dir. None of these match `PROTECTED_FILES` or any `agent:*` forbidden pattern. |
+| Case F creating a real `.github/skills/scope-guard-test/SKILL.md` in the fixture leaks state. | Fixture creates files inside the temp git repo, never the production repo. `mktemp -d` + `trap cleanup EXIT` (existing pattern) keeps it hermetic. |
+| Migrating Rule 1 to the helper changes the bypass log line. | Keep the log line identical (`"check-pr-scope: protected-file-update label present — bypassing protection for '$protected'."`). Only the label-check expression changes, not the message. Case B's `expected_grep` continues to match. |
+| Reviewer asks for the agent-scope checks (lines 148–161) to also use `has_label`. | Those are prefix-match string comparisons, not substring-match antipatterns. They're not in scope for #987. Document the difference in PR description if asked. |
 
 ---
 
 ## 11. Out of Scope
 
-Per issue #985:
+Per issue #987:
 
-- Removing `AGENTS.md` or `ARCHITECTURE.md` from `PROTECTED_FILES`.
-- Extending the bypass to `_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, or `.github/copilot-instructions.md`.
-- Extending `governance-update` to cover Rule 1.
-- Refactoring the script's overall structure (e.g., extracting rules into separate functions).
-- Adding a `--self-test` mode to the script itself.
-- Documenting the label outside `scripts/check-pr-scope.sh` docblock + `CLAUDE.md` (no separate `LABELS.md`).
-- Backfilling label-bypass tests for the existing `bulk-content` and `governance-update` rules (worthwhile follow-up, separate issue).
+- **Adding the `PROTECTED_FILES ↔ PROTECTED_FILE_UPDATE_BYPASS` drift guard** (config-error sanity check) — worth a separate issue if appetite arises.
+- **Anchoring the `agent:*` label checks at lines 148–161** — those use prefix-match strings, not substring-match antipatterns.
+- **Refactoring Rule 1's per-file allow-list check** (the second `printf '%s\n' "${PROTECTED_FILE_UPDATE_BYPASS[@]}" | grep -qx "$protected"` line) — that's a separate concern from label matching; keep it inline.
+- **Adding test framework dependencies** (`bats`, `shellspec`).
+- **CLAUDE.md changes** — no documented behaviour changes from the user's perspective.
+- **`AGENTS.md` / `ARCHITECTURE.md` changes** — protected files; not the target of this PR.
+- **Cross-repo / A2A protocol integration.**

--- a/SPEC.md
+++ b/SPEC.md
@@ -62,7 +62,7 @@ Anchor the `bulk-content` and `governance-update` label greps in `scripts/check-
 - [ ] **AC-6** `bash tests/scope-guard.sh` exits 0 with **6/6 PASS**.
 - [ ] **AC-7** Sanity replay against `main` HEAD: `bash scripts/check-pr-scope.sh` from the merged `main` state still PASSES (no protected file on `main`; no regression).
 - [ ] **AC-8** `bundle exec jekyll build` exits 0 (no Jekyll content surface touched).
-- [ ] **AC-9** Scope-guard boundary on this PR: `git diff --name-only main...HEAD` returns exactly — `scripts/check-pr-scope.sh`, `tests/scope-guard.sh`, plus lifecycle artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`), plus the carry-over archived #985 lifecycle artifacts (`tasks/archive/2026-05-24-scope-guard-985/{plan,todo}.md`). Total **≤ 7 files** (using the post-#988 ≤9 budget pattern minus 2 since this PR doesn't touch `CLAUDE.md` or `.github/workflows/test-build.yml`).
+- [ ] **AC-9** Scope-guard boundary on this PR: `git diff --name-only main...HEAD` returns exactly — `scripts/check-pr-scope.sh`, `tests/scope-guard.sh`, plus lifecycle artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`), plus the carry-over archived #985 lifecycle artifacts (`tasks/archive/2026-05-25-scope-guard-985/{plan,todo}.md`). Total **≤ 7 files** (using the post-#988 ≤9 budget pattern minus 2 since this PR doesn't touch `CLAUDE.md` or `.github/workflows/test-build.yml`).
 - [ ] **AC-10** No regression of `bulk-content` / `governance-update` exact-match behaviour: `PR_LABELS="bulk-content"` against >15 files still passes (Rule 2 bypassed); `PR_LABELS="governance-update"` against `.github/skills/foo` still passes (Rule 3 bypassed). Verified via manual probe or two additional fixture cases — manual probe is acceptable since both labels are well-exercised by real PRs in the repo history.
 
 ---
@@ -90,7 +90,7 @@ tests/scope-guard.sh              M   Multi-file run_case + Cases E & F
 SPEC.md                           M   This file
 tasks/plan.md                     M   #987 plan
 tasks/todo.md                     M   #987 todo
-tasks/archive/2026-05-24-scope-guard-985/  A   Carry-over: archived #985 plan + todo
+tasks/archive/2026-05-25-scope-guard-985/  A   Carry-over: archived #985 plan + todo
 ```
 
 **Total scope:** 5 substantive lifecycle files + 2 archive carry-over files = **7 files**. No changes to `.github/workflows/`, `CLAUDE.md`, `AGENTS.md`, `ARCHITECTURE.md`, or any `_posts/`, `_sass/`, `_layouts/`, `_config.yml`.

--- a/scripts/check-pr-scope.sh
+++ b/scripts/check-pr-scope.sh
@@ -85,15 +85,22 @@ echo "check-pr-scope: checking $(echo "$CHANGED_FILES" | wc -l | tr -d ' ') chan
 echo ""
 
 # ---------------------------------------------------------------------------
+# has_label <label-name> — exact-match check against the comma-joined
+# PR_LABELS (the format github.event.pull_request.labels.*.name | join(',')
+# produces in CI). Single source of truth for all label-driven bypasses so
+# a future label can't accidentally reintroduce an unanchored grep.
+# ---------------------------------------------------------------------------
+has_label() {
+  [ -z "${1:-}" ] && return 1
+  printf '%s\n' "${PR_LABELS:-}" | tr ',' '\n' | grep -Fxq "$1"
+}
+
+# ---------------------------------------------------------------------------
 # Rule 1: Protected files
 # ---------------------------------------------------------------------------
 for protected in "${PROTECTED_FILES[@]}"; do
   if echo "$CHANGED_FILES" | grep -qx "$protected"; then
-    # Anchored exact-match against the comma-joined PR_LABELS (the format
-    # github.event.pull_request.labels.*.name | join(',') produces in CI).
-    # Substring matching would let an unrelated label like
-    # "not-protected-file-update-foo" silently bypass the protection.
-    if printf '%s\n' "${PR_LABELS:-}" | tr ',' '\n' | grep -Fxq 'protected-file-update' && \
+    if has_label 'protected-file-update' && \
        printf '%s\n' "${PROTECTED_FILE_UPDATE_BYPASS[@]}" | grep -qx "$protected"; then
       echo "check-pr-scope: protected-file-update label present — bypassing protection for '$protected'."
       continue
@@ -107,7 +114,7 @@ done
 # Rule 2: >15 files changed (scope explosion)
 # Skip if PR is a deliberate bulk-content change (label: bulk-content)
 # ---------------------------------------------------------------------------
-if echo "${PR_LABELS:-}" | grep -q 'bulk-content'; then
+if has_label 'bulk-content'; then
   echo "check-pr-scope: bulk-content label present — skipping rule 2."
 else
   FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
@@ -121,7 +128,7 @@ fi
 # Rule 3: .github/skills/ or .github/instructions/ governance surfaces
 # Skip if PR is a deliberate governance update (label: governance-update)
 # ---------------------------------------------------------------------------
-if echo "${PR_LABELS:-}" | grep -q 'governance-update'; then
+if has_label 'governance-update'; then
   echo "check-pr-scope: governance-update label present — skipping rule 3."
 else
   GOVERNANCE_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^\.github/(skills|instructions)/' || true)

--- a/tasks/archive/2026-05-25-scope-guard-985/plan.md
+++ b/tasks/archive/2026-05-25-scope-guard-985/plan.md
@@ -1,0 +1,247 @@
+# Plan — Scope-guard label exemption for legitimate AGENTS.md / ARCHITECTURE.md changes (#985)
+
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#985](https://github.com/oviney/blog/issues/985)
+**Date:** 2026-05-24
+**Labels:** `agent:qa-gatekeeper`, `governance-update`
+**Branch:** `fix/985-scope-guard-protected-file-bypass` (to be created)
+**Lifecycle phase:** PLAN
+
+---
+
+## Scope summary
+
+Bash change to `scripts/check-pr-scope.sh` (per-file bypass inside Rule 1), new fixture-based test harness (`tests/scope-guard.sh`), one workflow-step wiring (`.github/workflows/test-build.yml`), and one docs row (`CLAUDE.md`). Four atomic commits. RED→GREEN sequencing — failing test harness lands first to expose the gap, then the bypass logic makes it pass.
+
+---
+
+## Dependency graph
+
+```
+Phase 0 (branch setup)
+    │
+    ▼
+Phase 1 (tests/scope-guard.sh — RED)
+    │   Case A passes (current behaviour: AGENTS.md no label → fail)
+    │   Case B FAILS (current behaviour: AGENTS.md with label → still fails — gap exposed)
+    │   Case C passes (current behaviour: Gemfile with label → fail)
+    │
+    ▼   Checkpoint A: confirm Case B is the only failing case
+    │
+Phase 2 (check-pr-scope.sh bypass — GREEN)
+    │   Case A still passes (no-label behaviour unchanged)
+    │   Case B now passes (label bypass works)
+    │   Case C still passes (label does NOT exempt Gemfile)
+    │
+    ▼   Checkpoint B: all three cases pass; replay against #984 diff state confirms fix
+    │
+Phase 3 (CI wiring)
+    │   .github/workflows/test-build.yml runs tests/scope-guard.sh
+    │
+    ▼
+Phase 4 (CLAUDE.md docs row)
+    │
+    ▼   Checkpoint C: full 10-AC battery
+    │
+Phase 5 (ship)
+```
+
+**Why this order, not RED→GREEN→docs→CI:**
+- Putting the test BEFORE the implementation surfaces the gap explicitly (the test was the reason for this PR in the first place).
+- CI wiring AFTER both test + script ensures CI doesn't run a failing test against an unfixed script on any pushed commit. CI runs only on branch tip; pushing all four commits together means CI sees the final green state.
+- Docs row at the end so the commit message can reference the final label name (no rework if the label name changed during build).
+
+---
+
+## Vertical slices
+
+### Phase 0 — Branch setup
+
+| Task | Action |
+|---|---|
+| 0.1 | Create branch `fix/985-scope-guard-protected-file-bypass` off `main` (post-#984-merge state at `4e22be8e`) |
+| 0.2 | Confirm working tree clean (sans the pre-existing `security.md` case-collision artifact + untracked `worktrees/`) |
+
+---
+
+### Phase 1 — `tests/scope-guard.sh` (RED — fixture harness lands first)
+
+*One atomic commit. Implements the test before the implementation it tests.*
+
+| Task | Action |
+|---|---|
+| 1.1 | Create `tests/scope-guard.sh` (~80 lines). Header documents the three fixture cases and the temp-git-repo pattern. |
+| 1.2 | Define `run_case <name> <pr_labels> <changed_file> <expected_exit> <expected_grep>` helper. Creates temp git repo via `mktemp -d`, `git init -q`, configures `origin` to a second temp clone (so `origin/main` resolves), commits a baseline, branches, modifies the changed file, copies the production `scripts/check-pr-scope.sh` into the temp repo, runs it with the given `PR_LABELS`, captures exit code + stdout, asserts expected exit + grep, prints pass/fail line. |
+| 1.3 | Add `trap` to clean up the temp dir on exit. |
+| 1.4 | Wire the three fixture cases per SPEC §3 AC-4 (Case A no-label-AGENTS.md, Case B with-label-AGENTS.md, Case C with-label-Gemfile). |
+| 1.5 | Final block: `if [ $FAIL -eq 0 ]; then echo "All N cases passed"; exit 0; else exit 1; fi`. |
+| 1.6 | `chmod +x tests/scope-guard.sh`. |
+
+**Phase 1 ACs covered:** AC-4 (test structure exists).
+
+**Phase 1 verification (expected RED):**
+```bash
+bash tests/scope-guard.sh
+# Expected: Case A PASS, Case B FAIL, Case C PASS — overall exit 1
+# The failure is the entire point — Case B is the gap we're filling next.
+```
+
+**Commit:** `test(#985): add scope-guard fixture test (RED on Case B)`
+
+---
+
+### Checkpoint A — Confirm the gap is real
+
+- [ ] Case A: PASS (AGENTS.md, no label → guard fails as expected)
+- [ ] Case B: **FAIL** (AGENTS.md, label → guard fails — this is the gap we're about to fix)
+- [ ] Case C: PASS (Gemfile, label → guard fails as expected — label doesn't blanket-bypass)
+
+If Case A or Case C fails, the test harness has a bug — debug before moving to Phase 2. If Case B passes, the script already has the bypass somehow — recheck the issue's premise.
+
+---
+
+### Phase 2 — `scripts/check-pr-scope.sh` per-file bypass (GREEN)
+
+*One atomic commit. Smallest possible change to the script.*
+
+| Task | Action |
+|---|---|
+| 2.1 | Add `PROTECTED_FILE_UPDATE_BYPASS=("AGENTS.md" "ARCHITECTURE.md")` array immediately below `PROTECTED_FILES=( … )` (around line 52). |
+| 2.2 | Modify Rule 1 loop (lines 75–80) to a two-tier check: inside the existing `if echo "$CHANGED_FILES" | grep -qx "$protected"; then` block, check `if echo "${PR_LABELS:-}" | grep -q 'protected-file-update' && printf '%s\n' "${PROTECTED_FILE_UPDATE_BYPASS[@]}" | grep -qx "$protected"; then` → emit bypass log line + `continue`. |
+| 2.3 | Update docblock at lines 21–29: add `protected-file-update` entry alongside `bulk-content` and `governance-update`, with one PASS example (`AGENTS.md` modified + label → bypass) and one FAIL example (`Gemfile` modified + label → still fails). |
+| 2.4 | No changes to Rules 2, 3, 4 or the summary block. |
+
+**Phase 2 ACs covered:** AC-1, AC-2, AC-3, AC-6.
+
+**Phase 2 verification (expected GREEN):**
+```bash
+bash tests/scope-guard.sh
+# Expected: All three cases PASS — overall exit 0
+```
+
+**Manual replay (AC-8):**
+```bash
+# In a separate worktree, NOT this branch's working tree
+git worktree add /tmp/replay-984 4e22be8e^
+cd /tmp/replay-984
+git diff --name-only 4e22be8e^..4e22be8e   # confirm AGENTS.md in diff
+# Now run the script as if at the merge commit's pre-state with various labels
+# (replay using the new script content)
+cp <branch>/scripts/check-pr-scope.sh ./scripts/check-pr-scope.sh
+git diff main...4e22be8e --name-only > /tmp/changed.txt    # cheap stand-in
+PR_LABELS="" bash scripts/check-pr-scope.sh    # expect FAIL on AGENTS.md
+PR_LABELS="protected-file-update" bash scripts/check-pr-scope.sh   # expect PASS
+git worktree remove /tmp/replay-984
+```
+
+**Commit:** `fix(#985): add per-file protected-file-update label bypass to Rule 1`
+
+---
+
+### Checkpoint B — All three cases green
+
+- [ ] `bash tests/scope-guard.sh` exits 0 with all three cases PASS
+- [ ] Manual replay against #984 diff state confirms the original false positive is now fixed
+- [ ] `bash scripts/check-pr-scope.sh` against the current branch (no protected files) still PASSES — baseline behaviour preserved
+
+---
+
+### Phase 3 — CI wiring (`test-build.yml`)
+
+*One atomic commit. Single workflow file change.*
+
+| Task | Action |
+|---|---|
+| 3.1 | In `.github/workflows/test-build.yml`, add a new step under the existing `check-agent-scope` job (lines 95–109): `- name: Run scope-guard fixture tests` + `run: bash tests/scope-guard.sh`. Place it AFTER the `Check agent scope compliance` step so the production check runs first. |
+| 3.2 | No `env:` block needed for the new step — `tests/scope-guard.sh` sets `PR_LABELS` internally per case. |
+
+**Phase 3 ACs covered:** AC-5.
+
+**Phase 3 verification:**
+```bash
+yq eval '.jobs.check-agent-scope.steps' .github/workflows/test-build.yml   # confirm new step present
+# CI verification deferred to /ship — runs on push.
+```
+
+**Commit:** `ci(#985): run scope-guard fixture tests in check-agent-scope job`
+
+---
+
+### Phase 4 — `CLAUDE.md` docs row
+
+*One atomic commit. Docs only.*
+
+| Task | Action |
+|---|---|
+| 4.1 | Find the "Local Agent Labels" or similar label-documentation table in `CLAUDE.md` (line 78 area mentions `governance-update`, line 83 mentions `bulk-content`). |
+| 4.2 | Add a `protected-file-update` row/paragraph alongside the existing two labels, with one-line definition + use cases ("issue-driven `AGENTS.md` or `ARCHITECTURE.md` changes; does NOT bypass `_config.yml`, `Gemfile*`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`"). |
+| 4.3 | If the existing label documentation lives in a tabular form, mirror it; if prose, mirror prose. |
+
+**Phase 4 ACs covered:** AC-7.
+
+**Phase 4 verification:**
+```bash
+grep -c "protected-file-update" CLAUDE.md   # expect ≥ 1
+```
+
+**Commit:** `docs(#985): document protected-file-update label in CLAUDE.md`
+
+---
+
+### Checkpoint C — Full 10-AC battery
+
+| AC | Check |
+|----|---|
+| AC-1 | `grep -n "PROTECTED_FILE_UPDATE_BYPASS" scripts/check-pr-scope.sh` → present |
+| AC-2 | Case A (no-label) FAILs, Case B (with-label-AGENTS.md) PASSes — covered by test harness |
+| AC-3 | Case C (with-label-Gemfile) FAILs — covered by test harness |
+| AC-4 | `bash tests/scope-guard.sh` exits 0 with 3/3 PASS |
+| AC-5 | `.github/workflows/test-build.yml` invokes `tests/scope-guard.sh` |
+| AC-6 | `grep -c "protected-file-update" scripts/check-pr-scope.sh` ≥ 3 (array + bypass log + docblock) |
+| AC-7 | `grep -c "protected-file-update" CLAUDE.md` ≥ 1 |
+| AC-8 | Manual #984-replay PASSes with label, FAILs without (Checkpoint B) |
+| AC-9 | `bundle exec jekyll build` exits 0 |
+| AC-10 | `git diff --name-only main...HEAD` returns ≤ 7 files (lifecycle + 4 substantive) |
+
+**Pass criteria:** all 10 ACs green.
+
+---
+
+### Phase 5 — Ship
+
+*Standard `/ship` flow.*
+
+| Task | Action |
+|---|---|
+| 5.1 | Push branch `fix/985-scope-guard-protected-file-bypass`. |
+| 5.2 | Open PR with `Closes #985`. Apply `agent:qa-gatekeeper` + `governance-update` labels (the script change touches `scripts/` — QA gatekeeper's domain — and the policy change is a governance update). |
+| 5.3 | CI: `check-agent-scope` should pass (no protected file in this PR's diff); new scope-guard test step should pass on all three cases. |
+| 5.4 | Wait for CI green. Admin-merge if blocked by 1-reviewer rule. |
+| 5.5 | Post-merge: confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
+| 5.6 | Comment on #985 with production verification notes. |
+| 5.7 | Update [[reference-scope-guard]] memory to note that #985 is merged and the workaround is no longer needed. |
+
+---
+
+## Risks (from SPEC §10, re-evaluated)
+
+| Risk | Realised? | Plan response |
+|---|---|---|
+| `grep -q 'protected-file-update'` substring-matches a confusable label like `protected-file-update-experimental` | No (no such label exists today) | Match `bulk-content` / `governance-update` precedent of unanchored grep; document as future hardening |
+| Temp-git-repo test fixtures flaky in CI | Unknown until Phase 5 CI run | Each case ~1s; if flaky, add `set -x` tracing in the test harness |
+| Workflow-file edit (`.github/workflows/test-build.yml`) trips Rule 4 agent-scope check | No — `agent:qa-gatekeeper` is explicitly allowed `.github/workflows/` (script line 128, AGENTS.md line 67) | None needed |
+| Script change breaks the existing guard for unrelated in-flight PRs | Mitigated by Checkpoint B (no-protected-file baseline still passes) and Case A (no-label behaviour preserved) | None additional |
+| Phantom `build` check + 1-reviewer rule blocks merge | Yes — recurring | Admin-merge per #953 / #984 precedent |
+
+---
+
+## Out of scope (locked, per SPEC §11)
+
+- Removing files from `PROTECTED_FILES`
+- Extending bypass to infra files
+- Extending `governance-update` to cover Rule 1
+- Refactoring script structure
+- Adding a `--self-test` mode to the script
+- A separate `LABELS.md` doc
+- Backfilling tests for existing `bulk-content` / `governance-update` rules
+- Touching `AGENTS.md` or `ARCHITECTURE.md` (they're the test subject, not the target)

--- a/tasks/archive/2026-05-25-scope-guard-985/todo.md
+++ b/tasks/archive/2026-05-25-scope-guard-985/todo.md
@@ -1,0 +1,81 @@
+# TODO — Scope-guard label exemption (#985)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Branch:** `fix/985-scope-guard-protected-file-bypass` (to create)
+
+---
+
+## Phase 0 — Setup
+
+- [ ] 0.1 Create branch `fix/985-scope-guard-protected-file-bypass` off `main` (at `4e22be8e`)
+- [ ] 0.2 Confirm working tree clean apart from known artifacts (`security.md` case-collision; untracked `worktrees/`)
+
+## Phase 1 — Test harness (RED) — one commit
+
+- [ ] 1.1 Create `tests/scope-guard.sh` with header docblock
+- [ ] 1.2 Implement `run_case` helper (temp git repo with origin fixture, run real script, capture exit + stdout, assert)
+- [ ] 1.3 Add `trap` to clean up temp dirs on exit/error
+- [ ] 1.4 Wire three fixture cases (A: no-label-AGENTS.md, B: with-label-AGENTS.md, C: with-label-Gemfile)
+- [ ] 1.5 Add pass/fail summary block at end
+- [ ] 1.6 `chmod +x tests/scope-guard.sh`
+- [ ] Verify (RED): `bash tests/scope-guard.sh` → exit 1; Case A PASS, Case B FAIL, Case C PASS
+- [ ] Commit: `test(#985): add scope-guard fixture test (RED on Case B)`
+
+## Checkpoint A — Gap confirmed
+
+- [ ] Case A: PASS (no-label AGENTS.md still trips guard)
+- [ ] Case B: FAIL (label doesn't yet bypass — the gap)
+- [ ] Case C: PASS (label correctly does NOT bypass Gemfile)
+
+## Phase 2 — Bypass logic (GREEN) — one commit
+
+- [ ] 2.1 Add `PROTECTED_FILE_UPDATE_BYPASS=("AGENTS.md" "ARCHITECTURE.md")` array below `PROTECTED_FILES`
+- [ ] 2.2 Add two-tier check inside Rule 1 loop (label + per-file allow-list → emit bypass log + `continue`)
+- [ ] 2.3 Update docblock at lines 21–29: document `protected-file-update` label with PASS/FAIL examples
+- [ ] 2.4 Confirm Rules 2, 3, 4 untouched
+- [ ] Verify (GREEN): `bash tests/scope-guard.sh` → exit 0; all three cases PASS
+- [ ] Verify (baseline): `bash scripts/check-pr-scope.sh` from this branch → PASS (no protected files in diff)
+- [ ] Manual replay (AC-8): worktree at `4e22be8e^`, run with/without `PR_LABELS` → matches expected
+- [ ] Commit: `fix(#985): add per-file protected-file-update label bypass to Rule 1`
+
+## Checkpoint B — All three cases green
+
+- [ ] Test harness: 3/3 PASS
+- [ ] Manual #984-replay: with-label PASS, without-label FAIL
+- [ ] No-protected-file baseline: PASS (regression guard)
+
+## Phase 3 — CI wiring — one commit
+
+- [ ] 3.1 Add new step to `check-agent-scope` job in `.github/workflows/test-build.yml`: `- name: Run scope-guard fixture tests` + `run: bash tests/scope-guard.sh`, placed AFTER the production check
+- [ ] Verify the new step is present
+- [ ] Commit: `ci(#985): run scope-guard fixture tests in check-agent-scope job`
+
+## Phase 4 — Docs — one commit
+
+- [ ] 4.1 Locate label documentation in `CLAUDE.md` (existing references at lines 78, 83, 99 for `governance-update` and `bulk-content`)
+- [ ] 4.2 Add `protected-file-update` documentation alongside in matching format (table row or prose paragraph)
+- [ ] Verify: `grep -c "protected-file-update" CLAUDE.md` ≥ 1
+- [ ] Commit: `docs(#985): document protected-file-update label in CLAUDE.md`
+
+## Checkpoint C — Full 10-AC battery before ship
+
+- [ ] AC-1 — `PROTECTED_FILE_UPDATE_BYPASS` present in script
+- [ ] AC-2 — Case A FAIL (without label), Case B PASS (with label)
+- [ ] AC-3 — Case C FAIL (Gemfile + label still trips)
+- [ ] AC-4 — `bash tests/scope-guard.sh` exits 0 (3/3 PASS)
+- [ ] AC-5 — Workflow invokes the test
+- [ ] AC-6 — `grep -c "protected-file-update" scripts/check-pr-scope.sh` ≥ 3
+- [ ] AC-7 — `grep -c "protected-file-update" CLAUDE.md` ≥ 1
+- [ ] AC-8 — Manual replay matches expectations
+- [ ] AC-9 — `bundle exec jekyll build` exit 0
+- [ ] AC-10 — `git diff --name-only main...HEAD | wc -l` ≤ 7
+
+## Phase 5 — Ship (`/ship` flow)
+
+- [ ] Push branch
+- [ ] Open PR with `Closes #985`; apply `agent:qa-gatekeeper` + `governance-update` labels
+- [ ] CI green (or admin-merge if blocked by phantom `build` + 1-reviewer rule per #953/#984 precedent)
+- [ ] Merge `--squash --delete-branch`
+- [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
+- [ ] Comment on #985 with production verification
+- [ ] Update [[reference-scope-guard]] memory: workaround no longer needed once merged

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,55 +1,54 @@
-# Plan — Scope-guard label exemption for legitimate AGENTS.md / ARCHITECTURE.md changes (#985)
+# Plan — Anchor bulk-content / governance-update label greps (#987)
 
 **Spec:** [../SPEC.md](../SPEC.md)
-**Issue:** [#985](https://github.com/oviney/blog/issues/985)
-**Date:** 2026-05-24
+**Issue:** [#987](https://github.com/oviney/blog/issues/987)
+**Date:** 2026-05-25
 **Labels:** `agent:qa-gatekeeper`, `governance-update`
-**Branch:** `fix/985-scope-guard-protected-file-bypass` (to be created)
+**Branch:** `fix/987-anchor-label-greps` (to be created)
 **Lifecycle phase:** PLAN
 
 ---
 
 ## Scope summary
 
-Bash change to `scripts/check-pr-scope.sh` (per-file bypass inside Rule 1), new fixture-based test harness (`tests/scope-guard.sh`), one workflow-step wiring (`.github/workflows/test-build.yml`), and one docs row (`CLAUDE.md`). Four atomic commits. RED→GREEN sequencing — failing test harness lands first to expose the gap, then the bypass logic makes it pass.
+Two substantive file changes:
+1. `scripts/check-pr-scope.sh` — define `has_label()` helper; route Rules 1, 2, 3 label checks through it.
+2. `tests/scope-guard.sh` — extend `run_case` to accept multi-file fixtures; add Cases E + F to pin the anchored semantics for `bulk-content` and `governance-update`.
+
+Five lifecycle files (SPEC + plan + todo + 2 carry-over archive). Total **≤ 7 files**.
+
+Classical RED→GREEN order: harness refactor (semantics-preserving) → new failing cases (gap exposed) → helper extraction (gap fixed).
 
 ---
 
 ## Dependency graph
 
 ```
-Phase 0 (branch setup)
+Phase 0 (branch + lifecycle)
     │
     ▼
-Phase 1 (tests/scope-guard.sh — RED)
-    │   Case A passes (current behaviour: AGENTS.md no label → fail)
-    │   Case B FAILS (current behaviour: AGENTS.md with label → still fails — gap exposed)
-    │   Case C passes (current behaviour: Gemfile with label → fail)
+Phase 1 (extend run_case to multi-file)
+    │   Cases A–D still 4/4 PASS (semantics-preserving refactor)
     │
-    ▼   Checkpoint A: confirm Case B is the only failing case
+    ▼   Checkpoint A: refactor regression-clean
     │
-Phase 2 (check-pr-scope.sh bypass — GREEN)
-    │   Case A still passes (no-label behaviour unchanged)
-    │   Case B now passes (label bypass works)
-    │   Case C still passes (label does NOT exempt Gemfile)
+Phase 2 (add Cases E + F — RED)
+    │   Cases A–D PASS, E + F FAIL (substring antipattern exposed)
     │
-    ▼   Checkpoint B: all three cases pass; replay against #984 diff state confirms fix
+    ▼   Checkpoint B: gap confirmed real
     │
-Phase 3 (CI wiring)
-    │   .github/workflows/test-build.yml runs tests/scope-guard.sh
-    │
-    ▼
-Phase 4 (CLAUDE.md docs row)
+Phase 3 (extract has_label + migrate 3 rules — GREEN)
+    │   Cases A–F all 6/6 PASS (helper anchors all three)
     │
     ▼   Checkpoint C: full 10-AC battery
     │
-Phase 5 (ship)
+Phase 4 (ship)
 ```
 
-**Why this order, not RED→GREEN→docs→CI:**
-- Putting the test BEFORE the implementation surfaces the gap explicitly (the test was the reason for this PR in the first place).
-- CI wiring AFTER both test + script ensures CI doesn't run a failing test against an unfixed script on any pushed commit. CI runs only on branch tip; pushing all four commits together means CI sees the final green state.
-- Docs row at the end so the commit message can reference the final label name (no rework if the label name changed during build).
+**Why this order:**
+- Harness refactor first: lets Cases E + F be added cleanly in Phase 2 without touching the production script yet.
+- Cases E + F before the script change: classic TDD — write the failing test, then make it pass. Branch history clearly records the gap → fix.
+- Helper extraction last: lands the fix that turns the failing cases green. Migrating Rule 1 through the same helper at this step preserves the anchored behaviour #988 already established and prevents future drift.
 
 ---
 
@@ -59,132 +58,105 @@ Phase 5 (ship)
 
 | Task | Action |
 |---|---|
-| 0.1 | Create branch `fix/985-scope-guard-protected-file-bypass` off `main` (post-#984-merge state at `4e22be8e`) |
-| 0.2 | Confirm working tree clean (sans the pre-existing `security.md` case-collision artifact + untracked `worktrees/`) |
+| 0.1 | `git fetch origin main`; checkout main; pull (current main at `a7f5021b`, the #988 merge) |
+| 0.2 | `git switch -c fix/987-anchor-label-greps` |
+| 0.3 | Stash #987 lifecycle work (SPEC + plan + todo) before the switch if not already; pop after |
+| 0.4 | Archive #985 lifecycle artifacts to `tasks/archive/2026-05-25-scope-guard-985/` |
+| 0.5 | Commit lifecycle: `docs(#987): lifecycle artifacts (SPEC + plan + todo) for label-grep anchoring` |
 
 ---
 
-### Phase 1 — `tests/scope-guard.sh` (RED — fixture harness lands first)
-
-*One atomic commit. Implements the test before the implementation it tests.*
+### Phase 1 — Extend `run_case` to multi-file fixtures
+*One atomic commit. Semantics-preserving refactor; Cases A–D continue passing.*
 
 | Task | Action |
 |---|---|
-| 1.1 | Create `tests/scope-guard.sh` (~80 lines). Header documents the three fixture cases and the temp-git-repo pattern. |
-| 1.2 | Define `run_case <name> <pr_labels> <changed_file> <expected_exit> <expected_grep>` helper. Creates temp git repo via `mktemp -d`, `git init -q`, configures `origin` to a second temp clone (so `origin/main` resolves), commits a baseline, branches, modifies the changed file, copies the production `scripts/check-pr-scope.sh` into the temp repo, runs it with the given `PR_LABELS`, captures exit code + stdout, asserts expected exit + grep, prints pass/fail line. |
-| 1.3 | Add `trap` to clean up the temp dir on exit. |
-| 1.4 | Wire the three fixture cases per SPEC §3 AC-4 (Case A no-label-AGENTS.md, Case B with-label-AGENTS.md, Case C with-label-Gemfile). |
-| 1.5 | Final block: `if [ $FAIL -eq 0 ]; then echo "All N cases passed"; exit 0; else exit 1; fi`. |
-| 1.6 | `chmod +x tests/scope-guard.sh`. |
+| 1.1 | In `tests/scope-guard.sh`, modify `run_case` so `$3` (`file_to_modify`) is treated as a newline-separated list of paths. Iterate over each, `mkdir -p $(dirname)` if needed, `printf 'modified\n' >> "$f"`, `git add .` once after the loop. |
+| 1.2 | No change required at the four existing call sites (A, B, C, D each pass a single path which is a 1-element list under the new contract). |
+| 1.3 | Add a comment above `run_case` documenting the multi-file contract: "If `$3` contains newlines, each path is touched in turn." |
 
-**Phase 1 ACs covered:** AC-4 (test structure exists).
+**Phase 1 ACs covered:** AC-3 (multi-file `run_case` contract).
 
-**Phase 1 verification (expected RED):**
+**Phase 1 verification:**
 ```bash
 bash tests/scope-guard.sh
-# Expected: Case A PASS, Case B FAIL, Case C PASS — overall exit 1
-# The failure is the entire point — Case B is the gap we're filling next.
+# Expected: 4/4 PASS, exit 0 (Cases A–D semantics-preserved)
 ```
 
-**Commit:** `test(#985): add scope-guard fixture test (RED on Case B)`
+**Commit:** `test(#987): extend run_case to accept newline-separated multi-file fixtures`
 
 ---
 
-### Checkpoint A — Confirm the gap is real
+### Checkpoint A — Refactor regression-clean
 
-- [ ] Case A: PASS (AGENTS.md, no label → guard fails as expected)
-- [ ] Case B: **FAIL** (AGENTS.md, label → guard fails — this is the gap we're about to fix)
-- [ ] Case C: PASS (Gemfile, label → guard fails as expected — label doesn't blanket-bypass)
-
-If Case A or Case C fails, the test harness has a bug — debug before moving to Phase 2. If Case B passes, the script already has the bypass somehow — recheck the issue's premise.
+- [ ] Cases A, B, C, D all PASS post-refactor
+- [ ] No new dependencies (still bash + git only)
+- [ ] Trap cleanup unchanged
 
 ---
 
-### Phase 2 — `scripts/check-pr-scope.sh` per-file bypass (GREEN)
-
-*One atomic commit. Smallest possible change to the script.*
+### Phase 2 — Cases E and F (RED)
+*One atomic commit. Adds failing tests that expose the substring antipattern.*
 
 | Task | Action |
 |---|---|
-| 2.1 | Add `PROTECTED_FILE_UPDATE_BYPASS=("AGENTS.md" "ARCHITECTURE.md")` array immediately below `PROTECTED_FILES=( … )` (around line 52). |
-| 2.2 | Modify Rule 1 loop (lines 75–80) to a two-tier check: inside the existing `if echo "$CHANGED_FILES" | grep -qx "$protected"; then` block, check `if echo "${PR_LABELS:-}" | grep -q 'protected-file-update' && printf '%s\n' "${PROTECTED_FILE_UPDATE_BYPASS[@]}" | grep -qx "$protected"; then` → emit bypass log line + `continue`. |
-| 2.3 | Update docblock at lines 21–29: add `protected-file-update` entry alongside `bulk-content` and `governance-update`, with one PASS example (`AGENTS.md` modified + label → bypass) and one FAIL example (`Gemfile` modified + label → still fails). |
-| 2.4 | No changes to Rules 2, 3, 4 or the summary block. |
+| 2.1 | Add Case E to `tests/scope-guard.sh`: 21 unique unprotected paths (`tests-e-1.txt` through `tests-e-21.txt`), `PR_LABELS="not-bulk-content-foo"`, expected exit=1, expected grep=`VIOLATION [scope-explosion]`. |
+| 2.2 | Add Case F: single path `.github/skills/scope-guard-test/SKILL.md` (multi-segment path that triggers Rule 3), `PR_LABELS="governance-update-experimental"`, expected exit=1, expected grep=`VIOLATION [governance-surface]`. |
+| 2.3 | Verify Case E's 21-path string uses `printf '%s\n'` correctly so each line becomes a fixture file. |
 
-**Phase 2 ACs covered:** AC-1, AC-2, AC-3, AC-6.
+**Phase 2 ACs covered:** AC-4 (Cases E and F defined).
 
-**Phase 2 verification (expected GREEN):**
+**Phase 2 verification (expected RED):**
 ```bash
 bash tests/scope-guard.sh
-# Expected: All three cases PASS — overall exit 0
+# Expected: 4 PASS (A–D), 2 FAIL (E, F) — overall exit 1
+# Case E fails: `grep -q 'bulk-content'` matches "not-bulk-content-foo" → Rule 2 wrongly skipped → guard returns exit 0
+# Case F fails: `grep -q 'governance-update'` matches "governance-update-experimental" → Rule 3 wrongly skipped → guard returns exit 0
 ```
 
-**Manual replay (AC-8):**
-```bash
-# In a separate worktree, NOT this branch's working tree
-git worktree add /tmp/replay-984 4e22be8e^
-cd /tmp/replay-984
-git diff --name-only 4e22be8e^..4e22be8e   # confirm AGENTS.md in diff
-# Now run the script as if at the merge commit's pre-state with various labels
-# (replay using the new script content)
-cp <branch>/scripts/check-pr-scope.sh ./scripts/check-pr-scope.sh
-git diff main...4e22be8e --name-only > /tmp/changed.txt    # cheap stand-in
-PR_LABELS="" bash scripts/check-pr-scope.sh    # expect FAIL on AGENTS.md
-PR_LABELS="protected-file-update" bash scripts/check-pr-scope.sh   # expect PASS
-git worktree remove /tmp/replay-984
-```
-
-**Commit:** `fix(#985): add per-file protected-file-update label bypass to Rule 1`
+**Commit:** `test(#987): add Cases E and F (RED — substring antipatterns on bulk-content/governance-update)`
 
 ---
 
-### Checkpoint B — All three cases green
+### Checkpoint B — Gap confirmed real
 
-- [ ] `bash tests/scope-guard.sh` exits 0 with all three cases PASS
-- [ ] Manual replay against #984 diff state confirms the original false positive is now fixed
-- [ ] `bash scripts/check-pr-scope.sh` against the current branch (no protected files) still PASSES — baseline behaviour preserved
+- [ ] Cases A–D: PASS
+- [ ] Case E: FAIL (substring antipattern wrongly bypasses Rule 2)
+- [ ] Case F: FAIL (substring antipattern wrongly bypasses Rule 3)
+- [ ] Exit code 1 overall
+
+If A–D fail, the multi-file refactor regressed something — debug before Phase 3.
+If E/F pass, the antipattern doesn't behave as expected — recheck the issue premise.
 
 ---
 
-### Phase 3 — CI wiring (`test-build.yml`)
-
-*One atomic commit. Single workflow file change.*
+### Phase 3 — `has_label()` helper + 3-rule migration (GREEN)
+*One atomic commit. Closes the antipattern globally.*
 
 | Task | Action |
 |---|---|
-| 3.1 | In `.github/workflows/test-build.yml`, add a new step under the existing `check-agent-scope` job (lines 95–109): `- name: Run scope-guard fixture tests` + `run: bash tests/scope-guard.sh`. Place it AFTER the `Check agent scope compliance` step so the production check runs first. |
-| 3.2 | No `env:` block needed for the new step — `tests/scope-guard.sh` sets `PR_LABELS` internally per case. |
+| 3.1 | In `scripts/check-pr-scope.sh`, define `has_label()` near the top of the rule section (after `CHANGED_FILES` line ~62, before Rule 1 line ~75). Signature: `has_label() { [ -z "${1:-}" ] && return 1; printf '%s\n' "${PR_LABELS:-}" \| tr ',' '\n' \| grep -Fxq "$1"; }`. |
+| 3.2 | Migrate Rule 1's anchored grep (current line ~96, the `protected-file-update` check) to `if has_label 'protected-file-update' && …; then`. Preserve the existing `&& …` per-file allow-list and the existing bypass log line. |
+| 3.3 | Replace Rule 2's `if echo "${PR_LABELS:-}" \| grep -q 'bulk-content'; then` (line ~110) with `if has_label 'bulk-content'; then`. Existing log/skip body unchanged. |
+| 3.4 | Replace Rule 3's `if echo "${PR_LABELS:-}" \| grep -q 'governance-update'; then` (line ~124) with `if has_label 'governance-update'; then`. Existing log/skip body unchanged. |
+| 3.5 | Confirm no remaining inline `grep -q '<label-string>'` patterns in the rule bodies for the three label-driven bypasses. |
+| 3.6 | Leave the `agent:*` checks (lines ~148–161) untouched — they're prefix-string matches, not substring antipatterns. Out of scope per SPEC §11. |
 
-**Phase 3 ACs covered:** AC-5.
+**Phase 3 ACs covered:** AC-1 (helper defined), AC-2 (three rules route through it), AC-5 (Cases A–D regression-clean), AC-6 (6/6 PASS).
 
-**Phase 3 verification:**
+**Phase 3 verification (expected GREEN):**
 ```bash
-yq eval '.jobs.check-agent-scope.steps' .github/workflows/test-build.yml   # confirm new step present
-# CI verification deferred to /ship — runs on push.
+bash tests/scope-guard.sh
+# Expected: 6/6 PASS, exit 0
+# Case A still passes (no-label fail unchanged)
+# Case B still passes (protected-file-update bypass via helper)
+# Case C still passes (Gemfile + label still trips — per-file allow-list intact)
+# Case D still passes (substring label "not-protected-file-update-foo" anchored away — same as before, just via helper)
+# Case E now passes (bulk-content substring no longer bypasses → Rule 2 trips → exit 1)
+# Case F now passes (governance-update substring no longer bypasses → Rule 3 trips → exit 1)
 ```
 
-**Commit:** `ci(#985): run scope-guard fixture tests in check-agent-scope job`
-
----
-
-### Phase 4 — `CLAUDE.md` docs row
-
-*One atomic commit. Docs only.*
-
-| Task | Action |
-|---|---|
-| 4.1 | Find the "Local Agent Labels" or similar label-documentation table in `CLAUDE.md` (line 78 area mentions `governance-update`, line 83 mentions `bulk-content`). |
-| 4.2 | Add a `protected-file-update` row/paragraph alongside the existing two labels, with one-line definition + use cases ("issue-driven `AGENTS.md` or `ARCHITECTURE.md` changes; does NOT bypass `_config.yml`, `Gemfile*`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`"). |
-| 4.3 | If the existing label documentation lives in a tabular form, mirror it; if prose, mirror prose. |
-
-**Phase 4 ACs covered:** AC-7.
-
-**Phase 4 verification:**
-```bash
-grep -c "protected-file-update" CLAUDE.md   # expect ≥ 1
-```
-
-**Commit:** `docs(#985): document protected-file-update label in CLAUDE.md`
+**Commit:** `fix(#987): extract has_label() helper; anchor bulk-content and governance-update label checks`
 
 ---
 
@@ -192,34 +164,34 @@ grep -c "protected-file-update" CLAUDE.md   # expect ≥ 1
 
 | AC | Check |
 |----|---|
-| AC-1 | `grep -n "PROTECTED_FILE_UPDATE_BYPASS" scripts/check-pr-scope.sh` → present |
-| AC-2 | Case A (no-label) FAILs, Case B (with-label-AGENTS.md) PASSes — covered by test harness |
-| AC-3 | Case C (with-label-Gemfile) FAILs — covered by test harness |
-| AC-4 | `bash tests/scope-guard.sh` exits 0 with 3/3 PASS |
-| AC-5 | `.github/workflows/test-build.yml` invokes `tests/scope-guard.sh` |
-| AC-6 | `grep -c "protected-file-update" scripts/check-pr-scope.sh` ≥ 3 (array + bypass log + docblock) |
-| AC-7 | `grep -c "protected-file-update" CLAUDE.md` ≥ 1 |
-| AC-8 | Manual #984-replay PASSes with label, FAILs without (Checkpoint B) |
-| AC-9 | `bundle exec jekyll build` exits 0 |
-| AC-10 | `git diff --name-only main...HEAD` returns ≤ 7 files (lifecycle + 4 substantive) |
+| AC-1 | `grep -c "^has_label()" scripts/check-pr-scope.sh` → 1 |
+| AC-2 | `grep -cE "has_label '" scripts/check-pr-scope.sh` → 3 (Rules 1, 2, 3); no remaining inline `grep -q 'bulk-content\|governance-update\|protected-file-update'` patterns in rule bodies |
+| AC-3 | `run_case` accepts multi-file input (verified by Case E's 21-path fixture working) |
+| AC-4 | Cases E + F present in `tests/scope-guard.sh` |
+| AC-5 | Cases A–D still PASS post-refactor |
+| AC-6 | `bash tests/scope-guard.sh` exits 0 with 6/6 PASS |
+| AC-7 | `bash scripts/check-pr-scope.sh` against current branch (no protected file in diff) returns PASS |
+| AC-8 | `bundle exec jekyll build` exits 0 |
+| AC-9 | `git diff --name-only main...HEAD \| wc -l` ≤ 7 |
+| AC-10 | Manual sanity (or via fixture probe): `PR_LABELS="bulk-content"` + 16 files → Rule 2 bypassed; `PR_LABELS="governance-update"` + `.github/skills/foo` → Rule 3 bypassed. No regression of canonical labels. |
 
 **Pass criteria:** all 10 ACs green.
 
 ---
 
-### Phase 5 — Ship
+### Phase 4 — Ship
 
 *Standard `/ship` flow.*
 
 | Task | Action |
 |---|---|
-| 5.1 | Push branch `fix/985-scope-guard-protected-file-bypass`. |
-| 5.2 | Open PR with `Closes #985`. Apply `agent:qa-gatekeeper` + `governance-update` labels (the script change touches `scripts/` — QA gatekeeper's domain — and the policy change is a governance update). |
-| 5.3 | CI: `check-agent-scope` should pass (no protected file in this PR's diff); new scope-guard test step should pass on all three cases. |
-| 5.4 | Wait for CI green. Admin-merge if blocked by 1-reviewer rule. |
-| 5.5 | Post-merge: confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
-| 5.6 | Comment on #985 with production verification notes. |
-| 5.7 | Update [[reference-scope-guard]] memory to note that #985 is merged and the workaround is no longer needed. |
+| 4.1 | Push branch `fix/987-anchor-label-greps` |
+| 4.2 | Open PR with `Closes #987`; apply `agent:qa-gatekeeper` + `governance-update` labels |
+| 4.3 | CI green expected (no protected files in this PR's diff; new fixture cases pass after the helper extraction) |
+| 4.4 | Admin-merge if blocked by 1-reviewer rule (per #953/#984/#988 precedent) |
+| 4.5 | Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA |
+| 4.6 | Comment on #987 with production verification notes |
+| 4.7 | Update [[reference-scope-guard]] memory: all three label-driven bypasses now anchored; antipattern fully closed |
 
 ---
 
@@ -227,21 +199,22 @@ grep -c "protected-file-update" CLAUDE.md   # expect ≥ 1
 
 | Risk | Realised? | Plan response |
 |---|---|---|
-| `grep -q 'protected-file-update'` substring-matches a confusable label like `protected-file-update-experimental` | No (no such label exists today) | Match `bulk-content` / `governance-update` precedent of unanchored grep; document as future hardening |
-| Temp-git-repo test fixtures flaky in CI | Unknown until Phase 5 CI run | Each case ~1s; if flaky, add `set -x` tracing in the test harness |
-| Workflow-file edit (`.github/workflows/test-build.yml`) trips Rule 4 agent-scope check | No — `agent:qa-gatekeeper` is explicitly allowed `.github/workflows/` (script line 128, AGENTS.md line 67) | None needed |
-| Script change breaks the existing guard for unrelated in-flight PRs | Mitigated by Checkpoint B (no-protected-file baseline still passes) and Case A (no-label behaviour preserved) | None additional |
-| Phantom `build` check + 1-reviewer rule blocks merge | Yes — recurring | Admin-merge per #953 / #984 precedent |
+| Helper refactor breaks Rule 1 | Mitigated by Cases A–D regression-pinning | Checkpoints A and B verify before Phase 3 lands |
+| `has_label` accepts empty label arg | Mitigated by `[ -z "${1:-}" ] && return 1` defensive guard | Task 3.1 includes this |
+| Case E's 21 files trip an unrelated rule | Mitigated by deliberately non-protected paths (`tests-e-*.txt`) | Task 2.1 specifies the naming |
+| Case F's `.github/skills/...` path leaks into production | `tmp` fixture isolation + `trap cleanup` per existing pattern | None additional |
+| Migrating Rule 1 changes the bypass log line | The log line is per-file (`bypassing protection for '$protected'`) and lives outside the `has_label` call | Case B's expected_grep continues to match |
+| Reviewer asks for `agent:*` label anchoring | Those are prefix-strings, not substring antipatterns | SPEC §11 documents the rationale; cite if asked |
+| Phantom `build` + 1-reviewer block on PR | Yes — recurring | Admin-merge per precedent |
 
 ---
 
 ## Out of scope (locked, per SPEC §11)
 
-- Removing files from `PROTECTED_FILES`
-- Extending bypass to infra files
-- Extending `governance-update` to cover Rule 1
-- Refactoring script structure
-- Adding a `--self-test` mode to the script
-- A separate `LABELS.md` doc
-- Backfilling tests for existing `bulk-content` / `governance-update` rules
-- Touching `AGENTS.md` or `ARCHITECTURE.md` (they're the test subject, not the target)
+- `PROTECTED_FILES ↔ PROTECTED_FILE_UPDATE_BYPASS` drift guard
+- `agent:*` label check anchoring (lines 148–161)
+- Refactoring Rule 1's per-file allow-list check (`PROTECTED_FILE_UPDATE_BYPASS` grep)
+- Test framework dependencies (bats, shellspec)
+- CLAUDE.md changes (no user-visible behaviour change)
+- `AGENTS.md` / `ARCHITECTURE.md` changes (protected; not this PR's target)
+- Cross-repo / A2A protocol integration

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,81 +1,77 @@
-# TODO — Scope-guard label exemption (#985)
+# TODO — Anchor bulk-content / governance-update label greps (#987)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Branch:** `fix/985-scope-guard-protected-file-bypass` (to create)
+**Branch:** `fix/987-anchor-label-greps` (to create)
 
 ---
 
 ## Phase 0 — Setup
 
-- [ ] 0.1 Create branch `fix/985-scope-guard-protected-file-bypass` off `main` (at `4e22be8e`)
-- [ ] 0.2 Confirm working tree clean apart from known artifacts (`security.md` case-collision; untracked `worktrees/`)
+- [ ] 0.1 Fetch origin/main; confirm at `a7f5021b` (#988 merge)
+- [ ] 0.2 Stash #987 lifecycle (SPEC + plan + todo)
+- [ ] 0.3 Switch to `main`; `git pull --ff-only origin main`
+- [ ] 0.4 `git switch -c fix/987-anchor-label-greps`
+- [ ] 0.5 Pop stash; archive #985 lifecycle to `tasks/archive/2026-05-25-scope-guard-985/`
+- [ ] 0.6 Commit: `docs(#987): lifecycle artifacts (SPEC + plan + todo) for label-grep anchoring`
 
-## Phase 1 — Test harness (RED) — one commit
+## Phase 1 — Extend `run_case` for multi-file (one commit)
 
-- [ ] 1.1 Create `tests/scope-guard.sh` with header docblock
-- [ ] 1.2 Implement `run_case` helper (temp git repo with origin fixture, run real script, capture exit + stdout, assert)
-- [ ] 1.3 Add `trap` to clean up temp dirs on exit/error
-- [ ] 1.4 Wire three fixture cases (A: no-label-AGENTS.md, B: with-label-AGENTS.md, C: with-label-Gemfile)
-- [ ] 1.5 Add pass/fail summary block at end
-- [ ] 1.6 `chmod +x tests/scope-guard.sh`
-- [ ] Verify (RED): `bash tests/scope-guard.sh` → exit 1; Case A PASS, Case B FAIL, Case C PASS
-- [ ] Commit: `test(#985): add scope-guard fixture test (RED on Case B)`
+- [ ] 1.1 Modify `run_case` in `tests/scope-guard.sh`: treat `$3` as newline-separated paths; loop to touch each; single `git add .`
+- [ ] 1.2 Confirm Cases A–D unchanged at call sites (single path is still valid input)
+- [ ] 1.3 Add inline contract comment above `run_case`
+- [ ] Verify: `bash tests/scope-guard.sh` → 4/4 PASS, exit 0 (no semantics change)
+- [ ] Commit: `test(#987): extend run_case to accept newline-separated multi-file fixtures`
 
-## Checkpoint A — Gap confirmed
+## Checkpoint A — Refactor regression-clean
 
-- [ ] Case A: PASS (no-label AGENTS.md still trips guard)
-- [ ] Case B: FAIL (label doesn't yet bypass — the gap)
-- [ ] Case C: PASS (label correctly does NOT bypass Gemfile)
+- [ ] Cases A, B, C, D PASS
+- [ ] No new deps
+- [ ] Trap cleanup intact
 
-## Phase 2 — Bypass logic (GREEN) — one commit
+## Phase 2 — Cases E and F (RED) — one commit
 
-- [ ] 2.1 Add `PROTECTED_FILE_UPDATE_BYPASS=("AGENTS.md" "ARCHITECTURE.md")` array below `PROTECTED_FILES`
-- [ ] 2.2 Add two-tier check inside Rule 1 loop (label + per-file allow-list → emit bypass log + `continue`)
-- [ ] 2.3 Update docblock at lines 21–29: document `protected-file-update` label with PASS/FAIL examples
-- [ ] 2.4 Confirm Rules 2, 3, 4 untouched
-- [ ] Verify (GREEN): `bash tests/scope-guard.sh` → exit 0; all three cases PASS
-- [ ] Verify (baseline): `bash scripts/check-pr-scope.sh` from this branch → PASS (no protected files in diff)
-- [ ] Manual replay (AC-8): worktree at `4e22be8e^`, run with/without `PR_LABELS` → matches expected
-- [ ] Commit: `fix(#985): add per-file protected-file-update label bypass to Rule 1`
+- [ ] 2.1 Add Case E: 21 paths `tests-e-1.txt`…`tests-e-21.txt`, `PR_LABELS="not-bulk-content-foo"`, expect exit=1 + `VIOLATION [scope-explosion]`
+- [ ] 2.2 Add Case F: path `.github/skills/scope-guard-test/SKILL.md`, `PR_LABELS="governance-update-experimental"`, expect exit=1 + `VIOLATION [governance-surface]`
+- [ ] Verify (RED): `bash tests/scope-guard.sh` → 4 PASS (A–D), 2 FAIL (E, F), exit 1
+- [ ] Commit: `test(#987): add Cases E and F (RED — substring antipatterns on bulk-content/governance-update)`
 
-## Checkpoint B — All three cases green
+## Checkpoint B — Gap confirmed real
 
-- [ ] Test harness: 3/3 PASS
-- [ ] Manual #984-replay: with-label PASS, without-label FAIL
-- [ ] No-protected-file baseline: PASS (regression guard)
+- [ ] Cases A–D PASS
+- [ ] Case E FAIL (substring antipattern bypasses Rule 2)
+- [ ] Case F FAIL (substring antipattern bypasses Rule 3)
 
-## Phase 3 — CI wiring — one commit
+## Phase 3 — `has_label()` helper + 3-rule migration (GREEN) — one commit
 
-- [ ] 3.1 Add new step to `check-agent-scope` job in `.github/workflows/test-build.yml`: `- name: Run scope-guard fixture tests` + `run: bash tests/scope-guard.sh`, placed AFTER the production check
-- [ ] Verify the new step is present
-- [ ] Commit: `ci(#985): run scope-guard fixture tests in check-agent-scope job`
+- [ ] 3.1 Define `has_label()` in `scripts/check-pr-scope.sh` between `CHANGED_FILES` (line ~62) and Rule 1 (line ~75). Body: `[ -z "${1:-}" ] && return 1; printf '%s\n' "${PR_LABELS:-}" | tr ',' '\n' | grep -Fxq "$1"`
+- [ ] 3.2 Migrate Rule 1's `protected-file-update` check to `if has_label 'protected-file-update' && …`
+- [ ] 3.3 Migrate Rule 2's check to `if has_label 'bulk-content'`
+- [ ] 3.4 Migrate Rule 3's check to `if has_label 'governance-update'`
+- [ ] 3.5 Confirm no remaining `grep -q '<label>'` patterns in rule bodies (only inside `has_label`)
+- [ ] 3.6 Leave `agent:*` checks (lines ~148–161) untouched
+- [ ] Verify (GREEN): `bash tests/scope-guard.sh` → 6/6 PASS, exit 0
+- [ ] Verify baseline: `bash scripts/check-pr-scope.sh` on current branch → PASS
+- [ ] Commit: `fix(#987): extract has_label() helper; anchor bulk-content and governance-update label checks`
 
-## Phase 4 — Docs — one commit
+## Checkpoint C — Full 10-AC battery
 
-- [ ] 4.1 Locate label documentation in `CLAUDE.md` (existing references at lines 78, 83, 99 for `governance-update` and `bulk-content`)
-- [ ] 4.2 Add `protected-file-update` documentation alongside in matching format (table row or prose paragraph)
-- [ ] Verify: `grep -c "protected-file-update" CLAUDE.md` ≥ 1
-- [ ] Commit: `docs(#985): document protected-file-update label in CLAUDE.md`
+- [ ] AC-1: `grep -c "^has_label()" scripts/check-pr-scope.sh` → 1
+- [ ] AC-2: `grep -cE "has_label '" scripts/check-pr-scope.sh` → 3 (Rules 1, 2, 3)
+- [ ] AC-3: `run_case` multi-file works (Case E proves)
+- [ ] AC-4: Cases E + F in `tests/scope-guard.sh`
+- [ ] AC-5: Cases A–D PASS
+- [ ] AC-6: `bash tests/scope-guard.sh` → 6/6 PASS, exit 0
+- [ ] AC-7: `bash scripts/check-pr-scope.sh` against branch → PASS
+- [ ] AC-8: `bundle exec jekyll build` exit 0
+- [ ] AC-9: `git diff --name-only main...HEAD | wc -l` ≤ 7
+- [ ] AC-10: Manual sanity — canonical `bulk-content` + 16 files still bypasses Rule 2; canonical `governance-update` + `.github/skills/foo` still bypasses Rule 3
 
-## Checkpoint C — Full 10-AC battery before ship
-
-- [ ] AC-1 — `PROTECTED_FILE_UPDATE_BYPASS` present in script
-- [ ] AC-2 — Case A FAIL (without label), Case B PASS (with label)
-- [ ] AC-3 — Case C FAIL (Gemfile + label still trips)
-- [ ] AC-4 — `bash tests/scope-guard.sh` exits 0 (3/3 PASS)
-- [ ] AC-5 — Workflow invokes the test
-- [ ] AC-6 — `grep -c "protected-file-update" scripts/check-pr-scope.sh` ≥ 3
-- [ ] AC-7 — `grep -c "protected-file-update" CLAUDE.md` ≥ 1
-- [ ] AC-8 — Manual replay matches expectations
-- [ ] AC-9 — `bundle exec jekyll build` exit 0
-- [ ] AC-10 — `git diff --name-only main...HEAD | wc -l` ≤ 7
-
-## Phase 5 — Ship (`/ship` flow)
+## Phase 4 — Ship (`/ship` flow)
 
 - [ ] Push branch
-- [ ] Open PR with `Closes #985`; apply `agent:qa-gatekeeper` + `governance-update` labels
-- [ ] CI green (or admin-merge if blocked by phantom `build` + 1-reviewer rule per #953/#984 precedent)
+- [ ] Open PR with `Closes #987`; apply `agent:qa-gatekeeper` + `governance-update` labels
+- [ ] CI green (or admin-merge per #953/#984/#988 precedent)
 - [ ] Merge `--squash --delete-branch`
 - [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
-- [ ] Comment on #985 with production verification
-- [ ] Update [[reference-scope-guard]] memory: workaround no longer needed once merged
+- [ ] Comment on #987 with production verification
+- [ ] Update [[reference-scope-guard]] memory: all three label-driven bypasses now anchored

--- a/tests/scope-guard.sh
+++ b/tests/scope-guard.sh
@@ -31,17 +31,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# run_case <name> <pr_labels> <file_to_modify> <expected_exit> <expected_grep>
+# run_case <name> <pr_labels> <files_to_modify> <expected_exit> <expected_grep>
+#
+# files_to_modify is a newline-separated list of paths. Each path is touched
+# (created if not in the baseline) on the test branch so it shows up in the
+# diff vs origin/main. A single path is a valid 1-element list — Cases A–D
+# continue to work unchanged under this contract.
 run_case() {
   local name="$1"
   local labels="$2"
-  local file_to_modify="$3"
+  local files_to_modify="$3"
   local expected_exit="$4"
   local expected_grep="$5"
 
+  local file_count
+  file_count=$(printf '%s\n' "$files_to_modify" | wc -l | tr -d ' ')
+
   echo ""
   echo "Case: $name"
-  echo "  file:    $file_to_modify"
+  if [ "$file_count" = "1" ]; then
+    echo "  file:    $files_to_modify"
+  else
+    echo "  files:   $file_count paths"
+  fi
   echo "  labels:  '${labels:-<unset>}'"
   echo "  expect:  exit=$expected_exit, grep='$expected_grep'"
 
@@ -72,9 +84,17 @@ run_case() {
     git push -q origin HEAD:main
 
     git switch -c test-branch -q
-    printf 'modified\n' >> "$file_to_modify"
+    # Touch each path; create parent dirs for nested paths
+    # (e.g. .github/skills/foo/SKILL.md).
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      mkdir -p "$(dirname "$path")"
+      printf 'modified\n' >> "$path"
+    done <<EOF
+$files_to_modify
+EOF
     git add .
-    git commit -q -m "modify $file_to_modify"
+    git commit -q -m "modify $file_count file(s)"
 
     mkdir -p scripts
     cp "$PROD_SCRIPT" scripts/check-pr-scope.sh

--- a/tests/scope-guard.sh
+++ b/tests/scope-guard.sh
@@ -5,10 +5,15 @@
 # one file, copies the production check-pr-scope.sh in, runs it with the
 # given PR_LABELS, then asserts exit code + a stdout grep.
 #
-# Cases (matches SPEC §3 AC-4 for #985):
-#   A. AGENTS.md modified, no PR_LABELS                → guard fails (exit 1)
-#   B. AGENTS.md modified, PR_LABELS=protected-file-update → guard passes (exit 0)
-#   C. Gemfile modified,  PR_LABELS=protected-file-update → guard still fails (exit 1)
+# Cases (per SPEC for #985 and #987):
+#   A. AGENTS.md modified, no PR_LABELS                       → fails (exit 1)
+#   B. AGENTS.md modified, PR_LABELS=protected-file-update    → passes (exit 0)
+#   C. Gemfile modified, PR_LABELS=protected-file-update      → fails  (exit 1, per-file allow-list)
+#   D. AGENTS.md modified, PR_LABELS=not-protected-file-update-foo (substring superset) → fails (exit 1)
+#   E. 21 files modified, PR_LABELS=not-bulk-content-foo      → fails (Rule 2 trips; pins #987 anchor)
+#   F. .github/skills/... modified, PR_LABELS=governance-update-experimental → fails (Rule 3 trips; pins #987 anchor)
+#   G. 21 files modified, PR_LABELS=bulk-content              → passes (canonical bypass preserved)
+#   H. .github/skills/... modified, PR_LABELS=governance-update → passes (canonical bypass preserved)
 #
 # Dependencies: bash, git. Same constraint as the script under test.
 
@@ -178,6 +183,21 @@ run_case "F: .github/skills/ modified, confusable governance-update substring la
   ".github/skills/scope-guard-test/SKILL.md" \
   "1" \
   "VIOLATION [governance-surface]"
+
+# Pin canonical-bypass behaviour as automated coverage (was manual-probe-only
+# per SPEC AC-10). A future refactor of has_label() can't silently break the
+# exact-match canonical bypass without one of these turning red.
+run_case "G: 21 files modified, canonical bulk-content label → Rule 2 bypassed, guard passes" \
+  "bulk-content" \
+  "$FILES_E" \
+  "0" \
+  "bulk-content label present — skipping rule 2"
+
+run_case "H: .github/skills/ modified, canonical governance-update label → Rule 3 bypassed, guard passes" \
+  "governance-update" \
+  ".github/skills/scope-guard-test/SKILL.md" \
+  "0" \
+  "governance-update label present — skipping rule 3"
 
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"

--- a/tests/scope-guard.sh
+++ b/tests/scope-guard.sh
@@ -157,6 +157,28 @@ run_case "D: AGENTS.md modified, confusable label (substring superset) → guard
   "1" \
   "VIOLATION [protected-file]: 'AGENTS.md'"
 
+# Pin the anchored-grep semantics for the bulk-content label (Rule 2).
+# The label is set to a confusable substring superset that the current
+# unanchored `grep -q 'bulk-content'` mistakenly matches — wrongly
+# bypassing Rule 2 against a >15-file diff. Will be GREEN once
+# Rule 2's check is migrated to has_label().
+FILES_E=$(seq -f 'tests-e-%g.txt' 1 21)
+run_case "E: 21 files modified, confusable bulk-content substring label → guard fails on scope-explosion" \
+  "not-bulk-content-foo" \
+  "$FILES_E" \
+  "1" \
+  "VIOLATION [scope-explosion]"
+
+# Pin the anchored-grep semantics for the governance-update label (Rule 3).
+# Same antipattern as Case E but on Rule 3: a confusable superset label
+# wrongly bypasses the .github/skills/ check today. Will be GREEN once
+# Rule 3's check is migrated to has_label().
+run_case "F: .github/skills/ modified, confusable governance-update substring label → guard fails on governance-surface" \
+  "governance-update-experimental" \
+  ".github/skills/scope-guard-test/SKILL.md" \
+  "1" \
+  "VIOLATION [governance-surface]"
+
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"
 if [ "$FAIL" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Closes the substring-match antipattern on the `bulk-content` and `governance-update` label greps in `scripts/check-pr-scope.sh` by extracting a single anchored `has_label()` helper and routing all three rule-level bypass checks (Rules 1, 2, 3) through it. Completes the cleanup that #985 / PR #988 started for `protected-file-update` only.

Before this PR: confusable labels like `not-bulk-content-foo` or `governance-update-experimental` silently bypassed Rules 2 / 3 (security-auditor judged this Info / not exploitable in current threat model — fix is consistency-driven). After this PR: those labels correctly trip their respective rules.

## Changes

- **`scripts/check-pr-scope.sh`** — new `has_label(<name>)` function (5 lines); three rule-level bypass checks (Rules 1, 2, 3) all route through it. The inline anchored grep #988 added on Rule 1 is removed (now handled by the helper).
- **`tests/scope-guard.sh`** — `run_case` extended to accept newline-separated multi-file fixtures (existing 4 call sites unchanged since a single path is a 1-element list). 4 new cases:
  - **E** (RED→GREEN): `not-bulk-content-foo` + 21 files → Rule 2 trips (pins the anchor)
  - **F** (RED→GREEN): `governance-update-experimental` + `.github/skills/...` → Rule 3 trips (pins the anchor)
  - **G** (regression-pin): canonical `bulk-content` + 21 files → Rule 2 bypassed (canonical preserved)
  - **H** (regression-pin): canonical `governance-update` + `.github/skills/...` → Rule 3 bypassed (canonical preserved)

## /ship fan-out review

- **code-reviewer**: LGTM. 0 Critical / 0 Important / 1 Nit (test header comment fixed in `285857b`) / 1 CONSIDER (migrate `agent:*` greps in a follow-up — different threat shape per SPEC §11).
- **security-auditor**: CLEAN. 0 Critical/High/Medium/Low. 5 Info notes including empirical verification of `has_label()` semantics across 15 input variations (canonical, comma-joined, substring-superset, leading/trailing whitespace, empty/unset).
- **test-engineer**: SHIP. All 10 ACs green. Nice-to-have Cases G + H promoted into this PR (`285857b`) — AC-10 (canonical-bypass) was manual-probe-only; now automated.

## Test harness now reports 8/8 PASS

| Case | Scenario | Result |
|---|---|---|
| A | AGENTS.md, no label | fails ✓ |
| B | AGENTS.md, `protected-file-update` | passes ✓ |
| C | Gemfile, `protected-file-update` | fails ✓ (per-file allow-list) |
| D | AGENTS.md, `not-protected-file-update-foo` | fails ✓ (anchor pin) |
| E | 21 files, `not-bulk-content-foo` | fails ✓ (new — #987 anchor pin) |
| F | `.github/skills/`, `governance-update-experimental` | fails ✓ (new — #987 anchor pin) |
| G | 21 files, canonical `bulk-content` | passes ✓ (new — canonical regression-pin) |
| H | `.github/skills/`, canonical `governance-update` | passes ✓ (new — canonical regression-pin) |

## Acceptance criteria (from #987)

- [x] AC-1: `has_label()` defined once
- [x] AC-2: Rules 1, 2, 3 all call helper; no remaining unanchored label greps in rule bodies
- [x] AC-3: `run_case` accepts multi-file fixtures
- [x] AC-4: Cases E + F added
- [x] AC-5: Cases A–D still PASS
- [x] AC-6: `bash tests/scope-guard.sh` exit 0 (now 8/8 PASS with G + H)
- [x] AC-7: `bash scripts/check-pr-scope.sh` against branch → PASS
- [x] AC-8: `bundle exec jekyll build` exit 0
- [x] AC-9: 7 files in diff
- [x] AC-10: Canonical labels still bypass (now automated via Cases G + H)

## Rollback

Pure bash refactor; no data state, no Jekyll content, no auth/payments. `gh pr revert` reverts cleanly. RTO < 5 min.

## Follow-up candidate

- Migrate `agent:*` label checks (script lines ~155–161) to `has_label()` for full symmetry. SPEC §11 currently excludes these because they're prefix-match strings with fail-closed semantics (different threat shape from the bulk-content/governance-update fail-open antipattern). Not a security blocker per code-reviewer + security-auditor in #987 review.

Closes #987