### PR TITLE
fix(#1004): gitignore worktrees + add to Jekyll exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,11 @@ healing-success-report.md
 
 # Ruby vendor directory
 vendor/
+
+# Parallel-agent worktrees (local-only — isolated agent sessions on issue
+# branches; never synced and excluded from the Jekyll build)
+worktrees/
+.worktrees/
+
+# Claude Code session-scheduler lock (local-only; per-session state)
+.claude/scheduled_tasks.lock

--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,8 @@ exclude:
   - package.json
   - package-lock.json
   - CHANGELOG.md
+  - worktrees/
+  - .worktrees/
 
 include:
   - dashboard/


### PR DESCRIPTION
## Summary

Closes the recurring local-build flake that this session worked around 12 times via \`mv worktrees /tmp/_w\` before \`bundle exec jekyll build\`. Two changes:

1. **\`.gitignore\`** — add \`worktrees/\`, \`.worktrees/\`, \`.claude/scheduled_tasks.lock\` (local-only state used by parallel agent sessions)
2. **\`_config.yml\`** — add \`worktrees/\` and \`.worktrees/\` to \`exclude:\` list (stops Jekyll from scanning into vendored gem templates that have unparseable ERB date literals)

## Validation

\`bundle exec jekyll build\` now exits 0 cleanly **with \`worktrees/\` present** — verified locally, 4.3s build, no errors. The workaround is no longer needed.

## Expected CI behaviour

**\`check-agent-scope\` will fail.** This is intentional. \`_config.yml\` is in \`PROTECTED_FILES\` (`scripts/check-pr-scope.sh:43-51\`) and the \`protected-file-update\` label was designed (#985) to bypass **only \`AGENTS.md\` and \`ARCHITECTURE.md\`** — infra files always trip the guard, by design.

PR is expected to admin-merge through the red check; #1004 itself provides the dedicated audit trail that the design requires.

This also serves as a real-world test that the per-file bypass invariant holds (the bypass-subset fixture filed in #1006 would have caught any drift).

## Acceptance criteria (from #1004)

- [x] \`.gitignore\` entries added
- [x] \`_config.yml\` exclude: list grows entries for \`worktrees/\` and \`.worktrees/\`
- [x] \`bundle exec jekyll build\` exit 0 locally without the workaround
- [ ] PR carries \`protected-file-update\` label — **not applied** (label has no effect on \`_config.yml\`; would be misleading metadata)

## Rollback

\`gh pr revert\`. RTO < 5 min.

Closes #1004