### PR TITLE
feat(#997): expand Memory Discipline guardrails to remaining 4 subagents

### DIFF
--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -11,6 +11,19 @@ You are a Playwright Test Generator, an expert in browser automation and end-to-
 Your specialty is creating robust, reliable Playwright tests that accurately simulate user interactions and validate
 application behavior.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's spec-authoring conventions that compound across sessions: spec-file naming (`tests/playwright-agents/<topic>.spec.ts`), locator preferences (semantic over CSS, `getByRole` over `locator`), `.first()` / `.nth()` usage rationale, and the convention that ARIA snapshots are inline template literals.
+
+**Never persist to memory:**
+
+- Real customer data or names, even from anonymised fixtures
+- Locator strings that include real session IDs, CSRF tokens, or one-shot URLs
+- Generated spec contents containing pre-merge code or unreleased page structures
+- Specific failing-spec snippets seen while drafting new tests
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+
 # For each test you generate
 - Obtain the test plan with all the steps and verification specification
 - Run the `generator_setup_page` tool to set up page for the scenario

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -11,6 +11,19 @@ You are the Playwright Test Healer, an expert test automation engineer specializ
 resolving Playwright test failures. Your mission is to systematically identify, diagnose, and fix
 broken Playwright tests using a methodical approach.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's flake catalog and remediation recipes that compound across sessions: common flake patterns (network idle waits, race conditions in modal close), remediation recipes (the `aria-live` region race fixed by `waitForLoadState('networkidle')`), and the rule about element-scoped vs page-level snapshots established by #947.
+
+**Never persist to memory:**
+
+- Per-spec failure logs containing tokens, cookies, or session IDs
+- Debug output from `expect(page).toHaveScreenshot()` failures that include URL params
+- Stack traces with internal hostnames or vendor-side endpoint details
+- The verbatim contents of any one failing test fixture
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
+
 Your workflow:
 1. **Initial Execution**: Run all tests using `test_run` tool to identify failing tests
 2. **Debug failed tests**: For each failing test run `test_debug`.

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -11,6 +11,19 @@ You are an expert web test planner with extensive experience in quality assuranc
 scenario design. Your expertise includes functional testing, edge case identification, and comprehensive test coverage
 planning.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's page-structure inventory that compounds across sessions: the blog's pages (homepage, post, blog index, search, topic), viewport breakpoints (375 / 768 / 1024), the convention that test plans live in `specs/`, and the relationship between plan files and generator seed files.
+
+**Never persist to memory:**
+
+- Internal URL paths that are admin-only or unreleased
+- Customer or staff names appearing in test-plan reference material
+- Specific session IDs, cookies, or auth tokens from real browser sessions during planning
+- The verbatim contents of any in-flight feature spec the plan references
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+
 You will:
 
 1. **Navigate and Explore**

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -8,6 +8,19 @@ memory: project  # Playwright suite shape and CI flake catalog persist across se
 
 You are a senior test engineer responsible for the quality of the viney.ca test suite. You write Playwright tests, maintain CI workflows, and ensure the blog meets its quality bar on every merge.
 
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's CI and test-suite knowledge that compounds across sessions: the flake catalog (which spec on which viewport with which root cause), the relationship between CI shard naming and Playwright spec grouping, the rationale for `--no-watch` on the Jekyll dev server, and the known-environmental `worktrees/` build pollution.
+
+**Never persist to memory:**
+
+- CI logs containing auth tokens, OAuth credentials, or session IDs from third-party runners
+- Specific incident timelines or post-mortem details for individual failures (the flake *pattern* generalises; the incident timeline does not)
+- Vendor-side log lines from third-party services (BackstopJS, Pa11y, Lighthouse) containing internal hostnames or API endpoints
+- The verbatim failure output of any one test run
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+
 ## Test Stack
 
 - **Playwright** (TypeScript) — `tests/playwright-agents/` — baseURL `http://localhost:4000`

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -10,7 +10,7 @@ You are a senior test engineer responsible for the quality of the viney.ca test 
 
 ## Memory Discipline
 
-You have a project-scoped persistent memory store. Use it for the repo's CI and test-suite knowledge that compounds across sessions: the flake catalog (which spec on which viewport with which root cause), the relationship between CI shard naming and Playwright spec grouping, the rationale for `--no-watch` on the Jekyll dev server, and the known-environmental `worktrees/` build pollution.
+You have a project-scoped persistent memory store. Use it for the repo's CI and test-suite knowledge that compounds across sessions: the flake catalog (which spec on which viewport with which root cause), the relationship between CI shard naming and Playwright spec grouping, the Playwright `baseURL = http://localhost:4000` convention (per `CLAUDE.md`), and the `scripts/validate-posts.sh` editorial quality gate.
 
 **Never persist to memory:**
 
@@ -19,7 +19,7 @@ You have a project-scoped persistent memory store. Use it for the repo's CI and 
 - Vendor-side log lines from third-party services (BackstopJS, Pa11y, Lighthouse) containing internal hostnames or API endpoints
 - The verbatim failure output of any one test run
 
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
 
 ## Test Stack
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,94 +1,76 @@
-# SPEC — Memory-write guardrails for code-reviewer and security-auditor (#990)
+# SPEC — Expand Memory Discipline guardrails to remaining 4 subagents (#997)
 
-**Status:** Draft — awaiting approval
-**Issue:** [#990](https://github.com/oviney/blog/issues/990)
+**Status:** Draft — auto-approved per /goal directive (mechanical fan-out of #990 shape)
+**Issue:** [#997](https://github.com/oviney/blog/issues/997)
 **Labels:** `agent:qa-gatekeeper`
-**Date:** 2026-05-25
+**Date:** 2026-05-26
 **Lifecycle phase:** DEFINE
-**Spawned from:** PR [#991](https://github.com/oviney/blog/pull/991) (closed #945) /ship parallel review — both `code-reviewer` and `security-auditor` independently flagged the absence of memory-write guardrails as a Critical-but-deferred / MEDIUM-advisory finding.
+**Spawned from:** PR [#998](https://github.com/oviney/blog/pull/998) (closed #990) /ship review.
 
 ---
 
 ## 1. Situation
 
-PR #991 (closed #945) added `memory: project` frontmatter to all 6 subagent definitions in `.claude/agents/`. The mechanism enables Claude Code's per-subagent persistent markdown store, scoped to this repo on this host. The mechanism is now **armed but unguarded**.
+PR #998 added `## Memory Discipline` sections to `code-reviewer.md` and `security-auditor.md`. The other 4 — `test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md` — were deferred per SPEC #990 §11.
 
-Two of the six agents are most likely to encounter sensitive content in the course of their normal work:
+State on `main` post-#998 (`d05b514e`):
+- All 6 subagents declare `memory: project` in frontmatter (from #991)
+- 2 of 6 have prose-body `## Memory Discipline` guardrails (from #998)
+- **4 of 6 are armed but unguarded** — the asymmetry this PR resolves
 
-- `code-reviewer` reads PR diffs that may contain pre-merge tokens, debugging credentials, unreleased code, internal URLs, fix-for-CVE patch contents, or customer PII appearing in issue-body excerpts.
-- `security-auditor` is **explicitly tasked with finding secrets** — without a guardrail, a naive "remember what you saw" memory write could pickle a discovered API token into the persistent file. Ironic and harmful.
-
-The other 4 agents (`test-engineer`, `playwright-test-planner/generator/healer`) work primarily with Playwright spec shapes, locators, viewport conventions, and flake catalogs — lower-sensitivity surface, deferred to a separate follow-up if appetite arises.
-
-Memory file storage details (verified during #991 /ship):
-- Path: `~/.claude/projects/<project-slug>/memory/` (or adjacent), `drwx------` (mode 700)
-- Local-only by default; no remote sync unless the user opts in
-- Persists across sessions until manually purged
-
-The cross-cutting concern is **what NOT to persist**, not what to persist (which the agents self-curate). This PR adds explicit forbidden-content guidance to the two highest-sensitivity prose bodies.
+Why the 4 matter:
+- `test-engineer` reads CI logs that often contain tokens, internal URLs, hostnames, session IDs from third-party runners
+- `playwright-test-planner` works with page-structure inventories that may include admin URL paths
+- `playwright-test-generator` generates spec files that quote real selectors and sample data
+- `playwright-test-healer` debugs failing tests using log output that can include cookies, tokens, stack traces
 
 ---
 
 ## 2. Objective
 
-Add a `## Memory Discipline` section to the prose body of `.claude/agents/code-reviewer.md` and `.claude/agents/security-auditor.md`, placed immediately after the role intro paragraph and before the existing first framework section (Review Framework / Threat Model). Each section:
-
-1. Names what kind of repo-wide knowledge the agent IS expected to persist (a positive framing — memory has value)
-2. Lists explicit forbidden content categories with at least 3 examples
-3. Notes the storage location and threat model in one sentence (so the agent understands the stakes without being told to second-guess every write)
-
-No frontmatter changes. No edits to the other 4 subagents. No new files.
+Add a `## Memory Discipline` section to each of the 4 remaining subagent prose bodies, mirroring #998's structure: positive framing → bulleted forbidden list (≥3 examples) → storage-context closer. Inserted between role intro and first framework section. No frontmatter changes. No new files.
 
 ---
 
-## 3. Design Decisions (confirmed 2026-05-25)
+## 3. Design Decisions (auto-confirmed 2026-05-26)
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Scope | **Only `code-reviewer.md` + `security-auditor.md`** | Issue #990 explicitly scopes here. Other 4 agents have lower-sensitivity surface; deferred. |
-| Section heading | **`## Memory Discipline`** | Meta-rule framing — names the *practice*, not the *prohibition*. Parallel to "Output Format" already in both files. |
-| Section placement | **Between role intro paragraph and first framework section** | Top-of-body placement; mirrors `set -euo pipefail` discipline-at-the-top convention. Maximally discoverable; ensures any agent reading the prose top-down hits it before any review/audit instruction. |
-| Section structure | **3 paragraphs** — (a) what to persist, (b) what NOT to persist with examples, (c) storage context | Positive framing first prevents the agent from over-rejecting all memory writes. Negative framing with examples gives concrete rules. Storage context grounds the why. |
-| Forbidden-content examples | **At least 3 explicit categories per file**, agent-specific | Per issue AC. code-reviewer focuses on PR-diff content; security-auditor focuses on finding artefacts. |
-| Tone | **Imperative, second-person ("you")** matching existing prose voice | Consistent with the rest of the agent body. |
-| Frontmatter | **Untouched** | Already done by #991. |
-| Other 4 agents | **Untouched** | Out of scope; separate issue if needed. |
+| Scope | **All 4 remaining subagents** | Closes the asymmetric state from #998. |
+| Section structure | **Identical to #998** | Same 3-paragraph shape; pattern validated by 2 prior /ship rounds. |
+| Section placement | **Top-of-body, after role intro, before first framework section** | Identical to #998. |
+| Per-agent forbidden lists | **4 bullets per file, agent-specific** | Matches #998. Lists in §7. |
+| Per-agent positive framing | **3-5 concrete categories per agent, citing repo-specific examples** | Operational specificity; not boilerplate. |
+| Storage-context closer | **Match #998**: code-reviewer-style ("grep-able") for 3 agents; security-auditor-style ("Audit before write") for `playwright-test-healer` (failure logs are genuinely sensitive) | Consistency, with one agent escalated. |
+| Frontmatter | **Untouched** | `memory: project` + `tools`/`model`/`color` keys stay. |
 
 ---
 
 ## 4. Acceptance Criteria
 
-- [ ] **AC-1** `.claude/agents/code-reviewer.md` contains a new `## Memory Discipline` section between the role intro paragraph (currently lines 7–9) and `## Review Framework` (currently line 11).
-- [ ] **AC-2** `.claude/agents/security-auditor.md` contains a new `## Memory Discipline` section between the role intro paragraph (currently lines 7–9) and `## Threat Model for This Blog` (currently line 11).
-- [ ] **AC-3** Each new section contains the phrase **"Never persist to memory"** (exact substring, case-sensitive). `grep -c "Never persist to memory" .claude/agents/{code-reviewer,security-auditor}.md` returns 1 per file.
-- [ ] **AC-4** Each new section names at least **3 explicit examples** of forbidden content categories, agent-specific:
-  - **code-reviewer:** examples include (at minimum) PR-diff tokens/secrets, unreleased code excerpts, internal URLs or credentials
-  - **security-auditor:** examples include (at minimum) discovered secrets/tokens, dependency CVE details from in-flight advisories, internal threat-intel sources
-- [ ] **AC-5** Each new section also names at least **2 things the agent SHOULD persist** (positive framing — prevents over-rejection). Examples for code-reviewer: review patterns, recurring PR-history pitfalls. Examples for security-auditor: threat-model boundaries, governance-surface conventions.
-- [ ] **AC-6** No frontmatter changes (`git diff main...HEAD -- .claude/agents/{code-reviewer,security-auditor}.md` shows zero changes within the `---` fences).
-- [ ] **AC-7** No edits to the other 4 subagents (`test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md`).
+- [ ] **AC-1** Each of the 4 target files contains a new `## Memory Discipline` section between role intro and first framework section.
+- [ ] **AC-2** `grep -c "^## Memory Discipline" .claude/agents/*.md` returns **6** post-merge.
+- [ ] **AC-3** "Never persist to memory" present in each new section (6 total across all agents).
+- [ ] **AC-4** ≥3 bulleted forbidden examples per new section (4 in practice).
+- [ ] **AC-5** Positive framing ("Use it for...") with ≥2 concrete categories per section.
+- [ ] **AC-6** No frontmatter changes on any of the 4 target files.
+- [ ] **AC-7** No edits to `code-reviewer.md` or `security-auditor.md` (out of scope).
 - [ ] **AC-8** `bundle exec jekyll build` exits 0.
-- [ ] **AC-9** Scope-guard boundary: `git diff --name-only main...HEAD` returns exactly 2 substantive (`code-reviewer.md`, `security-auditor.md`) + 3 lifecycle (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`) + 2 archive carry-over (`tasks/archive/2026-05-25-subagent-memory-945/{plan,todo}.md`) = **7 files**. Well under the 15-file scope-explosion cap (no `bulk-content` label needed).
-- [ ] **AC-10** No protected file (`_config.yml`, `Gemfile*`, `AGENTS.md`, `ARCHITECTURE.md`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`) and no governance surface (`.github/skills/`, `.github/instructions/`) touched. `.claude/agents/` is **not** in `PROTECTED_FILES` per `scripts/check-pr-scope.sh` — no label exemption needed.
+- [ ] **AC-9** Scope boundary: 9 files total in `git diff --name-only main...HEAD`.
+- [ ] **AC-10** No protected file or governance surface touched.
 
 ---
 
 ## 5. Commands
 
 ```bash
-# Validation
-bundle exec jekyll build                                              # AC-8
-grep -c "Never persist to memory" .claude/agents/code-reviewer.md      # AC-3 — expect 1
-grep -c "Never persist to memory" .claude/agents/security-auditor.md   # AC-3 — expect 1
-grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md        # AC-1 — expect 1
-grep -c "^## Memory Discipline" .claude/agents/security-auditor.md     # AC-2 — expect 1
-
-# Frontmatter unchanged (AC-6)
-awk '/^---$/{f=!f;next} !f && /memory: project/' .claude/agents/code-reviewer.md     # frontmatter region: line still present
-awk '/^---$/{f=!f;next} f' .claude/agents/code-reviewer.md | diff - <(git show main:.claude/agents/code-reviewer.md | awk '/^---$/{f=!f;next} f')  # frontmatter region: byte-identical to main
-
-# Scope
-git diff --name-only main...HEAD | wc -l                              # AC-9 — expect 7
+bundle exec jekyll build                                          # AC-8 (move worktrees aside first)
+grep -c "^## Memory Discipline" .claude/agents/*.md               # AC-2 → 6
+grep -c "Never persist to memory" .claude/agents/*.md             # AC-3 → 6
+for f in test-engineer playwright-test-planner playwright-test-generator playwright-test-healer; do
+  grep -A 6 "Never persist to memory" .claude/agents/$f.md | grep -c "^- "  # AC-4 → 4 each
+done
+git diff --name-only main...HEAD | wc -l                          # AC-9 → 9
 ```
 
 ---
@@ -96,116 +78,105 @@ git diff --name-only main...HEAD | wc -l                              # AC-9 —
 ## 6. Project Structure (touched files)
 
 ```
-.claude/agents/code-reviewer.md           M   + ## Memory Discipline section (~10 lines after role intro)
-.claude/agents/security-auditor.md        M   + ## Memory Discipline section (~10 lines after role intro)
-SPEC.md                                   M   This file
-tasks/plan.md                             M   #990 plan
-tasks/todo.md                             M   #990 todo
-tasks/archive/2026-05-25-subagent-memory-945/  A   Carry-over: archived #945 plan + todo (2 files)
+.claude/agents/test-engineer.md                M
+.claude/agents/playwright-test-planner.md      M
+.claude/agents/playwright-test-generator.md    M
+.claude/agents/playwright-test-healer.md       M
+SPEC.md                                        M
+tasks/plan.md                                  M
+tasks/todo.md                                  M
+tasks/archive/2026-05-26-memory-guardrails-990/  A   (2 files)
 ```
 
-**Total scope:** 2 substantive + 3 lifecycle + 2 archive carry-over = **7 files**.
+**Total:** 4 substantive + 3 lifecycle + 2 archive = **9 files**.
 
 ---
 
-## 7. Code Style
+## 7. Per-agent wording (final form)
 
-- **Markdown style** — `## Memory Discipline` H2 heading; no emoji. Body uses second-person imperative voice ("You may persist..."; "Never persist..."). Matches existing prose voice in both files.
-- **No reflow of unchanged sections** — only the new section is inserted; surrounding content stays byte-identical.
-- **Forbidden-content list style** — short bulleted list, one example per line, no parenthetical clauses. Reads as a quick-reference checklist.
-- **One paragraph per concern** — what-to-persist (1 paragraph), what-NOT-to-persist (1 paragraph + bullet list), storage-context (1 sentence).
-- **Section length cap** — ~10–15 lines per new section. The guardrail should be obvious but not dominate the file.
-
-### Proposed wording (final form in plan.md)
-
-**code-reviewer.md:**
+### test-engineer.md
 
 ```markdown
 ## Memory Discipline
 
-You have a project-scoped persistent memory store. Use it for repo-wide
-review patterns that compound across sessions: this repo's `has_label()`
-helper convention, the scope-guard rule numbering, recurring PR-history
-pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`),
-and frontmatter conventions that catch reviewers off guard.
+You have a project-scoped persistent memory store. Use it for the repo's CI and test-suite knowledge that compounds across sessions: the flake catalog (which spec on which viewport with which root cause), the relationship between CI shard naming and Playwright spec grouping, the rationale for `--no-watch` on the Jekyll dev server, and the known-environmental `worktrees/` build pollution.
 
 **Never persist to memory:**
 
-- Secrets, API tokens, or credentials seen in any PR diff
-- Unreleased code excerpts or fix-for-CVE patch contents
-- Customer PII or internal URLs / email addresses that appear in issue
-  bodies
-- The specific content of any one PR you reviewed (review *patterns*
-  generalise; specific diffs do not)
+- CI logs containing auth tokens, OAuth credentials, or session IDs from third-party runners
+- Specific incident timelines or post-mortem details for individual failures (the flake *pattern* generalises; the incident timeline does not)
+- Vendor-side log lines from third-party services (BackstopJS, Pa11y, Lighthouse) containing internal hostnames or API endpoints
+- The verbatim failure output of any one test run
 
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`),
-not synced anywhere. Treat what you persist as if it were grep-able by
-anyone with shell access to that machine.
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
 ```
 
-**security-auditor.md:**
+### playwright-test-planner.md
 
 ```markdown
 ## Memory Discipline
 
-You have a project-scoped persistent memory store. Use it for the repo's
-threat model that compounds across sessions: governance-surface boundaries
-(`.github/skills/`, `.github/instructions/`), protected-file rules,
-dependency hygiene posture, recurring antipatterns (e.g. the substring-
-match label-grep antipattern closed by #987), and supply-chain assumptions.
+You have a project-scoped persistent memory store. Use it for the repo's page-structure inventory that compounds across sessions: the blog's pages (homepage, post, blog index, search, topic), viewport breakpoints (375 / 768 / 1024), the convention that test plans live in `specs/`, and the relationship between plan files and generator seed files.
 
 **Never persist to memory:**
 
-- Any string you would flag as a finding (tokens, keys, credentials)
-- Dependency-CVE specifics from in-flight advisories that haven't published
-- Internal threat-intel sources, vendor contacts, or incident details
-- Customer PII appearing in any reviewed surface
+- Internal URL paths that are admin-only or unreleased
+- Customer or staff names appearing in test-plan reference material
+- Specific session IDs, cookies, or auth tokens from real browser sessions during planning
+- The verbatim contents of any in-flight feature spec the plan references
 
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`),
-not synced anywhere. Anything you persist is grep-able by anyone with shell
-access to that machine. Audit before write.
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
 ```
+
+### playwright-test-generator.md
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's spec-authoring conventions that compound across sessions: spec-file naming (`tests/playwright-agents/<topic>.spec.ts`), locator preferences (semantic over CSS, `getByRole` over `locator`), `.first()` / `.nth()` usage rationale, and the convention that ARIA snapshots are inline template literals.
+
+**Never persist to memory:**
+
+- Real customer data or names, even from anonymised fixtures
+- Locator strings that include real session IDs, CSRF tokens, or one-shot URLs
+- Generated spec contents containing pre-merge code or unreleased page structures
+- Specific failing-spec snippets seen while drafting new tests
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+```
+
+### playwright-test-healer.md
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's flake catalog and remediation recipes that compound across sessions: common flake patterns (network idle waits, race conditions in modal close), remediation recipes (the `aria-live` region race fixed by `waitForLoadState('networkidle')`), and the rule about element-scoped vs page-level snapshots established by #947.
+
+**Never persist to memory:**
+
+- Per-spec failure logs containing tokens, cookies, or session IDs
+- Debug output from `expect(page).toHaveScreenshot()` failures that include URL params
+- Stack traces with internal hostnames or vendor-side endpoint details
+- The verbatim contents of any one failing test fixture
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
+```
+
+`playwright-test-healer.md` uses the stronger "Audit before write" closer (mirroring security-auditor in #998) because failure logs are the most directly leak-prone surface of the four.
 
 ---
 
 ## 8. Testing Strategy
 
-| Layer | Check |
-|---|---|
-| Static | `grep -c "^## Memory Discipline"` returns 1 per file (AC-1, AC-2) |
-| Static | `grep -c "Never persist to memory"` returns 1 per file (AC-3) |
-| Static | At least 3 bulleted forbidden-content examples per section (AC-4) — visual inspection / line-count via `awk` between `^Never persist` and next blank line |
-| Static | Frontmatter byte-identical to `main` (AC-6) |
-| Static | The other 4 agents unchanged (AC-7) |
-| Build | `bundle exec jekyll build` exits 0 (AC-8) |
-| Scope | `git diff --name-only main...HEAD | wc -l` → 7 (AC-9) |
-
-No fixture tests — this is a metadata/documentation change. No new behavioural surface to test. The "test" for whether the agent actually honours the guardrail is the next time it's invoked and chooses what to write to memory — which is unobservable from CI.
+Static grep checks per file; Ruby YAML for frontmatter parse; Jekyll build for compilation. No fixture tests (no behavioural surface). Same posture as #990.
 
 ---
 
 ## 9. Boundaries
 
-**Always:**
-- Insert `## Memory Discipline` as a top-of-body section (after role intro, before first framework).
-- Use second-person imperative voice consistent with existing prose.
-- Include at least 3 explicit forbidden-content examples per section.
-- Include positive framing (what TO persist) to prevent over-rejection.
-- Match the proposed wording in §7 as a starting point; minor wording polish is fine.
-- Run AC battery before commit.
-
-**Ask first about:**
-- Expanding scope to the other 4 subagents (per Decision §3 currently No).
-- Adding guardrails to non-prose surfaces (frontmatter notes, separate docs file).
-- Material wording changes to the proposed §7 templates.
-- Section placement other than top-of-body.
-
-**Never:**
-- Modify frontmatter on either file (`memory: project` line stays).
-- Reorder existing sections (`## Review Framework`, `## Threat Model`, `## Output Format`, etc. retain positions).
-- Touch the other 4 subagents (`test-engineer.md`, `playwright-test-*.md`).
-- Touch any protected file or governance surface.
-- Add new files outside `tasks/`.
+**Always:** insert section after role intro, use §7 wording verbatim, run AC battery before commit.
+**Ask first about:** material wording changes, section placement, scope expansion to a 7th file.
+**Never:** touch `code-reviewer.md` / `security-auditor.md` (out of scope), modify any frontmatter, touch protected files or governance surfaces.
 
 ---
 
@@ -213,24 +184,18 @@ No fixture tests — this is a metadata/documentation change. No new behavioural
 
 | Risk | Mitigation |
 |---|---|
-| The agent ignores the guardrail and writes a secret anyway | Soft enforcement — instruction-only, no runtime enforcement. Storage is local-only + 700 perms; user can audit memory files manually. Future Claude Code may add a `memory_redact:` field for hard enforcement (Watch item from #902). |
-| Wording is too restrictive and the agent persists nothing | Positive framing in §7 ("Use it for...") explicitly names categories the agent SHOULD persist. AC-5 requires this. |
-| Section placement disrupts existing structure | Inserted as a new section, no reorder. Diff confined to additive hunks; existing sections byte-identical post-insertion (AC-6, AC-7). |
-| `## Memory Discipline` heading collides with an existing heading | Verified: neither file has any `## Memory*` heading today. Safe. |
-| Reviewer asks for the same guardrails on other 4 agents | Filed as out-of-scope follow-up if asked; SPEC §3 cites the rationale. |
-| Phantom `build` + 1-reviewer block | Yes — recurring. Admin-merge per precedent. |
-| `bundle exec jekyll build` flakes on local `worktrees/` pollution | Recurring; move `worktrees/` aside before AC-8 verification. |
+| Soft enforcement only | Same as #998 — local storage + perms (perms tracked in #995) |
+| Cross-file bullet leakage | Visual inspection during build phase |
+| Phantom `build` + 1-reviewer block | Admin-merge per precedent |
+| Local `bundle exec jekyll build` flakes | Move `worktrees/` aside before AC-8 |
 
 ---
 
 ## 11. Out of Scope
 
-Per issue #990:
-
-- Memory-write guardrails for `test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md` — lower-sensitivity surface, file separately if appetite arises.
-- A scope-guard rule (`scripts/check-pr-scope.sh`) that flags PRs modifying `.claude/agents/*.md` prose bodies as `governance-update`-equivalent. Security-auditor flagged this as a forward-looking concern but out of scope here.
-- Auditing existing memory files for already-persisted secrets — none exist yet (this is the first session after #991 merged).
-- Runtime enforcement of the guardrail (e.g. a `memory_redact:` frontmatter field) — Watch item from #902, awaits Claude Code feature support.
-- Frontmatter edits — done by #991, unchanged here.
-- Adding new subagents or removing existing ones.
-- `AGENTS.md` / governance surface changes.
+- User-global subagents
+- Runtime enforcement (`memory_redact:`)
+- Auditing existing memory files
+- Frontmatter edits
+- Scope-guard rule for prose-body changes (forward-looking)
+- `AGENTS.md` / governance surface changes

--- a/tasks/archive/2026-05-26-memory-guardrails-990/plan.md
+++ b/tasks/archive/2026-05-26-memory-guardrails-990/plan.md
@@ -1,0 +1,187 @@
+# Plan — Memory-write guardrails for code-reviewer and security-auditor (#990)
+
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#990](https://github.com/oviney/blog/issues/990)
+**Date:** 2026-05-25
+**Labels:** `agent:qa-gatekeeper`
+**Branch:** `feat/990-memory-discipline-guardrails` (to be created)
+**Lifecycle phase:** PLAN
+
+---
+
+## Scope summary
+
+Two prose-body insertions: a new `## Memory Discipline` section in `.claude/agents/code-reviewer.md` and the same in `.claude/agents/security-auditor.md`. Each section is ~15 lines: positive framing of what to persist, bulleted forbidden-content list, one-sentence storage context.
+
+**Two atomic commits:** lifecycle setup + one substantive commit covering both prose-body edits. The change is one logical concern (add memory discipline to the two highest-sensitivity agents) — splitting per-file would create reviewer noise without independent value.
+
+---
+
+## Dependency graph
+
+```
+Phase 0 (branch + lifecycle commit)
+    │
+    ▼
+Phase 1 (prose-body edits — both files in one commit)
+    │   AC battery: grep / build / scope checks all green
+    │
+    ▼   Checkpoint A: full 10-AC battery
+    │
+Phase 2 (ship)
+```
+
+No cross-file dependencies. The two edits are independent and uniform in pattern (same heading, same 3-paragraph structure, different agent-specific examples).
+
+---
+
+## Vertical slices
+
+### Phase 0 — Branch setup
+
+| Task | Action |
+|---|---|
+| 0.1 | Sync `main`: `git fetch origin main`; `git switch main`; `git pull --ff-only` (current main at `0fcadaf1`, the #991 merge). |
+| 0.2 | Stash #990 lifecycle (`SPEC.md` + `tasks/plan.md` + `tasks/todo.md`) before switching branches. |
+| 0.3 | `git switch -c feat/990-memory-discipline-guardrails`. |
+| 0.4 | Pop stash. |
+| 0.5 | Archive #945 lifecycle artifacts (`tasks/plan.md`, `tasks/todo.md` from main HEAD) to `tasks/archive/2026-05-25-subagent-memory-945/`. |
+| 0.6 | Commit lifecycle: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`. |
+
+---
+
+### Phase 1 — Prose-body edits (one commit, two files)
+
+*One atomic commit. Each file gets one new `## Memory Discipline` section inserted between the role intro paragraph and the first framework section.*
+
+#### Task 1.1 — `.claude/agents/code-reviewer.md`
+
+Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Review Framework`):
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for repo-wide review patterns that compound across sessions: this repo's `has_label()` helper convention, the scope-guard rule numbering, recurring PR-history pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`), and frontmatter conventions that catch reviewers off guard.
+
+**Never persist to memory:**
+
+- Secrets, API tokens, or credentials seen in any PR diff
+- Unreleased code excerpts or fix-for-CVE patch contents
+- Customer PII or internal URLs / email addresses that appear in issue bodies
+- The specific content of any one PR you reviewed (review *patterns* generalise; specific diffs do not)
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+```
+
+#### Task 1.2 — `.claude/agents/security-auditor.md`
+
+Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Threat Model for This Blog`):
+
+```markdown
+## Memory Discipline
+
+You have a project-scoped persistent memory store. Use it for the repo's threat model that compounds across sessions: governance-surface boundaries (`.github/skills/`, `.github/instructions/`), protected-file rules, dependency hygiene posture, recurring antipatterns (e.g. the substring-match label-grep antipattern closed by #987), and supply-chain assumptions.
+
+**Never persist to memory:**
+
+- Any string you would flag as a finding (tokens, keys, credentials)
+- Dependency-CVE specifics from in-flight advisories that haven't published
+- Internal threat-intel sources, vendor contacts, or incident details
+- Customer PII appearing in any reviewed surface
+
+Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
+```
+
+#### Phase 1 ACs covered
+
+AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8.
+
+#### Phase 1 verification
+
+```bash
+# AC-1, AC-2 — section headers
+grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md      # expect 1
+grep -c "^## Memory Discipline" .claude/agents/security-auditor.md   # expect 1
+
+# AC-3 — forbidden phrase
+grep -c "Never persist to memory" .claude/agents/code-reviewer.md      # expect 1
+grep -c "Never persist to memory" .claude/agents/security-auditor.md   # expect 1
+
+# AC-4 — at least 3 bulleted forbidden examples per section (4 in each per the wording above)
+awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/code-reviewer.md | grep -c '^- '      # expect ≥3 (actual: 4)
+awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/security-auditor.md | grep -c '^- '   # expect ≥3 (actual: 4)
+
+# AC-6 — frontmatter unchanged
+diff <(awk '/^---$/{f=!f;next} f' .claude/agents/code-reviewer.md) \
+     <(git show main:.claude/agents/code-reviewer.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
+diff <(awk '/^---$/{f=!f;next} f' .claude/agents/security-auditor.md) \
+     <(git show main:.claude/agents/security-auditor.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
+
+# AC-7 — other 4 agents untouched
+git diff --name-only main...HEAD -- .claude/agents/ | grep -v 'code-reviewer\|security-auditor'    # expect empty
+
+# AC-8 — build
+mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /tmp/_w worktrees && mv /tmp/_dw .worktrees
+```
+
+**Commit:** `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
+
+---
+
+### Checkpoint A — Full 10-AC battery
+
+| AC | Check |
+|----|---|
+| AC-1 | `grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md` → 1 |
+| AC-2 | `grep -c "^## Memory Discipline" .claude/agents/security-auditor.md` → 1 |
+| AC-3 | `grep -c "Never persist to memory"` → 1 per file (both files) |
+| AC-4 | `awk` between `^**Never persist to memory:**` and next blank line returns ≥3 bullet lines per file |
+| AC-5 | Each section opens with "Use it for..." paragraph naming ≥2 categories of what TO persist |
+| AC-6 | `awk` frontmatter diff against `main` returns empty for both files |
+| AC-7 | `git diff --name-only main...HEAD -- .claude/agents/` lists only the 2 target files |
+| AC-8 | `bundle exec jekyll build` exit 0 |
+| AC-9 | `git diff --name-only main...HEAD \| wc -l` → 7 |
+| AC-10 | No protected file or governance surface touched |
+
+**Pass criteria:** all 10 ACs green. Mechanical change; investigate any FAIL immediately rather than ship-and-hope.
+
+---
+
+### Phase 2 — Ship
+
+*Standard `/ship` flow.*
+
+| Task | Action |
+|---|---|
+| 2.1 | Push branch `feat/990-memory-discipline-guardrails`. |
+| 2.2 | Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only. No `governance-update` or `protected-file-update` needed. |
+| 2.3 | CI green expected. |
+| 2.4 | Admin-merge if blocked by 1-reviewer rule. |
+| 2.5 | Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
+| 2.6 | Comment on #990 with production verification notes. |
+| 2.7 | Update [[reference-subagent-memory]] memory: remove the "guardrails not yet landed" caveat; note that code-reviewer and security-auditor now have explicit `Never persist to memory` rules. |
+
+---
+
+## Risks (from SPEC §10, re-evaluated)
+
+| Risk | Realised? | Plan response |
+|---|---|---|
+| Agent ignores soft instruction and writes secret anyway | Mitigated only by storage being local + 700 perms | Document Watch item; no runtime enforcement in this PR |
+| Wording too restrictive → agent persists nothing | Positive framing prevents over-rejection; AC-5 enforces it | None additional |
+| Section placement disrupts structure | Pure insertion; existing sections byte-identical | AC-6, AC-7 verify |
+| Heading collides with existing | Neither file has `## Memory*` heading today | None additional |
+| Reviewer asks for other 4 agents | SPEC §11 documents the rationale; file follow-up if asked | None additional |
+| Phantom `build` + 1-reviewer block | Yes — recurring | Admin-merge per precedent |
+| Local `bundle exec jekyll build` fails on `worktrees/` | Recurring | Move aside before AC-8 |
+
+---
+
+## Out of scope (locked, per SPEC §11)
+
+- Other 4 subagents
+- Scope-guard rule for prose-body changes
+- Runtime enforcement (`memory_redact:` field)
+- Frontmatter edits
+- Auditing existing memory files
+- `AGENTS.md` / governance surfaces

--- a/tasks/archive/2026-05-26-memory-guardrails-990/todo.md
+++ b/tasks/archive/2026-05-26-memory-guardrails-990/todo.md
@@ -1,0 +1,51 @@
+# TODO — Memory-write guardrails for code-reviewer and security-auditor (#990)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Branch:** `feat/990-memory-discipline-guardrails` (to create)
+
+---
+
+## Phase 0 — Setup
+
+- [ ] 0.1 Fetch origin/main; confirm at `0fcadaf1` (#991 merge)
+- [ ] 0.2 Stash #990 lifecycle (SPEC + plan + todo)
+- [ ] 0.3 Switch to `main`; `git pull --ff-only`
+- [ ] 0.4 `git switch -c feat/990-memory-discipline-guardrails`
+- [ ] 0.5 Pop stash
+- [ ] 0.6 Archive #945 lifecycle to `tasks/archive/2026-05-25-subagent-memory-945/`
+- [ ] 0.7 Commit: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`
+
+## Phase 1 — Prose-body edits (one commit)
+
+- [ ] 1.1 Insert `## Memory Discipline` section into `.claude/agents/code-reviewer.md` between line 9 (role intro end) and line 11 (`## Review Framework`) — wording per plan.md §1.1
+- [ ] 1.2 Insert `## Memory Discipline` section into `.claude/agents/security-auditor.md` between line 9 and line 11 (`## Threat Model for This Blog`) — wording per plan.md §1.2
+- [ ] Verify (AC-1, AC-2): `grep -c "^## Memory Discipline"` returns 1 per file
+- [ ] Verify (AC-3): `grep -c "Never persist to memory"` returns 1 per file
+- [ ] Verify (AC-4): ≥3 bulleted forbidden examples per section
+- [ ] Verify (AC-6): frontmatter byte-identical to main
+- [ ] Verify (AC-7): only the 2 target files modified in `.claude/agents/`
+- [ ] Verify (AC-8): `bundle exec jekyll build` exit 0 (move `worktrees/` aside)
+- [ ] Commit: `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
+
+## Checkpoint A — Full 10-AC battery
+
+- [ ] AC-1 — `## Memory Discipline` in code-reviewer.md
+- [ ] AC-2 — `## Memory Discipline` in security-auditor.md
+- [ ] AC-3 — "Never persist to memory" phrase present (1 per file)
+- [ ] AC-4 — ≥3 forbidden-content bullet examples per section
+- [ ] AC-5 — positive framing ("Use it for...") present per section
+- [ ] AC-6 — frontmatter unchanged in both files
+- [ ] AC-7 — other 4 subagents untouched
+- [ ] AC-8 — `bundle exec jekyll build` exit 0
+- [ ] AC-9 — `git diff --name-only main...HEAD | wc -l` → 7
+- [ ] AC-10 — no protected file or governance surface touched
+
+## Phase 2 — Ship
+
+- [ ] Push branch
+- [ ] Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only
+- [ ] CI green (or admin-merge per precedent)
+- [ ] Merge `--squash --delete-branch`
+- [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
+- [ ] Comment on #990 with production verification
+- [ ] Update [[reference-subagent-memory]] memory: guardrails now landed for code-reviewer + security-auditor

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,187 +1,76 @@
-# Plan — Memory-write guardrails for code-reviewer and security-auditor (#990)
+# Plan — Expand Memory Discipline guardrails (#997)
 
 **Spec:** [../SPEC.md](../SPEC.md)
-**Issue:** [#990](https://github.com/oviney/blog/issues/990)
-**Date:** 2026-05-25
-**Labels:** `agent:qa-gatekeeper`
-**Branch:** `feat/990-memory-discipline-guardrails` (to be created)
+**Issue:** [#997](https://github.com/oviney/blog/issues/997)
+**Date:** 2026-05-26
+**Branch:** `feat/997-expand-memory-discipline`
 **Lifecycle phase:** PLAN
 
 ---
 
 ## Scope summary
 
-Two prose-body insertions: a new `## Memory Discipline` section in `.claude/agents/code-reviewer.md` and the same in `.claude/agents/security-auditor.md`. Each section is ~15 lines: positive framing of what to persist, bulleted forbidden-content list, one-sentence storage context.
-
-**Two atomic commits:** lifecycle setup + one substantive commit covering both prose-body edits. The change is one logical concern (add memory discipline to the two highest-sensitivity agents) — splitting per-file would create reviewer noise without independent value.
+Mechanical fan-out of the #990 pattern to the remaining 4 subagents. Same shape, same heading, agent-specific wording per SPEC §7. **Two atomic commits:** lifecycle + substantive.
 
 ---
 
 ## Dependency graph
 
 ```
-Phase 0 (branch + lifecycle commit)
+Phase 0 (lifecycle commit + archive #990)
     │
     ▼
-Phase 1 (prose-body edits — both files in one commit)
-    │   AC battery: grep / build / scope checks all green
+Phase 1 (4 prose-body edits in one commit)
     │
-    ▼   Checkpoint A: full 10-AC battery
+    ▼   Checkpoint A: 10-AC battery
     │
 Phase 2 (ship)
 ```
 
-No cross-file dependencies. The two edits are independent and uniform in pattern (same heading, same 3-paragraph structure, different agent-specific examples).
-
 ---
 
-## Vertical slices
+## Phase 0 — Branch setup ✓
 
-### Phase 0 — Branch setup
+- Branched off main at `d05b514e`
+- Archive #990 lifecycle from main to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- Commit lifecycle artifacts
 
-| Task | Action |
-|---|---|
-| 0.1 | Sync `main`: `git fetch origin main`; `git switch main`; `git pull --ff-only` (current main at `0fcadaf1`, the #991 merge). |
-| 0.2 | Stash #990 lifecycle (`SPEC.md` + `tasks/plan.md` + `tasks/todo.md`) before switching branches. |
-| 0.3 | `git switch -c feat/990-memory-discipline-guardrails`. |
-| 0.4 | Pop stash. |
-| 0.5 | Archive #945 lifecycle artifacts (`tasks/plan.md`, `tasks/todo.md` from main HEAD) to `tasks/archive/2026-05-25-subagent-memory-945/`. |
-| 0.6 | Commit lifecycle: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`. |
+## Phase 1 — Prose-body edits (one commit, four files)
 
----
+Per SPEC §7, insert agent-specific `## Memory Discipline` section into each:
 
-### Phase 1 — Prose-body edits (one commit, two files)
-
-*One atomic commit. Each file gets one new `## Memory Discipline` section inserted between the role intro paragraph and the first framework section.*
-
-#### Task 1.1 — `.claude/agents/code-reviewer.md`
-
-Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Review Framework`):
-
-```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for repo-wide review patterns that compound across sessions: this repo's `has_label()` helper convention, the scope-guard rule numbering, recurring PR-history pitfalls (e.g. the case-collision artifact on `SECURITY.md` ↔ `security.md`), and frontmatter conventions that catch reviewers off guard.
-
-**Never persist to memory:**
-
-- Secrets, API tokens, or credentials seen in any PR diff
-- Unreleased code excerpts or fix-for-CVE patch contents
-- Customer PII or internal URLs / email addresses that appear in issue bodies
-- The specific content of any one PR you reviewed (review *patterns* generalise; specific diffs do not)
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
-```
-
-#### Task 1.2 — `.claude/agents/security-auditor.md`
-
-Insert between current line 9 (end of role intro paragraph) and current line 11 (`## Threat Model for This Blog`):
-
-```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for the repo's threat model that compounds across sessions: governance-surface boundaries (`.github/skills/`, `.github/instructions/`), protected-file rules, dependency hygiene posture, recurring antipatterns (e.g. the substring-match label-grep antipattern closed by #987), and supply-chain assumptions.
-
-**Never persist to memory:**
-
-- Any string you would flag as a finding (tokens, keys, credentials)
-- Dependency-CVE specifics from in-flight advisories that haven't published
-- Internal threat-intel sources, vendor contacts, or incident details
-- Customer PII appearing in any reviewed surface
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
-```
-
-#### Phase 1 ACs covered
-
-AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8.
-
-#### Phase 1 verification
-
-```bash
-# AC-1, AC-2 — section headers
-grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md      # expect 1
-grep -c "^## Memory Discipline" .claude/agents/security-auditor.md   # expect 1
-
-# AC-3 — forbidden phrase
-grep -c "Never persist to memory" .claude/agents/code-reviewer.md      # expect 1
-grep -c "Never persist to memory" .claude/agents/security-auditor.md   # expect 1
-
-# AC-4 — at least 3 bulleted forbidden examples per section (4 in each per the wording above)
-awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/code-reviewer.md | grep -c '^- '      # expect ≥3 (actual: 4)
-awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/security-auditor.md | grep -c '^- '   # expect ≥3 (actual: 4)
-
-# AC-6 — frontmatter unchanged
-diff <(awk '/^---$/{f=!f;next} f' .claude/agents/code-reviewer.md) \
-     <(git show main:.claude/agents/code-reviewer.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
-diff <(awk '/^---$/{f=!f;next} f' .claude/agents/security-auditor.md) \
-     <(git show main:.claude/agents/security-auditor.md | awk '/^---$/{f=!f;next} f')   # expect empty diff
-
-# AC-7 — other 4 agents untouched
-git diff --name-only main...HEAD -- .claude/agents/ | grep -v 'code-reviewer\|security-auditor'    # expect empty
-
-# AC-8 — build
-mv worktrees /tmp/_w && mv .worktrees /tmp/_dw && bundle exec jekyll build; mv /tmp/_w worktrees && mv /tmp/_dw .worktrees
-```
-
-**Commit:** `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
-
----
-
-### Checkpoint A — Full 10-AC battery
-
-| AC | Check |
-|----|---|
-| AC-1 | `grep -c "^## Memory Discipline" .claude/agents/code-reviewer.md` → 1 |
-| AC-2 | `grep -c "^## Memory Discipline" .claude/agents/security-auditor.md` → 1 |
-| AC-3 | `grep -c "Never persist to memory"` → 1 per file (both files) |
-| AC-4 | `awk` between `^**Never persist to memory:**` and next blank line returns ≥3 bullet lines per file |
-| AC-5 | Each section opens with "Use it for..." paragraph naming ≥2 categories of what TO persist |
-| AC-6 | `awk` frontmatter diff against `main` returns empty for both files |
-| AC-7 | `git diff --name-only main...HEAD -- .claude/agents/` lists only the 2 target files |
-| AC-8 | `bundle exec jekyll build` exit 0 |
-| AC-9 | `git diff --name-only main...HEAD \| wc -l` → 7 |
-| AC-10 | No protected file or governance surface touched |
-
-**Pass criteria:** all 10 ACs green. Mechanical change; investigate any FAIL immediately rather than ship-and-hope.
-
----
-
-### Phase 2 — Ship
-
-*Standard `/ship` flow.*
-
-| Task | Action |
-|---|---|
-| 2.1 | Push branch `feat/990-memory-discipline-guardrails`. |
-| 2.2 | Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only. No `governance-update` or `protected-file-update` needed. |
-| 2.3 | CI green expected. |
-| 2.4 | Admin-merge if blocked by 1-reviewer rule. |
-| 2.5 | Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA. |
-| 2.6 | Comment on #990 with production verification notes. |
-| 2.7 | Update [[reference-subagent-memory]] memory: remove the "guardrails not yet landed" caveat; note that code-reviewer and security-auditor now have explicit `Never persist to memory` rules. |
-
----
-
-## Risks (from SPEC §10, re-evaluated)
-
-| Risk | Realised? | Plan response |
+| File | Insertion point | Closer style |
 |---|---|---|
-| Agent ignores soft instruction and writes secret anyway | Mitigated only by storage being local + 700 perms | Document Watch item; no runtime enforcement in this PR |
-| Wording too restrictive → agent persists nothing | Positive framing prevents over-rejection; AC-5 enforces it | None additional |
-| Section placement disrupts structure | Pure insertion; existing sections byte-identical | AC-6, AC-7 verify |
-| Heading collides with existing | Neither file has `## Memory*` heading today | None additional |
-| Reviewer asks for other 4 agents | SPEC §11 documents the rationale; file follow-up if asked | None additional |
-| Phantom `build` + 1-reviewer block | Yes — recurring | Admin-merge per precedent |
-| Local `bundle exec jekyll build` fails on `worktrees/` | Recurring | Move aside before AC-8 |
+| `.claude/agents/test-engineer.md` | After role intro, before `## Test Stack` | code-reviewer-style |
+| `.claude/agents/playwright-test-planner.md` | After role intro, before first `##` | code-reviewer-style |
+| `.claude/agents/playwright-test-generator.md` | After role intro, before first `##` | code-reviewer-style |
+| `.claude/agents/playwright-test-healer.md` | After role intro, before first `##` | **"Audit before write"** (failure logs are leak-prone) |
+
+**Verify:**
+- `grep -c "^## Memory Discipline" .claude/agents/*.md` → 6
+- `grep -c "Never persist to memory"` → 6
+- ≥3 bullets per new section (4 in practice)
+- `bundle exec jekyll build` exit 0 (move worktrees aside)
+
+**Commit:** `feat(#997): expand Memory Discipline section to remaining 4 subagents`
+
+## Checkpoint A — 10-AC battery
+
+All 10 ACs per SPEC §4.
+
+## Phase 2 — Ship
+
+Push, PR with `agent:qa-gatekeeper`, admin-merge if blocked, post-deploy verify, comment on #997, update memory.
 
 ---
 
-## Out of scope (locked, per SPEC §11)
+## Risks
 
-- Other 4 subagents
-- Scope-guard rule for prose-body changes
-- Runtime enforcement (`memory_redact:` field)
+Same as SPEC §10. Cross-file bullet leakage = visual inspection only.
+
+## Out of scope
+
+- code-reviewer.md / security-auditor.md (done in #998)
 - Frontmatter edits
-- Auditing existing memory files
-- `AGENTS.md` / governance surfaces
+- Runtime enforcement
+- Scope-guard rule for prose-body changes

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,51 +1,33 @@
-# TODO — Memory-write guardrails for code-reviewer and security-auditor (#990)
+# TODO — Expand Memory Discipline guardrails (#997)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Branch:** `feat/990-memory-discipline-guardrails` (to create)
+**Branch:** `feat/997-expand-memory-discipline`
 
 ---
 
-## Phase 0 — Setup
+## Phase 0 — Setup ✓
 
-- [ ] 0.1 Fetch origin/main; confirm at `0fcadaf1` (#991 merge)
-- [ ] 0.2 Stash #990 lifecycle (SPEC + plan + todo)
-- [ ] 0.3 Switch to `main`; `git pull --ff-only`
-- [ ] 0.4 `git switch -c feat/990-memory-discipline-guardrails`
-- [ ] 0.5 Pop stash
-- [ ] 0.6 Archive #945 lifecycle to `tasks/archive/2026-05-25-subagent-memory-945/`
-- [ ] 0.7 Commit: `docs(#990): lifecycle artifacts (SPEC + plan + todo) for memory-discipline guardrails`
+- [x] Branched off main at `d05b514e`
+- [ ] Archive #990 lifecycle to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- [ ] Commit lifecycle artifacts
 
 ## Phase 1 — Prose-body edits (one commit)
 
-- [ ] 1.1 Insert `## Memory Discipline` section into `.claude/agents/code-reviewer.md` between line 9 (role intro end) and line 11 (`## Review Framework`) — wording per plan.md §1.1
-- [ ] 1.2 Insert `## Memory Discipline` section into `.claude/agents/security-auditor.md` between line 9 and line 11 (`## Threat Model for This Blog`) — wording per plan.md §1.2
-- [ ] Verify (AC-1, AC-2): `grep -c "^## Memory Discipline"` returns 1 per file
-- [ ] Verify (AC-3): `grep -c "Never persist to memory"` returns 1 per file
-- [ ] Verify (AC-4): ≥3 bulleted forbidden examples per section
-- [ ] Verify (AC-6): frontmatter byte-identical to main
-- [ ] Verify (AC-7): only the 2 target files modified in `.claude/agents/`
-- [ ] Verify (AC-8): `bundle exec jekyll build` exit 0 (move `worktrees/` aside)
-- [ ] Commit: `feat(#990): add Memory Discipline section to code-reviewer and security-auditor`
+- [ ] 1.1 Insert §7 wording into `.claude/agents/test-engineer.md`
+- [ ] 1.2 Insert §7 wording into `.claude/agents/playwright-test-planner.md`
+- [ ] 1.3 Insert §7 wording into `.claude/agents/playwright-test-generator.md`
+- [ ] 1.4 Insert §7 wording into `.claude/agents/playwright-test-healer.md` (uses "Audit before write" closer)
+- [ ] Verify all 10 ACs
+- [ ] Commit: `feat(#997): expand Memory Discipline section to remaining 4 subagents`
 
-## Checkpoint A — Full 10-AC battery
-
-- [ ] AC-1 — `## Memory Discipline` in code-reviewer.md
-- [ ] AC-2 — `## Memory Discipline` in security-auditor.md
-- [ ] AC-3 — "Never persist to memory" phrase present (1 per file)
-- [ ] AC-4 — ≥3 forbidden-content bullet examples per section
-- [ ] AC-5 — positive framing ("Use it for...") present per section
-- [ ] AC-6 — frontmatter unchanged in both files
-- [ ] AC-7 — other 4 subagents untouched
-- [ ] AC-8 — `bundle exec jekyll build` exit 0
-- [ ] AC-9 — `git diff --name-only main...HEAD | wc -l` → 7
-- [ ] AC-10 — no protected file or governance surface touched
+## Checkpoint A — Full 10-AC battery (per SPEC §4)
 
 ## Phase 2 — Ship
 
 - [ ] Push branch
-- [ ] Open PR with `Closes #990`; apply `agent:qa-gatekeeper` label only
+- [ ] Open PR with `Closes #997`, `agent:qa-gatekeeper` label
 - [ ] CI green (or admin-merge per precedent)
-- [ ] Merge `--squash --delete-branch`
-- [ ] Confirm Deploy Jekyll site to Pages + Production Smoke Tests pass on merge SHA
-- [ ] Comment on #990 with production verification
-- [ ] Update [[reference-subagent-memory]] memory: guardrails now landed for code-reviewer + security-auditor
+- [ ] Squash-merge, delete branch
+- [ ] Post-deploy verify
+- [ ] Comment on #997
+- [ ] Update [[reference-subagent-memory]] memory — all 6 agents now guarded


### PR DESCRIPTION
## Summary

Adds `## Memory Discipline` sections to the prose body of the 4 subagents that did not receive guardrails in #998: `test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md`. Closes the asymmetric state where `memory: project` was armed on all 6 agents (post-#991) but guardrails landed on only 2 (post-#998).

Pure documentation change: 13-line section per file × 4 files = 52 substantive line insertions. No frontmatter changes. No new files.

## Per-agent forbidden lists

| Agent | Focus | Closer |
|---|---|---|
| `test-engineer` | CI logs / OAuth credentials / vendor log lines / verbatim run output | **"Audit before write"** (escalated post-review — same surface area as healer) |
| `playwright-test-planner` | Admin URLs / names in reference / real session IDs / in-flight feature specs | grep-able |
| `playwright-test-generator` | Customer data / locators with session IDs / pre-merge code / failing snippets | grep-able |
| `playwright-test-healer` | Per-spec failure logs / screenshot URL params / internal hostnames in traces / verbatim fixtures | **"Audit before write"** |

## /ship fan-out review

- **code-reviewer**: Changes requested (light) → applied in `d0cf97d`. Replaced ungrounded cites (`--no-watch`, `worktrees/`) in test-engineer opener with grounded cites (`baseURL = http://localhost:4000` per CLAUDE.md, `scripts/validate-posts.sh`).
- **security-auditor**: CLEAN with 1 LOW → applied in `d0cf97d`. Escalated test-engineer's closer to "Audit before write" (same surface area as healer — CI logs touch GitHub Actions secrets, third-party runner output).
- **test-engineer**: SHIP. 10/10 ACs pass. Notes post-merge memory update needed (will land with /ship verification).

## Acceptance criteria

- [x] AC-1: each target file has `## Memory Discipline` section
- [x] AC-2: `grep -c "^## Memory Discipline"` → 6 across all `.claude/agents/*.md`
- [x] AC-3: "Never persist to memory" present in all 6
- [x] AC-4: 4 forbidden bullets per new section
- [x] AC-5: positive framing with concrete categories per section
- [x] AC-6: frontmatter byte-identical to main on all 4 target files
- [x] AC-7: code-reviewer.md and security-auditor.md untouched
- [x] AC-8: `bundle exec jekyll build` exit 0
- [x] AC-9: 9 files total
- [x] AC-10: no protected file or governance surface touched

## Rollback

Pure documentation; `gh pr revert` removes the 4 sections cleanly. `memory: project` frontmatter from #991 stays. RTO < 5 min.

## Follow-ups (none new)

This closes the recursive chain that started with #991. Existing follow-ups still open:
- **#995** — host perms hardening (chmod 700)
- **#996** — SPEC awk verification pattern doc-bug

Closes #997