### PR TITLE
fix(#1003): rename test-build.yml 'test' job to 'build' (resolve phantom required check)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## Summary

One-line fix: rename the \`test\` job in \`.github/workflows/test-build.yml\` to \`build\`. This satisfies the branch-protection required check (\`build\`) that no PR-trigger workflow currently emits, allowing future PRs to merge without \`--admin\` once a reviewer approves.

## Why P1

Per the staff-engineer review (2026-05-26), this is the highest-leverage single change in the repo:

- Branch protection requires \`build\` + \`🔒 Security Audit\`
- The only workflow emitting \`build\` is \`jekyll.yml\` (push-trigger only — never runs on PRs)
- \`test-build.yml\` (PR-trigger) emitted \`test\`, \`validate-editorial\`, \`check-agent-scope\` — never \`build\`
- Result: every PR is BLOCKED on a check that cannot run → 10/10 session PRs were admin-merged
- Branch protection has been performative since it was set up

This rename closes that gap with zero behavioural change.

## Validation

- Job still runs the same steps: Jekyll build, HTML proofer, broken-link check
- No cross-workflow dependencies on the \`test\` name (\`grep needs:\` confirmed)
- This PR should be the **first** in the session that does NOT require \`--admin\` to merge (if a reviewer approves) — that's the validation signal

## Rollback

\`gh pr revert\` reverts the rename. RTO < 5 min. No data state.

## Follow-ups already filed from same staff-engineer review

- #1004 — gitignore worktrees
- #1005 — broken cross-post links + gate promotion
- #1006 — bypass-subset invariant fixture
- #1007 — workflow-ROI script

Closes #1003