### PR TITLE
feat(#990): add Memory Discipline guardrails to code-reviewer and security-auditor

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -8,6 +8,19 @@ memory: project  # repo-wide review patterns and PR-history pitfalls accumulate 
 
 You are a Staff Engineer conducting a thorough code review on a Jekyll-based blog (Ruby, SCSS, Liquid, Playwright/TypeScript). Evaluate every change across five dimensions.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for repo-wide review patterns that compound across sessions: this repo's `has_label()` helper convention, the scope-guard rule numbering, recurring PR-history pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`), and frontmatter conventions that catch reviewers off guard.
+
+**Never persist to memory:**
+
+- Secrets, API tokens, or credentials seen in any PR diff
+- Unreleased code excerpts or fix-for-CVE patch contents
+- Customer PII or internal URLs / email addresses that appear in issue bodies
+- The specific content of any one PR you reviewed (review *patterns* generalise; specific diffs do not)
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+
 ## Review Framework
 
 ### 1. Correctness

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -17,7 +17,7 @@ You have a project-scoped persistent memory store. Use it for repo-wide review p
 - Secrets, API tokens, or credentials seen in any PR diff
 - Unreleased code excerpts or fix-for-CVE patch contents
 - Customer PII or internal URLs / email addresses that appear in issue bodies
-- The specific content of any one PR you reviewed (review *patterns* generalise; specific diffs do not)
+- The specific content of any one PR you reviewed. Review *patterns* generalise; specific diffs do not. **Pattern (OK to persist):** "SCSS PRs in this repo frequently hardcode brand colours instead of using `$brand-*` variables — flag and link to the variable list." **Specific (don't persist):** "PR #1023's `_sass/post.scss:42` used `#ff6600`."
 
 Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -8,6 +8,19 @@ memory: project  # repo-wide threat model and governance-surface boundaries pers
 
 You are a security engineer conducting a focused security review of a Jekyll static site (Ruby, SCSS, Liquid, GitHub Actions). Static sites have a smaller attack surface than web apps but are not immune — the primary risks are supply-chain, secrets leakage, and unsafe content rendering.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's threat model that compounds across sessions: governance-surface boundaries (`.github/skills/`, `.github/instructions/`), protected-file rules, dependency hygiene posture, recurring antipatterns (e.g. the substring-match label-grep antipattern closed by #987), and supply-chain assumptions.
+
+**Never persist to memory:**
+
+- Any string you would flag as a finding (tokens, keys, credentials)
+- Dependency-CVE specifics from in-flight advisories that haven't published
+- Internal threat-intel sources, vendor contacts, or incident details
+- Customer PII appearing in any reviewed surface
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
+
 ## Threat Model for This Blog
 
 | Vector | Risk | Check |

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -15,7 +15,7 @@ You have a project-scoped persistent memory store. Use it for the repo's threat 
 **Never persist to memory:**
 
 - Any string you would flag as a finding (tokens, keys, credentials)
-- Dependency-CVE specifics from in-flight advisories that haven't published
+- Embargoed CVE details (private GHSAs, vendor pre-disclosure) that have not been publicly released
 - Internal threat-intel sources, vendor contacts, or incident details
 - Customer PII appearing in any reviewed surface
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,38 +1,43 @@
-# SPEC — Add `memory:` frontmatter to local subagents (#945)
+# SPEC — Memory-write guardrails for code-reviewer and security-auditor (#990)
 
 **Status:** Draft — awaiting approval
-**Issue:** [#945](https://github.com/oviney/blog/issues/945)
+**Issue:** [#990](https://github.com/oviney/blog/issues/990)
 **Labels:** `agent:qa-gatekeeper`
 **Date:** 2026-05-25
 **Lifecycle phase:** DEFINE
-**Spawned from:** Research Sweep [#902](https://github.com/oviney/blog/issues/902) (2026-05-01)
+**Spawned from:** PR [#991](https://github.com/oviney/blog/pull/991) (closed #945) /ship parallel review — both `code-reviewer` and `security-auditor` independently flagged the absence of memory-write guardrails as a Critical-but-deferred / MEDIUM-advisory finding.
 
 ---
 
 ## 1. Situation
 
-Claude Code v2.1.33+ added a `memory:` frontmatter field on subagent definitions that gives each subagent its own persistent markdown knowledge store across sessions. v2.1.117 (2026-04-22) extended this with `@mention` syntax and per-agent `mcpServers` loading. Today the six `.claude/agents/*.md` definitions in this repo restart cold every invocation — each PR review, test plan, or security audit re-derives repo context from scratch.
+PR #991 (closed #945) added `memory: project` frontmatter to all 6 subagent definitions in `.claude/agents/`. The mechanism enables Claude Code's per-subagent persistent markdown store, scoped to this repo on this host. The mechanism is now **armed but unguarded**.
 
-Current frontmatter shapes in `.claude/agents/`:
+Two of the six agents are most likely to encounter sensitive content in the course of their normal work:
 
-| File | Current frontmatter keys |
-|---|---|
-| `code-reviewer.md` | `name`, `description` |
-| `security-auditor.md` | `name`, `description` |
-| `test-engineer.md` | `name`, `description` |
-| `playwright-test-planner.md` | `name`, `description`, `tools`, `model`, `color` |
-| `playwright-test-generator.md` | `name`, `description`, `tools`, `model`, `color` |
-| `playwright-test-healer.md` | `name`, `description`, `tools`, `model`, `color` |
+- `code-reviewer` reads PR diffs that may contain pre-merge tokens, debugging credentials, unreleased code, internal URLs, fix-for-CVE patch contents, or customer PII appearing in issue-body excerpts.
+- `security-auditor` is **explicitly tasked with finding secrets** — without a guardrail, a naive "remember what you saw" memory write could pickle a discovered API token into the persistent file. Ironic and harmful.
 
-None of the six declare a `memory:` field today. Adding one enables persistent per-agent knowledge accumulation across sessions.
+The other 4 agents (`test-engineer`, `playwright-test-planner/generator/healer`) work primarily with Playwright spec shapes, locators, viewport conventions, and flake catalogs — lower-sensitivity surface, deferred to a separate follow-up if appetite arises.
 
-This session's earlier work — three scope-guard PRs and the AGENTS.md handoff graph — is exactly the kind of context these subagents would benefit from carrying forward: code-reviewer accumulating "this repo uses `has_label()` for label checks, not inline greps"; security-auditor accumulating "labels are gated by collaborator triage permission, not fork PRs"; test-engineer accumulating "the scope-guard harness lives at `tests/scope-guard.sh` with 8 fixture cases".
+Memory file storage details (verified during #991 /ship):
+- Path: `~/.claude/projects/<project-slug>/memory/` (or adjacent), `drwx------` (mode 700)
+- Local-only by default; no remote sync unless the user opts in
+- Persists across sessions until manually purged
+
+The cross-cutting concern is **what NOT to persist**, not what to persist (which the agents self-curate). This PR adds explicit forbidden-content guidance to the two highest-sensitivity prose bodies.
 
 ---
 
 ## 2. Objective
 
-Add a `memory:` field to every `.claude/agents/*.md` YAML frontmatter, scoped `project` for all six (repo-wide knowledge is the dominant pattern for these personas), with a one-line inline YAML comment justifying the scope choice. No prose body changes. No new files.
+Add a `## Memory Discipline` section to the prose body of `.claude/agents/code-reviewer.md` and `.claude/agents/security-auditor.md`, placed immediately after the role intro paragraph and before the existing first framework section (Review Framework / Threat Model). Each section:
+
+1. Names what kind of repo-wide knowledge the agent IS expected to persist (a positive framing — memory has value)
+2. Lists explicit forbidden content categories with at least 3 examples
+3. Notes the storage location and threat model in one sentence (so the agent understands the stakes without being told to second-guess every write)
+
+No frontmatter changes. No edits to the other 4 subagents. No new files.
 
 ---
 
@@ -40,28 +45,31 @@ Add a `memory:` field to every `.claude/agents/*.md` YAML frontmatter, scoped `p
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Scope per agent | **All 6 → `memory: project`** | Every persona's accumulated knowledge is repo-wide: review patterns, threat models, flake catalogs, locator conventions. Session-private context is the wrong abstraction here. |
-| Justification placement | **Inline YAML comment on the `memory:` line** | Justification sits adjacent to the value it justifies. Compact, grep-able, no prose body churn, single source of truth. |
-| Justification style | **One short phrase per agent**, describing what kind of knowledge accumulates | e.g. `memory: project  # repo-wide review patterns accumulate across sessions`. Specific to the agent's role; not boilerplate. |
-| Field placement | **Immediately after `description:`** | Natural reading order: name → description → memory scope → (optional tools/model/color). Consistent across all six files. |
-| Tools/model/color preservation | **Unchanged** | The 3 playwright-test-* agents have richer frontmatter. Only the `memory:` line is added; existing keys keep their positions. |
-| Markdown body | **Untouched** | The AC permits justification "in the file (one-line frontmatter comment or short note in the prose)". The frontmatter comment satisfies it; no prose edits needed. |
-| New files | **None** | This PR is purely frontmatter additions across 6 existing files. |
+| Scope | **Only `code-reviewer.md` + `security-auditor.md`** | Issue #990 explicitly scopes here. Other 4 agents have lower-sensitivity surface; deferred. |
+| Section heading | **`## Memory Discipline`** | Meta-rule framing — names the *practice*, not the *prohibition*. Parallel to "Output Format" already in both files. |
+| Section placement | **Between role intro paragraph and first framework section** | Top-of-body placement; mirrors `set -euo pipefail` discipline-at-the-top convention. Maximally discoverable; ensures any agent reading the prose top-down hits it before any review/audit instruction. |
+| Section structure | **3 paragraphs** — (a) what to persist, (b) what NOT to persist with examples, (c) storage context | Positive framing first prevents the agent from over-rejecting all memory writes. Negative framing with examples gives concrete rules. Storage context grounds the why. |
+| Forbidden-content examples | **At least 3 explicit categories per file**, agent-specific | Per issue AC. code-reviewer focuses on PR-diff content; security-auditor focuses on finding artefacts. |
+| Tone | **Imperative, second-person ("you")** matching existing prose voice | Consistent with the rest of the agent body. |
+| Frontmatter | **Untouched** | Already done by #991. |
+| Other 4 agents | **Untouched** | Out of scope; separate issue if needed. |
 
 ---
 
 ## 4. Acceptance Criteria
 
-- [ ] **AC-1** Every `.claude/agents/*.md` file's YAML frontmatter contains a `memory:` line.
-- [ ] **AC-2** `awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md | wc -l` returns `6`.
-- [ ] **AC-3** Every `memory:` value is `project` (no `local` values; verified per Decision §3).
-- [ ] **AC-4** Every `memory:` line carries an inline `#` YAML comment justifying the scope choice — agent-specific, not boilerplate. `grep -c '^memory:.*#' .claude/agents/*.md` reports 1 match per file across all six.
-- [ ] **AC-5** No existing frontmatter key is removed or reordered. The 3 simple agents retain `name`, `description`. The 3 playwright-test agents retain `name`, `description`, `tools`, `model`, `color`. Verified by diffing each file's frontmatter against `main`.
-- [ ] **AC-6** No markdown body changes — only the YAML frontmatter inside the `---` fences. Verified by `git diff main...HEAD` showing only frontmatter region edits.
-- [ ] **AC-7** `bundle exec jekyll build` exits 0. (Trivial — `.claude/` is outside the Jekyll source — but the check is cheap and lives in the issue AC.)
-- [ ] **AC-8** No file outside `.claude/agents/`, the lifecycle directory, or the archive carry-over is modified. No governance surface (`.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`) touched. No protected file touched.
-- [ ] **AC-9** YAML remains valid for each file. Verified by parsing the frontmatter as YAML (`yq eval '.memory' <file>` returns `project` for each).
-- [ ] **AC-10** Scope-guard boundary: `git diff --name-only main...HEAD` returns exactly — 6 `.claude/agents/*.md` + 3 lifecycle (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`) + 2 carry-over archive (`tasks/archive/2026-05-25-scope-guard-987/{plan,todo}.md`) = **11 files**. Well under the 15-file scope-explosion cap (no `bulk-content` label needed).
+- [ ] **AC-1** `.claude/agents/code-reviewer.md` contains a new `## Memory Discipline` section between the role intro paragraph (currently lines 7–9) and `## Review Framework` (currently line 11).
+- [ ] **AC-2** `.claude/agents/security-auditor.md` contains a new `## Memory Discipline` section between the role intro paragraph (currently lines 7–9) and `## Threat Model for This Blog` (currently line 11).
+- [ ] **AC-3** Each new section contains the phrase **"Never persist to memory"** (exact substring, case-sensitive). `grep -c "Never persist to memory" .claude/agents/{code-reviewer,security-auditor}.md` returns 1 per file.
+- [ ] **AC-4** Each new section names at least **3 explicit examples** of forbidden content categories, agent-specific:
+  - **code-reviewer:** examples include (at minimum) PR-diff tokens/secrets, unreleased code excerpts, internal URLs or credentials
+  - **security-auditor:** examples include (at minimum) discovered secrets/tokens, dependency CVE details from in-flight advisories, internal threat-intel sources
+- [ ] **AC-5** Each new section also names at least **2 things the agent SHOULD persist** (positive framing — prevents over-rejection). Examples for code-reviewer: review patterns, recurring PR-history pitfalls. Examples for security-auditor: threat-model boundaries, governance-surface conventions.
+- [ ] **AC-6** No frontmatter changes (`git diff main...HEAD -- .claude/agents/{code-reviewer,security-auditor}.md` shows zero changes within the `---` fences).
+- [ ] **AC-7** No edits to the other 4 subagents (`test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md`).
+- [ ] **AC-8** `bundle exec jekyll build` exits 0.
+- [ ] **AC-9** Scope-guard boundary: `git diff --name-only main...HEAD` returns exactly 2 substantive (`code-reviewer.md`, `security-auditor.md`) + 3 lifecycle (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`) + 2 archive carry-over (`tasks/archive/2026-05-25-subagent-memory-945/{plan,todo}.md`) = **7 files**. Well under the 15-file scope-explosion cap (no `bulk-content` label needed).
+- [ ] **AC-10** No protected file (`_config.yml`, `Gemfile*`, `AGENTS.md`, `ARCHITECTURE.md`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`) and no governance surface (`.github/skills/`, `.github/instructions/`) touched. `.claude/agents/` is **not** in `PROTECTED_FILES` per `scripts/check-pr-scope.sh` — no label exemption needed.
 
 ---
 
@@ -69,12 +77,18 @@ Add a `memory:` field to every `.claude/agents/*.md` YAML frontmatter, scoped `p
 
 ```bash
 # Validation
-bundle exec jekyll build                                                    # AC-7
-awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md | wc -l   # AC-2 — expect 6
-grep -c '^memory:' .claude/agents/*.md                                      # AC-1/AC-3 — every file: 1
-grep -c '^memory:.*#' .claude/agents/*.md                                   # AC-4 — every file: 1
-yq eval '.memory' .claude/agents/code-reviewer.md                           # AC-9 — expect "project" (cross-check one file)
-git diff --name-only main...HEAD | wc -l                                    # AC-10 — expect 11
+bundle exec jekyll build                                              # AC-8
+grep -c "Never persist to memory" .claude/agents/code-reviewer.md      # AC-3 — expect 1
+grep -c "Never persist to memory" .claude/agents/security-auditor.md   # AC-3 — expect 1
+grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md        # AC-1 — expect 1
+grep -c "^## Memory Discipline" .claude/agents/security-auditor.md     # AC-2 — expect 1
+
+# Frontmatter unchanged (AC-6)
+awk '/^---$/{f=!f;next} !f && /memory: project/' .claude/agents/code-reviewer.md     # frontmatter region: line still present
+awk '/^---$/{f=!f;next} f' .claude/agents/code-reviewer.md | diff - <(git show main:.claude/agents/code-reviewer.md | awk '/^---$/{f=!f;next} f')  # frontmatter region: byte-identical to main
+
+# Scope
+git diff --name-only main...HEAD | wc -l                              # AC-9 — expect 7
 ```
 
 ---
@@ -82,40 +96,75 @@ git diff --name-only main...HEAD | wc -l                                    # AC
 ## 6. Project Structure (touched files)
 
 ```
-.claude/agents/code-reviewer.md              M   + memory: project (review patterns)
-.claude/agents/security-auditor.md           M   + memory: project (threat model)
-.claude/agents/test-engineer.md              M   + memory: project (test architecture, flake catalog)
-.claude/agents/playwright-test-planner.md    M   + memory: project (page-structure inventory)
-.claude/agents/playwright-test-generator.md  M   + memory: project (locator conventions)
-.claude/agents/playwright-test-healer.md     M   + memory: project (flake patterns per spec)
-SPEC.md                                      M   This file
-tasks/plan.md                                M   #945 plan
-tasks/todo.md                                M   #945 todo
-tasks/archive/2026-05-25-scope-guard-987/    A   Carry-over: archived #987 plan + todo (2 files)
+.claude/agents/code-reviewer.md           M   + ## Memory Discipline section (~10 lines after role intro)
+.claude/agents/security-auditor.md        M   + ## Memory Discipline section (~10 lines after role intro)
+SPEC.md                                   M   This file
+tasks/plan.md                             M   #990 plan
+tasks/todo.md                             M   #990 todo
+tasks/archive/2026-05-25-subagent-memory-945/  A   Carry-over: archived #945 plan + todo (2 files)
 ```
 
-**Total scope:** 6 substantive + 3 lifecycle + 2 archive carry-over = **11 files**.
+**Total scope:** 2 substantive + 3 lifecycle + 2 archive carry-over = **7 files**.
 
 ---
 
 ## 7. Code Style
 
-- **YAML frontmatter style** — single space after `memory:`, single space before `#` comment, comment value is a short noun phrase (no period). Example: `memory: project  # repo-wide review patterns accumulate across sessions`.
-- **No reflow** — preserve existing key order; insert `memory:` immediately after `description:` (which sometimes spans multiple lines via single-quotes in the playwright-test-generator file).
-- **No body edits** — every byte change is inside the `---` fences.
-- **Justification phrasing** — agent-specific, not generic. Each comment names the kind of knowledge that accumulates (e.g. "review patterns", "threat model", "flake catalog"). Not "Project scope" or "Repo-wide" — those are tautologies.
-- **No trailing whitespace** on the new line.
+- **Markdown style** — `## Memory Discipline` H2 heading; no emoji. Body uses second-person imperative voice ("You may persist..."; "Never persist..."). Matches existing prose voice in both files.
+- **No reflow of unchanged sections** — only the new section is inserted; surrounding content stays byte-identical.
+- **Forbidden-content list style** — short bulleted list, one example per line, no parenthetical clauses. Reads as a quick-reference checklist.
+- **One paragraph per concern** — what-to-persist (1 paragraph), what-NOT-to-persist (1 paragraph + bullet list), storage-context (1 sentence).
+- **Section length cap** — ~10–15 lines per new section. The guardrail should be obvious but not dominate the file.
 
-Per-agent justification text (proposed; final wording in plan.md):
+### Proposed wording (final form in plan.md)
 
-| Agent | Justification comment |
-|---|---|
-| code-reviewer | `# repo-wide review patterns and PR-history pitfalls accumulate across sessions` |
-| security-auditor | `# repo-wide threat model and governance-surface boundaries persist` |
-| test-engineer | `# Playwright suite shape and CI flake catalog persist across sessions` |
-| playwright-test-planner | `# page-structure inventory and viewport conventions persist` |
-| playwright-test-generator | `# locator and spec-file conventions accumulate across sessions` |
-| playwright-test-healer | `# per-spec flake patterns and remediation recipes accumulate` |
+**code-reviewer.md:**
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for repo-wide
+review patterns that compound across sessions: this repo's `has_label()`
+helper convention, the scope-guard rule numbering, recurring PR-history
+pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`),
+and frontmatter conventions that catch reviewers off guard.
+
+**Never persist to memory:**
+
+- Secrets, API tokens, or credentials seen in any PR diff
+- Unreleased code excerpts or fix-for-CVE patch contents
+- Customer PII or internal URLs / email addresses that appear in issue
+  bodies
+- The specific content of any one PR you reviewed (review *patterns*
+  generalise; specific diffs do not)
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`),
+not synced anywhere. Treat what you persist as if it were grep-able by
+anyone with shell access to that machine.
+```
+
+**security-auditor.md:**
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's
+threat model that compounds across sessions: governance-surface boundaries
+(`.github/skills/`, `.github/instructions/`), protected-file rules,
+dependency hygiene posture, recurring antipatterns (e.g. the substring-
+match label-grep antipattern closed by #987), and supply-chain assumptions.
+
+**Never persist to memory:**
+
+- Any string you would flag as a finding (tokens, keys, credentials)
+- Dependency-CVE specifics from in-flight advisories that haven't published
+- Internal threat-intel sources, vendor contacts, or incident details
+- Customer PII appearing in any reviewed surface
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`),
+not synced anywhere. Anything you persist is grep-able by anyone with shell
+access to that machine. Audit before write.
+```
 
 ---
 
@@ -123,36 +172,40 @@ Per-agent justification text (proposed; final wording in plan.md):
 
 | Layer | Check |
 |---|---|
-| Static | `awk` AC-2 returns 6; `grep` AC-1/AC-3/AC-4 each return 6 |
-| Static | YAML parses for each of the 6 files (AC-9) |
-| Diff | `git diff main...HEAD --name-only` returns 11 files; every `.claude/agents/*.md` change is confined to within the frontmatter fences (AC-5, AC-6, AC-8, AC-10) |
-| Build | `bundle exec jekyll build` exits 0 (AC-7) |
+| Static | `grep -c "^## Memory Discipline"` returns 1 per file (AC-1, AC-2) |
+| Static | `grep -c "Never persist to memory"` returns 1 per file (AC-3) |
+| Static | At least 3 bulleted forbidden-content examples per section (AC-4) — visual inspection / line-count via `awk` between `^Never persist` and next blank line |
+| Static | Frontmatter byte-identical to `main` (AC-6) |
+| Static | The other 4 agents unchanged (AC-7) |
+| Build | `bundle exec jekyll build` exits 0 (AC-8) |
+| Scope | `git diff --name-only main...HEAD | wc -l` → 7 (AC-9) |
 
-No fixture tests, no Playwright spec — this is a metadata-only change in a directory outside the Jekyll source.
-
-No CI gate addition required — the existing `check-agent-scope` job covers the `.claude/agents/` boundary indirectly via Rule 4 (`agent:qa-gatekeeper` is permitted to touch `tests/`, but `.claude/agents/` isn't in any forbidden pattern, so Rule 4 won't trip).
+No fixture tests — this is a metadata/documentation change. No new behavioural surface to test. The "test" for whether the agent actually honours the guardrail is the next time it's invoked and chooses what to write to memory — which is unobservable from CI.
 
 ---
 
 ## 9. Boundaries
 
 **Always:**
-- Insert `memory:` immediately after `description:` in each file.
-- Use `memory: project` for all six files (per Decision §3).
-- Add an agent-specific inline YAML `#` comment justifying the scope.
-- Run the AC battery (`awk`/`grep`/`yq`/`jekyll build`) before pushing.
+- Insert `## Memory Discipline` as a top-of-body section (after role intro, before first framework).
+- Use second-person imperative voice consistent with existing prose.
+- Include at least 3 explicit forbidden-content examples per section.
+- Include positive framing (what TO persist) to prevent over-rejection.
+- Match the proposed wording in §7 as a starting point; minor wording polish is fine.
+- Run AC battery before commit.
 
 **Ask first about:**
-- Switching any agent from `project` to `local`.
-- Adding a `memory:` field to subagents outside `.claude/agents/` (e.g. `~/.claude/agents/` user-global) — out of scope per #945.
-- Editing the markdown body of any subagent file — out of scope; this PR is frontmatter-only.
-- Adding a new subagent file as part of this PR — out of scope.
+- Expanding scope to the other 4 subagents (per Decision §3 currently No).
+- Adding guardrails to non-prose surfaces (frontmatter notes, separate docs file).
+- Material wording changes to the proposed §7 templates.
+- Section placement other than top-of-body.
 
 **Never:**
-- Modify any of the protected files (`_config.yml`, `Gemfile`, `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `AGENTS.md`, `ARCHITECTURE.md`). [Per scope guard.]
-- Modify governance surface (`.github/skills/`, `.github/instructions/`). [No `governance-update` label needed.]
-- Reorder or remove existing frontmatter keys.
-- Change the markdown body of any `.claude/agents/*.md` file.
+- Modify frontmatter on either file (`memory: project` line stays).
+- Reorder existing sections (`## Review Framework`, `## Threat Model`, `## Output Format`, etc. retain positions).
+- Touch the other 4 subagents (`test-engineer.md`, `playwright-test-*.md`).
+- Touch any protected file or governance surface.
+- Add new files outside `tasks/`.
 
 ---
 
@@ -160,22 +213,24 @@ No CI gate addition required — the existing `check-agent-scope` job covers the
 
 | Risk | Mitigation |
 |---|---|
-| YAML parse error from a stray indentation or quote in the new `memory:` line | AC-9 (YAML parses); local verification via `yq eval '.memory' <file>` per file before commit. |
-| Inline `#` comment misinterpreted as part of the value by some YAML parser | YAML 1.1/1.2 both treat `#` outside quoted strings as a comment delimiter. `memory: project  # ...` is the canonical form. Verified by precedent in many Claude Code subagent examples and by the AC-9 yq check. |
-| Claude Code v2.1.33+ requirement — older versions of Claude Code may not honour the `memory:` field | Unsupported runtimes treat unknown frontmatter keys as inert (per YAML spec); no degradation. Worst case: the field is read but ignored. Out of scope per #945. |
-| Subagent that gets `memory: project` writes sensitive PR-review content into a persistent file | Cross-cutting governance concern, not introduced by this PR. The memory feature stores markdown in a user-scope path; the user can audit/redact. Scope review of stored memory contents is Worth-Watching from #902. |
-| `bundle exec jekyll build` failing for unrelated reasons (e.g. local worktrees/ pollution as seen in earlier PRs) | Verify with worktrees moved aside, matching the local-build hygiene pattern documented in the [[reference-scope-guard]] session. |
+| The agent ignores the guardrail and writes a secret anyway | Soft enforcement — instruction-only, no runtime enforcement. Storage is local-only + 700 perms; user can audit memory files manually. Future Claude Code may add a `memory_redact:` field for hard enforcement (Watch item from #902). |
+| Wording is too restrictive and the agent persists nothing | Positive framing in §7 ("Use it for...") explicitly names categories the agent SHOULD persist. AC-5 requires this. |
+| Section placement disrupts existing structure | Inserted as a new section, no reorder. Diff confined to additive hunks; existing sections byte-identical post-insertion (AC-6, AC-7). |
+| `## Memory Discipline` heading collides with an existing heading | Verified: neither file has any `## Memory*` heading today. Safe. |
+| Reviewer asks for the same guardrails on other 4 agents | Filed as out-of-scope follow-up if asked; SPEC §3 cites the rationale. |
+| Phantom `build` + 1-reviewer block | Yes — recurring. Admin-merge per precedent. |
+| `bundle exec jekyll build` flakes on local `worktrees/` pollution | Recurring; move `worktrees/` aside before AC-8 verification. |
 
 ---
 
 ## 11. Out of Scope
 
-Per issue #945:
+Per issue #990:
 
-- Adding `memory:` to user-global subagents (`~/.claude/agents/*.md`) — outside this repo.
-- Deciding what subagents should *store* in memory — subagents self-curate; this issue only enables the mechanism.
-- Migrating to the Claude Managed Agents "dreaming" feature — Watch item in #902.
-- Editing the markdown body of any subagent file.
-- Adding or removing subagents.
-- Touching `AGENTS.md` or governance surfaces.
-- Adding fixture tests for the `memory:` field (no behavioural surface to test).
+- Memory-write guardrails for `test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md` — lower-sensitivity surface, file separately if appetite arises.
+- A scope-guard rule (`scripts/check-pr-scope.sh`) that flags PRs modifying `.claude/agents/*.md` prose bodies as `governance-update`-equivalent. Security-auditor flagged this as a forward-looking concern but out of scope here.
+- Auditing existing memory files for already-persisted secrets — none exist yet (this is the first session after #991 merged).
+- Runtime enforcement of the guardrail (e.g. a `memory_redact:` frontmatter field) — Watch item from #902, awaits Claude Code feature support.
+- Frontmatter edits — done by #991, unchanged here.
+- Adding new subagents or removing existing ones.
+- `AGENTS.md` / governance surface changes.

--- a/tasks/archive/2026-05-25-subagent-memory-945/plan.md
+++ b/tasks/archive/2026-05-25-subagent-memory-945/plan.md
@@ -1,0 +1,148 @@
+# Plan — Add `memory:` frontmatter to local subagents (#945)
+
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#945](https://github.com/oviney/blog/issues/945)
+**Date:** 2026-05-25
+**Labels:** `agent:qa-gatekeeper`
+**Branch:** `feat/945-subagent-memory-frontmatter` (to be created)
+**Lifecycle phase:** PLAN
+
+---
+
+## Scope summary
+
+Mechanical fan-out: add one `memory: project` line (with an agent-specific inline `#` justification comment) to each of six `.claude/agents/*.md` files. No body edits, no new files, no test surface to write.
+
+**Two atomic commits:** lifecycle setup, then all 6 subagent edits in one commit. The change is one logical concern (enable memory persistence across all subagents) and one uniform edit per file — splitting it further would create commit-noise without independent reviewability.
+
+---
+
+## Dependency graph
+
+```
+Phase 0 (branch + lifecycle commit)
+    │
+    ▼
+Phase 1 (frontmatter edits — all 6 files in one commit)
+    │   AC battery: awk/grep/yq/build all green
+    │
+    ▼   Checkpoint A: full 10-AC battery
+    │
+Phase 2 (ship)
+```
+
+No cross-file dependencies — all 6 edits are independent. The only ordering is "lifecycle first so the spec/plan/todo are on the branch before the substantive change lands".
+
+---
+
+## Vertical slices
+
+### Phase 0 — Branch setup
+
+| Task | Action |
+|---|---|
+| 0.1 | Sync `main`: `git fetch origin main`; `git switch main`; `git pull --ff-only` (current main at `7ac6e91e`, the #989 merge). |
+| 0.2 | Stash #945 lifecycle (`SPEC.md` + `tasks/plan.md` + `tasks/todo.md`) before switching branches. |
+| 0.3 | `git switch -c feat/945-subagent-memory-frontmatter`. |
+| 0.4 | Pop stash. |
+| 0.5 | Archive #987 lifecycle artifacts (`tasks/plan.md`, `tasks/todo.md` from main HEAD) to `tasks/archive/2026-05-25-scope-guard-987/`. |
+| 0.6 | Commit lifecycle: `docs(#945): lifecycle artifacts (SPEC + plan + todo) for subagent memory frontmatter`. |
+
+---
+
+### Phase 1 — Frontmatter edits (one commit, six files)
+
+*One atomic commit. Each file gets exactly one new line inserted immediately after `description:`. No reorder, no body change.*
+
+| Task | File | New line (inserted after `description:`) |
+|---|---|---|
+| 1.1 | `.claude/agents/code-reviewer.md` | `memory: project  # repo-wide review patterns and PR-history pitfalls accumulate across sessions` |
+| 1.2 | `.claude/agents/security-auditor.md` | `memory: project  # repo-wide threat model and governance-surface boundaries persist` |
+| 1.3 | `.claude/agents/test-engineer.md` | `memory: project  # Playwright suite shape and CI flake catalog persist across sessions` |
+| 1.4 | `.claude/agents/playwright-test-planner.md` | `memory: project  # page-structure inventory and viewport conventions persist` |
+| 1.5 | `.claude/agents/playwright-test-generator.md` | `memory: project  # locator and spec-file conventions accumulate across sessions` |
+| 1.6 | `.claude/agents/playwright-test-healer.md` | `memory: project  # per-spec flake patterns and remediation recipes accumulate` |
+
+**Phase 1 ACs covered:** AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8, AC-9.
+
+**Phase 1 verification:**
+```bash
+# Count
+awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md | wc -l   # AC-2: 6
+
+# Every memory: line has a #-comment (per-file count)
+for f in .claude/agents/*.md; do
+  grep -c '^memory:.*#' "$f"   # expect 1 per file
+done
+
+# YAML parses (AC-9)
+for f in .claude/agents/*.md; do
+  yq eval '.memory' "$f"   # expect "project"
+done
+
+# Build (AC-7)
+mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /tmp/_w worktrees && mv /tmp/_dw .worktrees
+```
+
+**Commit:** `feat(#945): add memory: project frontmatter to all 6 subagents`
+
+---
+
+### Checkpoint A — Full 10-AC battery
+
+| AC | Check |
+|----|---|
+| AC-1 | `grep -l '^memory:' .claude/agents/*.md \| wc -l` → 6 |
+| AC-2 | `awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md \| wc -l` → 6 |
+| AC-3 | `awk '/^---$/{f=!f;next} f && /^memory:/' .claude/agents/*.md \| grep -v 'project' \| wc -l` → 0 (no non-`project` values) |
+| AC-4 | `grep -c '^memory:.*#' .claude/agents/*.md` reports 1 match per file |
+| AC-5 | Frontmatter key order unchanged for each file (`git diff main...HEAD -- .claude/agents/*.md` shows only `+memory:` insertions, no reordering) |
+| AC-6 | `git diff main...HEAD` confined to YAML frontmatter region (no body changes) |
+| AC-7 | `bundle exec jekyll build` exit 0 (move local `worktrees/` aside first) |
+| AC-8 | No file under `.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`, `_config.yml`, `Gemfile*`, `.github/CODEOWNERS`, `AGENTS.md`, `ARCHITECTURE.md` modified |
+| AC-9 | `yq eval '.memory' <file>` returns `project` for each of the 6 files |
+| AC-10 | `git diff --name-only main...HEAD \| wc -l` → 11 |
+
+**Pass criteria:** all 10 ACs green. Mechanical change so all should pass first try; investigate any FAIL immediately rather than ship-and-hope.
+
+---
+
+### Phase 2 — Ship
+
+*Standard `/ship` flow.*
+
+| Task | Action |
+|---|---|
+| 2.1 | Push branch `feat/945-subagent-memory-frontmatter`. |
+| 2.2 | Open PR with `Closes #945`; apply `agent:qa-gatekeeper` label (no `governance-update` or `protected-file-update` needed — no governance surface or protected file touched). |
+| 2.3 | CI green expected — the scope guard runs with #989's anchored `has_label()` helper; no false positives. |
+| 2.4 | Admin-merge if blocked by 1-reviewer rule (per repeated precedent). |
+| 2.5 | Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
+| 2.6 | Comment on #945 with production verification notes. |
+| 2.7 | Memory: note in [[reference-scope-guard]] or new memory entry that subagents now have project-scoped memory; useful for future agents that wonder "do I have persistent memory here?". |
+
+---
+
+## Risks (from SPEC §10, re-evaluated)
+
+| Risk | Realised? | Plan response |
+|---|---|---|
+| YAML parse error | Mitigated by `yq` AC-9 check | None additional |
+| Inline `#` misinterpreted as value | YAML 1.1/1.2 spec-compliant; verified `yq` round-trips | None additional |
+| Older Claude Code ignores `memory:` field | Graceful degradation (unknown key inert) | None additional |
+| Subagent stores sensitive PR content in project-scope memory | Cross-cutting governance concern out of scope per #945 | Watch item #902 |
+| Local `bundle exec jekyll build` fails due to `worktrees/` pollution | Recurring; documented in earlier PR memory | Move `worktrees/` aside before AC-7 verification, restore after |
+| Phantom `build` + 1-reviewer block | Yes — recurring | Admin-merge per precedent |
+| Scope-guard tripping on this PR | Won't — `.claude/agents/` is not protected and not in any agent's forbidden pattern for `agent:qa-gatekeeper` | None needed |
+
+---
+
+## Out of scope (locked, per SPEC §11)
+
+- `~/.claude/agents/*.md` user-global subagents
+- Deciding what subagents *store* in memory
+- Managed Agents "dreaming" feature
+- Markdown body edits
+- New/removed subagents
+- `AGENTS.md` / governance surfaces
+- Fixture tests for `memory:` field

--- a/tasks/archive/2026-05-25-subagent-memory-945/todo.md
+++ b/tasks/archive/2026-05-25-subagent-memory-945/todo.md
@@ -1,0 +1,53 @@
+# TODO — Add `memory:` frontmatter to local subagents (#945)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Branch:** `feat/945-subagent-memory-frontmatter` (to create)
+
+---
+
+## Phase 0 — Setup
+
+- [ ] 0.1 Fetch origin/main; confirm at `7ac6e91e` (#989 merge)
+- [ ] 0.2 Stash #945 lifecycle (SPEC + plan + todo)
+- [ ] 0.3 Switch to `main`; `git pull --ff-only`
+- [ ] 0.4 `git switch -c feat/945-subagent-memory-frontmatter`
+- [ ] 0.5 Pop stash
+- [ ] 0.6 Archive #987 lifecycle to `tasks/archive/2026-05-25-scope-guard-987/`
+- [ ] 0.7 Commit: `docs(#945): lifecycle artifacts (SPEC + plan + todo) for subagent memory frontmatter`
+
+## Phase 1 — Frontmatter edits (one commit)
+
+- [ ] 1.1 `.claude/agents/code-reviewer.md` — insert `memory: project  # repo-wide review patterns and PR-history pitfalls accumulate across sessions` after `description:`
+- [ ] 1.2 `.claude/agents/security-auditor.md` — insert `memory: project  # repo-wide threat model and governance-surface boundaries persist`
+- [ ] 1.3 `.claude/agents/test-engineer.md` — insert `memory: project  # Playwright suite shape and CI flake catalog persist across sessions`
+- [ ] 1.4 `.claude/agents/playwright-test-planner.md` — insert `memory: project  # page-structure inventory and viewport conventions persist`
+- [ ] 1.5 `.claude/agents/playwright-test-generator.md` — insert `memory: project  # locator and spec-file conventions accumulate across sessions`
+- [ ] 1.6 `.claude/agents/playwright-test-healer.md` — insert `memory: project  # per-spec flake patterns and remediation recipes accumulate`
+- [ ] Verify `awk` count → 6
+- [ ] Verify `grep -c '^memory:.*#'` returns 1 per file
+- [ ] Verify `yq eval '.memory' <file>` returns `project` for each
+- [ ] Verify `bundle exec jekyll build` exits 0 (move `worktrees/` aside first)
+- [ ] Commit: `feat(#945): add memory: project frontmatter to all 6 subagents`
+
+## Checkpoint A — Full 10-AC battery
+
+- [ ] AC-1 — `grep -l '^memory:' .claude/agents/*.md | wc -l` → 6
+- [ ] AC-2 — `awk` count → 6
+- [ ] AC-3 — every value is `project` (no `local`)
+- [ ] AC-4 — 1 `#` comment per file
+- [ ] AC-5 — no frontmatter key reordering
+- [ ] AC-6 — no markdown body changes
+- [ ] AC-7 — `bundle exec jekyll build` exit 0
+- [ ] AC-8 — no protected file or governance surface touched
+- [ ] AC-9 — YAML parses cleanly
+- [ ] AC-10 — `git diff --name-only main...HEAD | wc -l` → 11
+
+## Phase 2 — Ship
+
+- [ ] Push branch
+- [ ] Open PR with `Closes #945`; apply `agent:qa-gatekeeper` label only
+- [ ] CI green (or admin-merge per precedent)
+- [ ] Merge `--squash --delete-branch`
+- [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
+- [ ] Comment on #945 with production verification
+- [ ] Update memory: note that subagents now have project-scoped persistent memory

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,19 +1,19 @@
-# Plan — Add `memory:` frontmatter to local subagents (#945)
+# Plan — Memory-write guardrails for code-reviewer and security-auditor (#990)
 
 **Spec:** [../SPEC.md](../SPEC.md)
-**Issue:** [#945](https://github.com/oviney/blog/issues/945)
+**Issue:** [#990](https://github.com/oviney/blog/issues/990)
 **Date:** 2026-05-25
 **Labels:** `agent:qa-gatekeeper`
-**Branch:** `feat/945-subagent-memory-frontmatter` (to be created)
+**Branch:** `feat/990-memory-discipline-guardrails` (to be created)
 **Lifecycle phase:** PLAN
 
 ---
 
 ## Scope summary
 
-Mechanical fan-out: add one `memory: project` line (with an agent-specific inline `#` justification comment) to each of six `.claude/agents/*.md` files. No body edits, no new files, no test surface to write.
+Two prose-body insertions: a new `## Memory Discipline` section in `.claude/agents/code-reviewer.md` and the same in `.claude/agents/security-auditor.md`. Each section is ~15 lines: positive framing of what to persist, bulleted forbidden-content list, one-sentence storage context.
 
-**Two atomic commits:** lifecycle setup, then all 6 subagent edits in one commit. The change is one logical concern (enable memory persistence across all subagents) and one uniform edit per file — splitting it further would create commit-noise without independent reviewability.
+**Two atomic commits:** lifecycle setup + one substantive commit covering both prose-body edits. The change is one logical concern (add memory discipline to the two highest-sensitivity agents) — splitting per-file would create reviewer noise without independent value.
 
 ---
 
@@ -23,15 +23,15 @@ Mechanical fan-out: add one `memory: project` line (with an agent-specific inlin
 Phase 0 (branch + lifecycle commit)
     │
     ▼
-Phase 1 (frontmatter edits — all 6 files in one commit)
-    │   AC battery: awk/grep/yq/build all green
+Phase 1 (prose-body edits — both files in one commit)
+    │   AC battery: grep / build / scope checks all green
     │
     ▼   Checkpoint A: full 10-AC battery
     │
 Phase 2 (ship)
 ```
 
-No cross-file dependencies — all 6 edits are independent. The only ordering is "lifecycle first so the spec/plan/todo are on the branch before the substantive change lands".
+No cross-file dependencies. The two edits are independent and uniform in pattern (same heading, same 3-paragraph structure, different agent-specific examples).
 
 ---
 
@@ -41,50 +41,90 @@ No cross-file dependencies — all 6 edits are independent. The only ordering is
 
 | Task | Action |
 |---|---|
-| 0.1 | Sync `main`: `git fetch origin main`; `git switch main`; `git pull --ff-only` (current main at `7ac6e91e`, the #989 merge). |
-| 0.2 | Stash #945 lifecycle (`SPEC.md` + `tasks/plan.md` + `tasks/todo.md`) before switching branches. |
-| 0.3 | `git switch -c feat/945-subagent-memory-frontmatter`. |
+| 0.1 | Sync `main`: `git fetch origin main`; `git switch main`; `git pull --ff-only` (current main at `0fcadaf1`, the #991 merge). |
+| 0.2 | Stash #990 lifecycle (`SPEC.md` + `tasks/plan.md` + `tasks/todo.md`) before switching branches. |
+| 0.3 | `git switch -c feat/990-memory-discipline-guardrails`. |
 | 0.4 | Pop stash. |
-| 0.5 | Archive #987 lifecycle artifacts (`tasks/plan.md`, `tasks/todo.md` from main HEAD) to `tasks/archive/2026-05-25-scope-guard-987/`. |
-| 0.6 | Commit lifecycle: `docs(#945): lifecycle artifacts (SPEC + plan + todo) for subagent memory frontmatter`. |
+| 0.5 | Archive #945 lifecycle artifacts (`tasks/plan.md`, `tasks/todo.md` from main HEAD) to `tasks/archive/2026-05-25-subagent-memory-945/`. |
+| 0.6 | Commit lifecycle: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`. |
 
 ---
 
-### Phase 1 — Frontmatter edits (one commit, six files)
+### Phase 1 — Prose-body edits (one commit, two files)
 
-*One atomic commit. Each file gets exactly one new line inserted immediately after `description:`. No reorder, no body change.*
+*One atomic commit. Each file gets one new `## Memory Discipline` section inserted between the role intro paragraph and the first framework section.*
 
-| Task | File | New line (inserted after `description:`) |
-|---|---|---|
-| 1.1 | `.claude/agents/code-reviewer.md` | `memory: project  # repo-wide review patterns and PR-history pitfalls accumulate across sessions` |
-| 1.2 | `.claude/agents/security-auditor.md` | `memory: project  # repo-wide threat model and governance-surface boundaries persist` |
-| 1.3 | `.claude/agents/test-engineer.md` | `memory: project  # Playwright suite shape and CI flake catalog persist across sessions` |
-| 1.4 | `.claude/agents/playwright-test-planner.md` | `memory: project  # page-structure inventory and viewport conventions persist` |
-| 1.5 | `.claude/agents/playwright-test-generator.md` | `memory: project  # locator and spec-file conventions accumulate across sessions` |
-| 1.6 | `.claude/agents/playwright-test-healer.md` | `memory: project  # per-spec flake patterns and remediation recipes accumulate` |
+#### Task 1.1 — `.claude/agents/code-reviewer.md`
 
-**Phase 1 ACs covered:** AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8, AC-9.
+Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Review Framework`):
 
-**Phase 1 verification:**
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for repo-wide review patterns that compound across sessions: this repo's `has_label()` helper convention, the scope-guard rule numbering, recurring PR-history pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`), and frontmatter conventions that catch reviewers off guard.
+
+**Never persist to memory:**
+
+- Secrets, API tokens, or credentials seen in any PR diff
+- Unreleased code excerpts or fix-for-CVE patch contents
+- Customer PII or internal URLs / email addresses that appear in issue bodies
+- The specific content of any one PR you reviewed (review *patterns* generalise; specific diffs do not)
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+```
+
+#### Task 1.2 — `.claude/agents/security-auditor.md`
+
+Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Threat Model for This Blog`):
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's threat model that compounds across sessions: governance-surface boundaries (`.github/skills/`, `.github/instructions/`), protected-file rules, dependency hygiene posture, recurring antipatterns (e.g. the substring-match label-grep antipattern closed by #987), and supply-chain assumptions.
+
+**Never persist to memory:**
+
+- Any string you would flag as a finding (tokens, keys, credentials)
+- Dependency-CVE specifics from in-flight advisories that haven't published
+- Internal threat-intel sources, vendor contacts, or incident details
+- Customer PII appearing in any reviewed surface
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
+```
+
+#### Phase 1 ACs covered
+
+AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8.
+
+#### Phase 1 verification
+
 ```bash
-# Count
-awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md | wc -l   # AC-2: 6
+# AC-1, AC-2 — section headers
+grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md      # expect 1
+grep -c "^## Memory Discipline" .claude/agents/security-auditor.md   # expect 1
 
-# Every memory: line has a #-comment (per-file count)
-for f in .claude/agents/*.md; do
-  grep -c '^memory:.*#' "$f"   # expect 1 per file
-done
+# AC-3 — forbidden phrase
+grep -c "Never persist to memory" .claude/agents/code-reviewer.md      # expect 1
+grep -c "Never persist to memory" .claude/agents/security-auditor.md   # expect 1
 
-# YAML parses (AC-9)
-for f in .claude/agents/*.md; do
-  yq eval '.memory' "$f"   # expect "project"
-done
+# AC-4 — at least 3 bulleted forbidden examples per section (4 in each per the wording above)
+awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/code-reviewer.md | grep -c '^- '      # expect ≥3 (actual: 4)
+awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/security-auditor.md | grep -c '^- '   # expect ≥3 (actual: 4)
 
-# Build (AC-7)
+# AC-6 — frontmatter unchanged
+diff <(awk '/^---$/{f=!f;next} f' .claude/agents/code-reviewer.md) \
+     <(git show main:.claude/agents/code-reviewer.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
+diff <(awk '/^---$/{f=!f;next} f' .claude/agents/security-auditor.md) \
+     <(git show main:.claude/agents/security-auditor.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
+
+# AC-7 — other 4 agents untouched
+git diff --name-only main...HEAD -- .claude/agents/ | grep -v 'code-reviewer\|security-auditor'    # expect empty
+
+# AC-8 — build
 mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /tmp/_w worktrees && mv /tmp/_dw .worktrees
 ```
 
-**Commit:** `feat(#945): add memory: project frontmatter to all 6 subagents`
+**Commit:** `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
 
 ---
 
@@ -92,18 +132,18 @@ mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /
 
 | AC | Check |
 |----|---|
-| AC-1 | `grep -l '^memory:' .claude/agents/*.md \| wc -l` → 6 |
-| AC-2 | `awk '/^---$/{f=!f;next} f && /^memory:/{print FILENAME}' .claude/agents/*.md \| wc -l` → 6 |
-| AC-3 | `awk '/^---$/{f=!f;next} f && /^memory:/' .claude/agents/*.md \| grep -v 'project' \| wc -l` → 0 (no non-`project` values) |
-| AC-4 | `grep -c '^memory:.*#' .claude/agents/*.md` reports 1 match per file |
-| AC-5 | Frontmatter key order unchanged for each file (`git diff main...HEAD -- .claude/agents/*.md` shows only `+memory:` insertions, no reordering) |
-| AC-6 | `git diff main...HEAD` confined to YAML frontmatter region (no body changes) |
-| AC-7 | `bundle exec jekyll build` exit 0 (move local `worktrees/` aside first) |
-| AC-8 | No file under `.github/skills/`, `.github/instructions/`, `.github/copilot-instructions.md`, `_config.yml`, `Gemfile*`, `.github/CODEOWNERS`, `AGENTS.md`, `ARCHITECTURE.md` modified |
-| AC-9 | `yq eval '.memory' <file>` returns `project` for each of the 6 files |
-| AC-10 | `git diff --name-only main...HEAD \| wc -l` → 11 |
+| AC-1 | `grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md` → 1 |
+| AC-2 | `grep -c "^## Memory Discipline" .claude/agents/security-auditor.md` → 1 |
+| AC-3 | `grep -c "Never persist to memory"` → 1 per file (both files) |
+| AC-4 | `awk` between `^**Never persist to memory:**` and next blank line returns ≥3 bullet lines per file |
+| AC-5 | Each section opens with "Use it for..." paragraph naming ≥2 categories of what TO persist |
+| AC-6 | `awk` frontmatter diff against `main` returns empty for both files |
+| AC-7 | `git diff --name-only main...HEAD -- .claude/agents/` lists only the 2 target files |
+| AC-8 | `bundle exec jekyll build` exit 0 |
+| AC-9 | `git diff --name-only main...HEAD \| wc -l` → 7 |
+| AC-10 | No protected file or governance surface touched |
 
-**Pass criteria:** all 10 ACs green. Mechanical change so all should pass first try; investigate any FAIL immediately rather than ship-and-hope.
+**Pass criteria:** all 10 ACs green. Mechanical change; investigate any FAIL immediately rather than ship-and-hope.
 
 ---
 
@@ -113,13 +153,13 @@ mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /
 
 | Task | Action |
 |---|---|
-| 2.1 | Push branch `feat/945-subagent-memory-frontmatter`. |
-| 2.2 | Open PR with `Closes #945`; apply `agent:qa-gatekeeper` label (no `governance-update` or `protected-file-update` needed — no governance surface or protected file touched). |
-| 2.3 | CI green expected — the scope guard runs with #989's anchored `has_label()` helper; no false positives. |
-| 2.4 | Admin-merge if blocked by 1-reviewer rule (per repeated precedent). |
+| 2.1 | Push branch `feat/990-memory-discipline-guardrails`. |
+| 2.2 | Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only. No `governance-update` or `protected-file-update` needed. |
+| 2.3 | CI green expected. |
+| 2.4 | Admin-merge if blocked by 1-reviewer rule. |
 | 2.5 | Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
-| 2.6 | Comment on #945 with production verification notes. |
-| 2.7 | Memory: note in [[reference-scope-guard]] or new memory entry that subagents now have project-scoped memory; useful for future agents that wonder "do I have persistent memory here?". |
+| 2.6 | Comment on #990 with production verification notes. |
+| 2.7 | Update [[reference-subagent-memory]] memory: remove the "guardrails not yet landed" caveat; note that code-reviewer and security-auditor now have explicit `Never persist to memory` rules. |
 
 ---
 
@@ -127,22 +167,21 @@ mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /
 
 | Risk | Realised? | Plan response |
 |---|---|---|
-| YAML parse error | Mitigated by `yq` AC-9 check | None additional |
-| Inline `#` misinterpreted as value | YAML 1.1/1.2 spec-compliant; verified `yq` round-trips | None additional |
-| Older Claude Code ignores `memory:` field | Graceful degradation (unknown key inert) | None additional |
-| Subagent stores sensitive PR content in project-scope memory | Cross-cutting governance concern out of scope per #945 | Watch item #902 |
-| Local `bundle exec jekyll build` fails due to `worktrees/` pollution | Recurring; documented in earlier PR memory | Move `worktrees/` aside before AC-7 verification, restore after |
+| Agent ignores soft instruction and writes secret anyway | Mitigated only by storage being local + 700 perms | Document Watch item; no runtime enforcement in this PR |
+| Wording too restrictive → agent persists nothing | Positive framing prevents over-rejection; AC-5 enforces it | None additional |
+| Section placement disrupts structure | Pure insertion; existing sections byte-identical | AC-6, AC-7 verify |
+| Heading collides with existing | Neither file has `## Memory*` heading today | None additional |
+| Reviewer asks for other 4 agents | SPEC §11 documents the rationale; file follow-up if asked | None additional |
 | Phantom `build` + 1-reviewer block | Yes — recurring | Admin-merge per precedent |
-| Scope-guard tripping on this PR | Won't — `.claude/agents/` is not protected and not in any agent's forbidden pattern for `agent:qa-gatekeeper` | None needed |
+| Local `bundle exec jekyll build` fails on `worktrees/` | Recurring | Move aside before AC-8 |
 
 ---
 
 ## Out of scope (locked, per SPEC §11)
 
-- `~/.claude/agents/*.md` user-global subagents
-- Deciding what subagents *store* in memory
-- Managed Agents "dreaming" feature
-- Markdown body edits
-- New/removed subagents
+- Other 4 subagents
+- Scope-guard rule for prose-body changes
+- Runtime enforcement (`memory_redact:` field)
+- Frontmatter edits
+- Auditing existing memory files
 - `AGENTS.md` / governance surfaces
-- Fixture tests for `memory:` field

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,53 +1,51 @@
-# TODO — Add `memory:` frontmatter to local subagents (#945)
+# TODO — Memory-write guardrails for code-reviewer and security-auditor (#990)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Branch:** `feat/945-subagent-memory-frontmatter` (to create)
+**Branch:** `feat/990-memory-discipline-guardrails` (to create)
 
 ---
 
 ## Phase 0 — Setup
 
-- [ ] 0.1 Fetch origin/main; confirm at `7ac6e91e` (#989 merge)
-- [ ] 0.2 Stash #945 lifecycle (SPEC + plan + todo)
+- [ ] 0.1 Fetch origin/main; confirm at `0fcadaf1` (#991 merge)
+- [ ] 0.2 Stash #990 lifecycle (SPEC + plan + todo)
 - [ ] 0.3 Switch to `main`; `git pull --ff-only`
-- [ ] 0.4 `git switch -c feat/945-subagent-memory-frontmatter`
+- [ ] 0.4 `git switch -c feat/990-memory-discipline-guardrails`
 - [ ] 0.5 Pop stash
-- [ ] 0.6 Archive #987 lifecycle to `tasks/archive/2026-05-25-scope-guard-987/`
-- [ ] 0.7 Commit: `docs(#945): lifecycle artifacts (SPEC + plan + todo) for subagent memory frontmatter`
+- [ ] 0.6 Archive #945 lifecycle to `tasks/archive/2026-05-25-subagent-memory-945/`
+- [ ] 0.7 Commit: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`
 
-## Phase 1 — Frontmatter edits (one commit)
+## Phase 1 — Prose-body edits (one commit)
 
-- [ ] 1.1 `.claude/agents/code-reviewer.md` — insert `memory: project  # repo-wide review patterns and PR-history pitfalls accumulate across sessions` after `description:`
-- [ ] 1.2 `.claude/agents/security-auditor.md` — insert `memory: project  # repo-wide threat model and governance-surface boundaries persist`
-- [ ] 1.3 `.claude/agents/test-engineer.md` — insert `memory: project  # Playwright suite shape and CI flake catalog persist across sessions`
-- [ ] 1.4 `.claude/agents/playwright-test-planner.md` — insert `memory: project  # page-structure inventory and viewport conventions persist`
-- [ ] 1.5 `.claude/agents/playwright-test-generator.md` — insert `memory: project  # locator and spec-file conventions accumulate across sessions`
-- [ ] 1.6 `.claude/agents/playwright-test-healer.md` — insert `memory: project  # per-spec flake patterns and remediation recipes accumulate`
-- [ ] Verify `awk` count → 6
-- [ ] Verify `grep -c '^memory:.*#'` returns 1 per file
-- [ ] Verify `yq eval '.memory' <file>` returns `project` for each
-- [ ] Verify `bundle exec jekyll build` exits 0 (move `worktrees/` aside first)
-- [ ] Commit: `feat(#945): add memory: project frontmatter to all 6 subagents`
+- [ ] 1.1 Insert `## Memory Discipline` section into `.claude/agents/code-reviewer.md` between line 9 (role intro end) and line 11 (`## Review Framework`) — wording per plan.md §1.1
+- [ ] 1.2 Insert `## Memory Discipline` section into `.claude/agents/security-auditor.md` between line 9 and line 11 (`## Threat Model for This Blog`) — wording per plan.md §1.2
+- [ ] Verify (AC-1, AC-2): `grep -c "^## Memory Discipline"` returns 1 per file
+- [ ] Verify (AC-3): `grep -c "Never persist to memory"` returns 1 per file
+- [ ] Verify (AC-4): ≥3 bulleted forbidden examples per section
+- [ ] Verify (AC-6): frontmatter byte-identical to main
+- [ ] Verify (AC-7): only the 2 target files modified in `.claude/agents/`
+- [ ] Verify (AC-8): `bundle exec jekyll build` exit 0 (move `worktrees/` aside)
+- [ ] Commit: `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
 
 ## Checkpoint A — Full 10-AC battery
 
-- [ ] AC-1 — `grep -l '^memory:' .claude/agents/*.md | wc -l` → 6
-- [ ] AC-2 — `awk` count → 6
-- [ ] AC-3 — every value is `project` (no `local`)
-- [ ] AC-4 — 1 `#` comment per file
-- [ ] AC-5 — no frontmatter key reordering
-- [ ] AC-6 — no markdown body changes
-- [ ] AC-7 — `bundle exec jekyll build` exit 0
-- [ ] AC-8 — no protected file or governance surface touched
-- [ ] AC-9 — YAML parses cleanly
-- [ ] AC-10 — `git diff --name-only main...HEAD | wc -l` → 11
+- [ ] AC-1 — `## Memory Discipline` in code-reviewer.md
+- [ ] AC-2 — `## Memory Discipline` in security-auditor.md
+- [ ] AC-3 — "Never persist to memory" phrase present (1 per file)
+- [ ] AC-4 — ≥3 forbidden-content bullet examples per section
+- [ ] AC-5 — positive framing ("Use it for...") present per section
+- [ ] AC-6 — frontmatter unchanged in both files
+- [ ] AC-7 — other 4 subagents untouched
+- [ ] AC-8 — `bundle exec jekyll build` exit 0
+- [ ] AC-9 — `git diff --name-only main...HEAD | wc -l` → 7
+- [ ] AC-10 — no protected file or governance surface touched
 
 ## Phase 2 — Ship
 
 - [ ] Push branch
-- [ ] Open PR with `Closes #945`; apply `agent:qa-gatekeeper` label only
+- [ ] Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only
 - [ ] CI green (or admin-merge per precedent)
 - [ ] Merge `--squash --delete-branch`
 - [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
-- [ ] Comment on #945 with production verification
-- [ ] Update memory: note that subagents now have project-scoped persistent memory
+- [ ] Comment on #990 with production verification
+- [ ] Update [[reference-subagent-memory]] memory: guardrails now landed for code-reviewer + security-auditor


### PR DESCRIPTION
## Summary

Adds a `## Memory Discipline` section to the prose body of `.claude/agents/code-reviewer.md` and `.claude/agents/security-auditor.md`, immediately after the role intro and before the first framework section. Each section: positive framing of what TO persist (≥2 categories) → bulleted forbidden list (4 examples) → one-sentence storage-context closer.

Closes the cross-cutting concern that both /ship reviewers (independently) flagged when auditing PR #991/#945 — `memory: project` was armed for all 6 subagents but neither high-sensitivity agent had explicit guidance on what NOT to persist.

## Changes

- **`.claude/agents/code-reviewer.md`** — 13-line `## Memory Discipline` section (lines 11–22). Forbidden categories: secrets/tokens in PR diffs; unreleased code or fix-for-CVE patch contents; PII / internal URLs / email addresses from issue bodies; specific PR content (with concrete pattern-vs-specific example pair).
- **`.claude/agents/security-auditor.md`** — 13-line `## Memory Discipline` section. Forbidden categories: any string the agent would flag as a finding; embargoed CVE details (private GHSAs, vendor pre-disclosure); internal threat-intel sources or vendor contacts; customer PII.

Both sections cite repo-specific examples in the positive-framing paragraph (`has_label()` helper from #987, scope-guard rule numbering, case-collision artifact on `SECURITY.md` ↔ `security.md`) so the agent reading at runtime has concrete categories to recognise.

## /ship fan-out review

- **code-reviewer**: changes requested (light) → 2 Important wording fixes applied in `361154b` (pattern-vs-specific example pair; embargoed-CVE wording).
- **security-auditor**: CLEAN ship. Verified the guardrail closes the gap from #991; verified storage path + perms claim; confirmed no governance/protected surface touched.
- **test-engineer**: SHIP. 10/10 ACs pass. Filed 3 follow-ups for: memory-dir perms (#995), SPEC awk doc-bug (#996), guardrails for remaining 4 agents (#997).

## Acceptance criteria

- [x] AC-1, AC-2: `## Memory Discipline` heading in both files (1 each)
- [x] AC-3: "Never persist to memory" phrase in both files (1 each)
- [x] AC-4: 4 forbidden-content bullets per section (requirement ≥3)
- [x] AC-5: positive framing with ≥2 categories of what TO persist per section
- [x] AC-6: frontmatter byte-identical to main (both files)
- [x] AC-7: other 4 subagents untouched
- [x] AC-8: `bundle exec jekyll build` exit 0
- [x] AC-9: 7 files total in diff
- [x] AC-10: no protected file or governance surface touched

## Rollback

Pure documentation-only change. `gh pr revert` removes the prose sections cleanly; the underlying `memory: project` mechanism from #991 stays intact. RTO < 5 min.

## Follow-ups filed

- **#995** — Tighten `~/.claude/projects/<slug>/` perms from 755 to 700 (host hardening, security-auditor noted current perms don't match SPEC's claim of 700)
- **#996** — Document SPEC AC verification patterns that work for bold-header bulleted lists (the AC-4 awk pattern in the spec returns 0; build phase used a corrected grep -A 6 pattern)
- **#997** — Expand `## Memory Discipline` to the remaining 4 subagents (test-engineer + 3 playwright-test-*), with agent-specific forbidden lists

Closes #990