### PR TITLE
feat(#952): reference Claude Code /goal and claude agents in 2 SKILL files

### DIFF
--- a/.github/skills/jekyll-qa/SKILL.md
+++ b/.github/skills/jekyll-qa/SKILL.md
@@ -477,6 +477,8 @@ Specific areas to verify:
 # Step 4: Document decision in PR comment
 ```
 
+**Autonomous-loop note:** When the merge decision happens under an active `/goal` directive (Claude Code v2.1.139+), the loop stops on this gate until the merge succeeds or the override is documented. Use `claude agents` to confirm no parallel review (code-reviewer, security-auditor, test-engineer) is still in flight before applying an admin-merge.
+
 **Merge with Overrides (Requires Documentation):**
 
 When merging despite CI failures:

--- a/.github/skills/using-agent-skills/SKILL.md
+++ b/.github/skills/using-agent-skills/SKILL.md
@@ -122,3 +122,5 @@ bundle exec jekyll build   # must pass
 | `/test` | `test` + `jekyll-qa` |
 | `/review` | `review` + `code-review` |
 | `/ship` | `ship` + `git-operations` |
+| `/goal <directive>` | sets an autonomous-loop completion condition (Claude Code v2.1.139+); useful during **DEFINE** (sketch the goal), **BUILD** (auto-progress through tasks), and **SHIP** (auto-merge after CI). See `claude agents` to observe in-flight state. |
+| `claude agents` (view) | lists every active subagent session (Claude Code v2.1.139+). Inspect during long parallel fan-outs — e.g., a `/ship` review with code-reviewer + security-auditor + test-engineer concurrently. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,201 +1,125 @@
-# SPEC — Expand Memory Discipline guardrails to remaining 4 subagents (#997)
+# SPEC — Reference Claude Code `/goal` + `claude agents` in 2 SKILL files (#952)
 
-**Status:** Draft — auto-approved per /goal directive (mechanical fan-out of #990 shape)
-**Issue:** [#997](https://github.com/oviney/blog/issues/997)
-**Labels:** `agent:qa-gatekeeper`
+**Status:** Draft — auto-approved per /goal directive (well-scoped per issue body)
+**Issue:** [#952](https://github.com/oviney/blog/issues/952)
+**Labels:** `agent:qa-gatekeeper`, `governance-update` (touches `.github/skills/`)
 **Date:** 2026-05-26
-**Lifecycle phase:** DEFINE
-**Spawned from:** PR [#998](https://github.com/oviney/blog/pull/998) (closed #990) /ship review.
+**Branch:** `feat/952-claude-code-skill-refs`
 
 ---
 
 ## 1. Situation
 
-PR #998 added `## Memory Discipline` sections to `code-reviewer.md` and `security-auditor.md`. The other 4 — `test-engineer.md`, `playwright-test-planner.md`, `playwright-test-generator.md`, `playwright-test-healer.md` — were deferred per SPEC #990 §11.
+Claude Code v2.1.139 (2026-05-11) added `/goal` (autonomous-loop completion conditions) and `claude agents` (inspect active subagent sessions). The repo's two operational SKILL files don't reference either:
 
-State on `main` post-#998 (`d05b514e`):
-- All 6 subagents declare `memory: project` in frontmatter (from #991)
-- 2 of 6 have prose-body `## Memory Discipline` guardrails (from #998)
-- **4 of 6 are armed but unguarded** — the asymmetry this PR resolves
+- `.github/skills/using-agent-skills/SKILL.md` — describes the spec/plan/build/test/review/ship lifecycle
+- `.github/skills/jekyll-qa/SKILL.md` — QA gatekeeper workflow
 
-Why the 4 matter:
-- `test-engineer` reads CI logs that often contain tokens, internal URLs, hostnames, session IDs from third-party runners
-- `playwright-test-planner` works with page-structure inventories that may include admin URL paths
-- `playwright-test-generator` generates spec files that quote real selectors and sample data
-- `playwright-test-healer` debugs failing tests using log output that can include cookies, tokens, stack traces
+Adding references gives operators a concrete mechanism for the existing "verify before complete" guidance. This session itself exercised `/goal` heavily (3 invocations to date) and would have benefited from documenting it earlier.
 
 ---
 
 ## 2. Objective
 
-Add a `## Memory Discipline` section to each of the 4 remaining subagent prose bodies, mirroring #998's structure: positive framing → bulleted forbidden list (≥3 examples) → storage-context closer. Inserted between role intro and first framework section. No frontmatter changes. No new files.
+Add one-line references to `/goal` and `claude agents` in each of the 2 SKILL files, anchored to a specific lifecycle phase or workflow step (per issue AC). No structural changes; pure additions. PR carries `governance-update` label because `.github/skills/` is a governance surface.
 
 ---
 
-## 3. Design Decisions (auto-confirmed 2026-05-26)
+## 3. Design Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Scope | **All 4 remaining subagents** | Closes the asymmetric state from #998. |
-| Section structure | **Identical to #998** | Same 3-paragraph shape; pattern validated by 2 prior /ship rounds. |
-| Section placement | **Top-of-body, after role intro, before first framework section** | Identical to #998. |
-| Per-agent forbidden lists | **4 bullets per file, agent-specific** | Matches #998. Lists in §7. |
-| Per-agent positive framing | **3-5 concrete categories per agent, citing repo-specific examples** | Operational specificity; not boilerplate. |
-| Storage-context closer | **Match #998**: code-reviewer-style ("grep-able") for 3 agents; security-auditor-style ("Audit before write") for `playwright-test-healer` (failure logs are genuinely sensitive) | Consistency, with one agent escalated. |
-| Frontmatter | **Untouched** | `memory: project` + `tools`/`model`/`color` keys stay. |
+| Scope | **`using-agent-skills/SKILL.md` + `jekyll-qa/SKILL.md`** | Per issue. |
+| `using-agent-skills/SKILL.md` placement | **Extend the existing `## Slash Commands` table** at line 115 with 2 new rows | Natural home — same table style as `/spec`, `/plan`, etc. |
+| `jekyll-qa/SKILL.md` placement | **Add a one-line note adjacent to `### 2.6. PR Merge Decision Matrix`** | This is the "verify before merge" section the issue calls out. |
+| Wording style | **Match existing table-row style** in `using-agent-skills`; **operational prose** in `jekyll-qa` | Consistent with each file's existing voice. |
+| Label | **`governance-update`** required | `.github/skills/` is a governance surface per the scope guard. |
 
 ---
 
 ## 4. Acceptance Criteria
 
-- [ ] **AC-1** Each of the 4 target files contains a new `## Memory Discipline` section between role intro and first framework section.
-- [ ] **AC-2** `grep -c "^## Memory Discipline" .claude/agents/*.md` returns **6** post-merge.
-- [ ] **AC-3** "Never persist to memory" present in each new section (6 total across all agents).
-- [ ] **AC-4** ≥3 bulleted forbidden examples per new section (4 in practice).
-- [ ] **AC-5** Positive framing ("Use it for...") with ≥2 concrete categories per section.
-- [ ] **AC-6** No frontmatter changes on any of the 4 target files.
-- [ ] **AC-7** No edits to `code-reviewer.md` or `security-auditor.md` (out of scope).
-- [ ] **AC-8** `bundle exec jekyll build` exits 0.
-- [ ] **AC-9** Scope boundary: 9 files total in `git diff --name-only main...HEAD`.
-- [ ] **AC-10** No protected file or governance surface touched.
+- [ ] **AC-1** `.github/skills/using-agent-skills/SKILL.md` references both `/goal` and `claude agents` in the `## Slash Commands` table.
+- [ ] **AC-2** `.github/skills/jekyll-qa/SKILL.md` references at least one of `/goal` or `claude agents` adjacent to the merge-decision section.
+- [ ] **AC-3** Per issue's mechanical AC: `grep -E "/goal|claude agents" .github/skills/using-agent-skills/SKILL.md .github/skills/jekyll-qa/SKILL.md | wc -l` returns ≥ 2.
+- [ ] **AC-4** Each reference is anchored to a lifecycle phase or workflow step (not free-floating bullet).
+- [ ] **AC-5** `bundle exec jekyll build` exits 0.
+- [ ] **AC-6** No structural changes to either SKILL file — only additive rows/lines.
+- [ ] **AC-7** PR carries `governance-update` label preemptively (scope guard requirement).
+- [ ] **AC-8** Scope: 2 substantive + 3 lifecycle + 2 archive = **7 files**.
+- [ ] **AC-9** No protected file touched.
 
 ---
 
 ## 5. Commands
 
 ```bash
-bundle exec jekyll build                                          # AC-8 (move worktrees aside first)
-grep -c "^## Memory Discipline" .claude/agents/*.md               # AC-2 → 6
-grep -c "Never persist to memory" .claude/agents/*.md             # AC-3 → 6
-for f in test-engineer playwright-test-planner playwright-test-generator playwright-test-healer; do
-  grep -A 6 "Never persist to memory" .claude/agents/$f.md | grep -c "^- "  # AC-4 → 4 each
-done
-git diff --name-only main...HEAD | wc -l                          # AC-9 → 9
+bundle exec jekyll build                                                            # AC-5
+grep -E "/goal|claude agents" .github/skills/using-agent-skills/SKILL.md .github/skills/jekyll-qa/SKILL.md | wc -l   # AC-3 ≥ 2
+git diff --name-only main...HEAD | wc -l                                            # AC-8 → 7
 ```
 
 ---
 
-## 6. Project Structure (touched files)
+## 6. Project Structure
 
 ```
-.claude/agents/test-engineer.md                M
-.claude/agents/playwright-test-planner.md      M
-.claude/agents/playwright-test-generator.md    M
-.claude/agents/playwright-test-healer.md       M
-SPEC.md                                        M
-tasks/plan.md                                  M
-tasks/todo.md                                  M
-tasks/archive/2026-05-26-memory-guardrails-990/  A   (2 files)
+.github/skills/using-agent-skills/SKILL.md  M   + 2 rows in Slash Commands table
+.github/skills/jekyll-qa/SKILL.md           M   + 1 line adjacent to PR Merge Decision Matrix
+SPEC.md                                     M
+tasks/plan.md                               M
+tasks/todo.md                               M
+tasks/archive/2026-05-26-expand-memory-997/  A   (2 files)
 ```
 
-**Total:** 4 substantive + 3 lifecycle + 2 archive = **9 files**.
+Total: 7 files.
 
 ---
 
-## 7. Per-agent wording (final form)
+## 7. Wording (final form)
 
-### test-engineer.md
+### using-agent-skills/SKILL.md — extend the `## Slash Commands` table
+
+Add two rows after `/ship`:
 
 ```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for the repo's CI and test-suite knowledge that compounds across sessions: the flake catalog (which spec on which viewport with which root cause), the relationship between CI shard naming and Playwright spec grouping, the rationale for `--no-watch` on the Jekyll dev server, and the known-environmental `worktrees/` build pollution.
-
-**Never persist to memory:**
-
-- CI logs containing auth tokens, OAuth credentials, or session IDs from third-party runners
-- Specific incident timelines or post-mortem details for individual failures (the flake *pattern* generalises; the incident timeline does not)
-- Vendor-side log lines from third-party services (BackstopJS, Pa11y, Lighthouse) containing internal hostnames or API endpoints
-- The verbatim failure output of any one test run
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+| `/goal <directive>` | sets an autonomous-loop completion condition; useful during **DEFINE** (sketch the goal), **BUILD** (auto-progress through tasks), and **SHIP** (auto-merge after CI). See `claude agents` to observe in-flight state. |
+| `claude agents` (view) | lists every active subagent session. Inspect during long parallel fan-outs — e.g., a `/ship` review with code-reviewer + security-auditor + test-engineer concurrently. |
 ```
 
-### playwright-test-planner.md
+### jekyll-qa/SKILL.md — add note adjacent to PR Merge Decision Matrix
+
+Insert one paragraph immediately after the decision-process block (~line 478), before "Merge with Overrides":
 
 ```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for the repo's page-structure inventory that compounds across sessions: the blog's pages (homepage, post, blog index, search, topic), viewport breakpoints (375 / 768 / 1024), the convention that test plans live in `specs/`, and the relationship between plan files and generator seed files.
-
-**Never persist to memory:**
-
-- Internal URL paths that are admin-only or unreleased
-- Customer or staff names appearing in test-plan reference material
-- Specific session IDs, cookies, or auth tokens from real browser sessions during planning
-- The verbatim contents of any in-flight feature spec the plan references
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
+**Autonomous-loop note:** When the merge decision happens under an active `/goal` directive (Claude Code v2.1.139+), the loop stops on this gate until the merge succeeds or the override is documented. Use `claude agents` to confirm no parallel review (code-reviewer, security-auditor, test-engineer) is still in flight before applying an admin-merge.
 ```
-
-### playwright-test-generator.md
-
-```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for the repo's spec-authoring conventions that compound across sessions: spec-file naming (`tests/playwright-agents/<topic>.spec.ts`), locator preferences (semantic over CSS, `getByRole` over `locator`), `.first()` / `.nth()` usage rationale, and the convention that ARIA snapshots are inline template literals.
-
-**Never persist to memory:**
-
-- Real customer data or names, even from anonymised fixtures
-- Locator strings that include real session IDs, CSRF tokens, or one-shot URLs
-- Generated spec contents containing pre-merge code or unreleased page structures
-- Specific failing-spec snippets seen while drafting new tests
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Treat what you persist as if it were grep-able by anyone with shell access to that machine.
-```
-
-### playwright-test-healer.md
-
-```markdown
-## Memory Discipline
-
-You have a project-scoped persistent memory store. Use it for the repo's flake catalog and remediation recipes that compound across sessions: common flake patterns (network idle waits, race conditions in modal close), remediation recipes (the `aria-live` region race fixed by `waitForLoadState('networkidle')`), and the rule about element-scoped vs page-level snapshots established by #947.
-
-**Never persist to memory:**
-
-- Per-spec failure logs containing tokens, cookies, or session IDs
-- Debug output from `expect(page).toHaveScreenshot()` failures that include URL params
-- Stack traces with internal hostnames or vendor-side endpoint details
-- The verbatim contents of any one failing test fixture
-
-Memory is stored locally on the maintainer's machine (`~/.claude/projects/`), not synced anywhere. Anything you persist is grep-able by anyone with shell access to that machine. Audit before write.
-```
-
-`playwright-test-healer.md` uses the stronger "Audit before write" closer (mirroring security-auditor in #998) because failure logs are the most directly leak-prone surface of the four.
 
 ---
 
-## 8. Testing Strategy
+## 8. Boundaries
 
-Static grep checks per file; Ruby YAML for frontmatter parse; Jekyll build for compilation. No fixture tests (no behavioural surface). Same posture as #990.
-
----
-
-## 9. Boundaries
-
-**Always:** insert section after role intro, use §7 wording verbatim, run AC battery before commit.
-**Ask first about:** material wording changes, section placement, scope expansion to a 7th file.
-**Never:** touch `code-reviewer.md` / `security-auditor.md` (out of scope), modify any frontmatter, touch protected files or governance surfaces.
+**Always:** insert per §7 wording; preserve existing table/section structure; run AC battery before commit.
+**Ask first about:** material wording changes; placement elsewhere; expanding to other SKILL files.
+**Never:** modify protected files (`_config.yml`, `Gemfile*`, `AGENTS.md`, `ARCHITECTURE.md`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`); reorder existing SKILL sections; remove existing content.
 
 ---
 
-## 10. Risks
+## 9. Risks
 
 | Risk | Mitigation |
 |---|---|
-| Soft enforcement only | Same as #998 — local storage + perms (perms tracked in #995) |
-| Cross-file bullet leakage | Visual inspection during build phase |
+| `governance-update` label not applied → scope guard fails | Apply at PR open time; the label-bypass machinery from #989 anchors the check |
+| Wording references features that aren't documented elsewhere in the repo | The features are upstream Claude Code v2.1.139+ — referencing them is the *point* of this PR |
 | Phantom `build` + 1-reviewer block | Admin-merge per precedent |
-| Local `bundle exec jekyll build` flakes | Move `worktrees/` aside before AC-8 |
 
 ---
 
-## 11. Out of Scope
+## 10. Out of Scope
 
-- User-global subagents
-- Runtime enforcement (`memory_redact:`)
-- Auditing existing memory files
-- Frontmatter edits
-- Scope-guard rule for prose-body changes (forward-looking)
-- `AGENTS.md` / governance surface changes
+Per issue #952:
+- `.claude-plugin.json` packaging (Watch item from #943)
+- Refactoring existing SKILL structure
+- OTEL `agent_id` / `parent_agent_id` documentation
+- `continueOnBlock` hook documentation
+- Expanding to SKILL files other than the 2 named

--- a/tasks/archive/2026-05-26-expand-memory-997/plan.md
+++ b/tasks/archive/2026-05-26-expand-memory-997/plan.md
@@ -1,0 +1,76 @@
+# Plan — Expand Memory Discipline guardrails (#997)
+
+**Spec:** [../SPEC.md](../SPEC.md)
+**Issue:** [#997](https://github.com/oviney/blog/issues/997)
+**Date:** 2026-05-26
+**Branch:** `feat/997-expand-memory-discipline`
+**Lifecycle phase:** PLAN
+
+---
+
+## Scope summary
+
+Mechanical fan-out of the #990 pattern to the remaining 4 subagents. Same shape, same heading, agent-specific wording per SPEC §7. **Two atomic commits:** lifecycle + substantive.
+
+---
+
+## Dependency graph
+
+```
+Phase 0 (lifecycle commit + archive #990)
+    │
+    ▼
+Phase 1 (4 prose-body edits in one commit)
+    │
+    ▼   Checkpoint A: 10-AC battery
+    │
+Phase 2 (ship)
+```
+
+---
+
+## Phase 0 — Branch setup ✓
+
+- Branched off main at `d05b514e`
+- Archive #990 lifecycle from main to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- Commit lifecycle artifacts
+
+## Phase 1 — Prose-body edits (one commit, four files)
+
+Per SPEC §7, insert agent-specific `## Memory Discipline` section into each:
+
+| File | Insertion point | Closer style |
+|---|---|---|
+| `.claude/agents/test-engineer.md` | After role intro, before `## Test Stack` | code-reviewer-style |
+| `.claude/agents/playwright-test-planner.md` | After role intro, before first `##` | code-reviewer-style |
+| `.claude/agents/playwright-test-generator.md` | After role intro, before first `##` | code-reviewer-style |
+| `.claude/agents/playwright-test-healer.md` | After role intro, before first `##` | **"Audit before write"** (failure logs are leak-prone) |
+
+**Verify:**
+- `grep -c "^## Memory Discipline" .claude/agents/*.md` → 6
+- `grep -c "Never persist to memory"` → 6
+- ≥3 bullets per new section (4 in practice)
+- `bundle exec jekyll build` exit 0 (move worktrees aside)
+
+**Commit:** `feat(#997): expand Memory Discipline section to remaining 4 subagents`
+
+## Checkpoint A — 10-AC battery
+
+All 10 ACs per SPEC §4.
+
+## Phase 2 — Ship
+
+Push, PR with `agent:qa-gatekeeper`, admin-merge if blocked, post-deploy verify, comment on #997, update memory.
+
+---
+
+## Risks
+
+Same as SPEC §10. Cross-file bullet leakage = visual inspection only.
+
+## Out of scope
+
+- code-reviewer.md / security-auditor.md (done in #998)
+- Frontmatter edits
+- Runtime enforcement
+- Scope-guard rule for prose-body changes

--- a/tasks/archive/2026-05-26-expand-memory-997/todo.md
+++ b/tasks/archive/2026-05-26-expand-memory-997/todo.md
@@ -1,0 +1,33 @@
+# TODO — Expand Memory Discipline guardrails (#997)
+
+**Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
+**Branch:** `feat/997-expand-memory-discipline`
+
+---
+
+## Phase 0 — Setup ✓
+
+- [x] Branched off main at `d05b514e`
+- [ ] Archive #990 lifecycle to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- [ ] Commit lifecycle artifacts
+
+## Phase 1 — Prose-body edits (one commit)
+
+- [ ] 1.1 Insert §7 wording into `.claude/agents/test-engineer.md`
+- [ ] 1.2 Insert §7 wording into `.claude/agents/playwright-test-planner.md`
+- [ ] 1.3 Insert §7 wording into `.claude/agents/playwright-test-generator.md`
+- [ ] 1.4 Insert §7 wording into `.claude/agents/playwright-test-healer.md` (uses "Audit before write" closer)
+- [ ] Verify all 10 ACs
+- [ ] Commit: `feat(#997): expand Memory Discipline section to remaining 4 subagents`
+
+## Checkpoint A — Full 10-AC battery (per SPEC §4)
+
+## Phase 2 — Ship
+
+- [ ] Push branch
+- [ ] Open PR with `Closes #997`, `agent:qa-gatekeeper` label
+- [ ] CI green (or admin-merge per precedent)
+- [ ] Squash-merge, delete branch
+- [ ] Post-deploy verify
+- [ ] Comment on #997
+- [ ] Update [[reference-subagent-memory]] memory — all 6 agents now guarded

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,76 +1,72 @@
-# Plan — Expand Memory Discipline guardrails (#997)
+# Plan — Reference Claude Code `/goal` + `claude agents` in 2 SKILL files (#952)
 
 **Spec:** [../SPEC.md](../SPEC.md)
-**Issue:** [#997](https://github.com/oviney/blog/issues/997)
+**Issue:** [#952](https://github.com/oviney/blog/issues/952)
+**Branch:** `feat/952-claude-code-skill-refs`
 **Date:** 2026-05-26
-**Branch:** `feat/997-expand-memory-discipline`
-**Lifecycle phase:** PLAN
 
 ---
 
-## Scope summary
+## Scope
 
-Mechanical fan-out of the #990 pattern to the remaining 4 subagents. Same shape, same heading, agent-specific wording per SPEC §7. **Two atomic commits:** lifecycle + substantive.
-
----
+2 additive edits to SKILL files. **Two atomic commits:** lifecycle + substantive.
 
 ## Dependency graph
 
 ```
-Phase 0 (lifecycle commit + archive #990)
+Phase 0 (lifecycle commit + archive #997)
     │
     ▼
-Phase 1 (4 prose-body edits in one commit)
+Phase 1 (2 SKILL file edits in one commit)
     │
-    ▼   Checkpoint A: 10-AC battery
+    ▼   Checkpoint A: 9-AC battery
     │
 Phase 2 (ship)
 ```
 
----
+## Phase 0 — Lifecycle commit
 
-## Phase 0 — Branch setup ✓
-
-- Branched off main at `d05b514e`
-- Archive #990 lifecycle from main to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- Branched off main at `6ac2e1c7`
+- Archived #997 lifecycle to `tasks/archive/2026-05-26-expand-memory-997/`
 - Commit lifecycle artifacts
 
-## Phase 1 — Prose-body edits (one commit, four files)
+## Phase 1 — SKILL edits (one commit)
 
-Per SPEC §7, insert agent-specific `## Memory Discipline` section into each:
-
-| File | Insertion point | Closer style |
-|---|---|---|
-| `.claude/agents/test-engineer.md` | After role intro, before `## Test Stack` | code-reviewer-style |
-| `.claude/agents/playwright-test-planner.md` | After role intro, before first `##` | code-reviewer-style |
-| `.claude/agents/playwright-test-generator.md` | After role intro, before first `##` | code-reviewer-style |
-| `.claude/agents/playwright-test-healer.md` | After role intro, before first `##` | **"Audit before write"** (failure logs are leak-prone) |
+| File | Edit |
+|---|---|
+| `.github/skills/using-agent-skills/SKILL.md` | Add 2 rows to existing `## Slash Commands` table (after `/ship` row, ~line 124) per SPEC §7 |
+| `.github/skills/jekyll-qa/SKILL.md` | Add 1 paragraph after the merge-decision-process bash block (~line 478), before "Merge with Overrides" subheading, per SPEC §7 |
 
 **Verify:**
-- `grep -c "^## Memory Discipline" .claude/agents/*.md` → 6
-- `grep -c "Never persist to memory"` → 6
-- ≥3 bullets per new section (4 in practice)
-- `bundle exec jekyll build` exit 0 (move worktrees aside)
+- `grep -E "/goal|claude agents" <both files> | wc -l` → ≥ 2 (likely 4: 2 rows in using-agent-skills + 1 paragraph mentioning both in jekyll-qa)
+- `bundle exec jekyll build` exit 0
+- No structural reorder
 
-**Commit:** `feat(#997): expand Memory Discipline section to remaining 4 subagents`
+**Commit:** `feat(#952): reference /goal and claude agents in using-agent-skills and jekyll-qa SKILLs`
 
-## Checkpoint A — 10-AC battery
-
-All 10 ACs per SPEC §4.
+## Checkpoint A — 9-AC battery (per SPEC §4)
 
 ## Phase 2 — Ship
 
-Push, PR with `agent:qa-gatekeeper`, admin-merge if blocked, post-deploy verify, comment on #997, update memory.
+- Push branch
+- Open PR with `Closes #952`, `agent:qa-gatekeeper` + **`governance-update`** labels (required — touches `.github/skills/`)
+- CI green (or admin-merge per precedent)
+- Squash-merge, delete branch
+- Post-deploy verify
+- Comment on #952
 
 ---
 
-## Risks
+## Risks (from SPEC §9)
 
-Same as SPEC §10. Cross-file bullet leakage = visual inspection only.
+| Risk | Mitigation |
+|---|---|
+| Missing `governance-update` label → scope-guard fails | Apply at PR-open time |
+| Phantom `build` + 1-reviewer block | Admin-merge per precedent |
 
-## Out of scope
+## Out of scope (per SPEC §10)
 
-- code-reviewer.md / security-auditor.md (done in #998)
-- Frontmatter edits
-- Runtime enforcement
-- Scope-guard rule for prose-body changes
+- `.claude-plugin.json` packaging
+- Refactoring SKILL structure
+- OTEL / `continueOnBlock` docs
+- Expanding to other SKILL files

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,33 +1,26 @@
-# TODO — Expand Memory Discipline guardrails (#997)
+# TODO — Reference Claude Code `/goal` + `claude agents` in 2 SKILL files (#952)
 
 **Spec:** [../SPEC.md](../SPEC.md) · **Plan:** [plan.md](plan.md)
-**Branch:** `feat/997-expand-memory-discipline`
-
----
+**Branch:** `feat/952-claude-code-skill-refs`
 
 ## Phase 0 — Setup ✓
 
-- [x] Branched off main at `d05b514e`
-- [ ] Archive #990 lifecycle to `tasks/archive/2026-05-26-memory-guardrails-990/`
+- [x] Branched off main at `6ac2e1c7`
+- [x] Archived #997 lifecycle to `tasks/archive/2026-05-26-expand-memory-997/`
 - [ ] Commit lifecycle artifacts
 
-## Phase 1 — Prose-body edits (one commit)
+## Phase 1 — SKILL edits (one commit)
 
-- [ ] 1.1 Insert §7 wording into `.claude/agents/test-engineer.md`
-- [ ] 1.2 Insert §7 wording into `.claude/agents/playwright-test-planner.md`
-- [ ] 1.3 Insert §7 wording into `.claude/agents/playwright-test-generator.md`
-- [ ] 1.4 Insert §7 wording into `.claude/agents/playwright-test-healer.md` (uses "Audit before write" closer)
-- [ ] Verify all 10 ACs
-- [ ] Commit: `feat(#997): expand Memory Discipline section to remaining 4 subagents`
-
-## Checkpoint A — Full 10-AC battery (per SPEC §4)
+- [ ] 1.1 Add 2 rows to `## Slash Commands` table in `.github/skills/using-agent-skills/SKILL.md`
+- [ ] 1.2 Add 1 paragraph after merge-decision-process block in `.github/skills/jekyll-qa/SKILL.md`
+- [ ] Verify ACs (per SPEC §4)
+- [ ] Commit: `feat(#952): reference /goal and claude agents in using-agent-skills and jekyll-qa SKILLs`
 
 ## Phase 2 — Ship
 
 - [ ] Push branch
-- [ ] Open PR with `Closes #997`, `agent:qa-gatekeeper` label
-- [ ] CI green (or admin-merge per precedent)
+- [ ] Open PR with `Closes #952`, **`agent:qa-gatekeeper` + `governance-update`** labels
+- [ ] CI green (or admin-merge)
 - [ ] Squash-merge, delete branch
 - [ ] Post-deploy verify
-- [ ] Comment on #997
-- [ ] Update [[reference-subagent-memory]] memory — all 6 agents now guarded
+- [ ] Comment on #952


### PR DESCRIPTION
## Summary

Adds Claude Code v2.1.139+ feature references to two operational SKILL files. Pure additive change — no structural reorder.

## Changes

- **`.github/skills/using-agent-skills/SKILL.md`** — extends the existing `## Slash Commands` table with 2 new rows:
  - `/goal <directive>` — autonomous-loop completion condition; useful during DEFINE/BUILD/SHIP
  - `claude agents` (view) — lists active subagent sessions; inspect during long parallel fan-outs
- **`.github/skills/jekyll-qa/SKILL.md`** — adds an "Autonomous-loop note" paragraph immediately after the `### 2.6. PR Merge Decision Matrix` decision-process block, noting that `/goal` stops the loop on the merge gate and pointing to `claude agents` for confirming no parallel review is in flight before admin-merge

Each reference is anchored to a specific lifecycle phase or workflow step (per issue AC), not a free-floating bullet.

## Acceptance criteria

- [x] AC-1: both terms in `using-agent-skills/SKILL.md`
- [x] AC-2: at least one of `/goal` / `claude agents` in `jekyll-qa/SKILL.md`
- [x] AC-3: `grep -E "/goal|claude agents" <both files> | wc -l` → 3 (well above ≥2 requirement)
- [x] AC-4: references anchored to Slash Commands table + PR Merge Decision Matrix
- [x] AC-5: `bundle exec jekyll build` exit 0
- [x] AC-6: no structural reorder
- [x] AC-7: PR carries `governance-update` label (touches `.github/skills/`)
- [x] AC-8: 7 files total (2 substantive + 3 lifecycle + 2 archive)
- [x] AC-9: no protected file touched

## /ship fan-out

Skipped per the explicit rule (2 substantive files, ~4 lines added, no auth/payments/data/config touched). The change is doc-only and the session has now established this pattern across 7 prior PRs.

## Rollback

Pure documentation; `gh pr revert` removes the additions cleanly. RTO < 5 min.

## Notable

This is the first PR to exercise the **`governance-update` label-bypass machinery** that #989 anchored. If `check-agent-scope` passes cleanly with this label applied, it validates the post-#989 anchored grep on `governance-update`.

Closes #952