### PR TITLE
fix(#1005): remove misleading grep-based broken-link check (htmlproofer is the real gate)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,26 +29,20 @@ jobs:
       - name: Build Jekyll site
         run: bundle exec jekyll build --verbose
       
-      - name: Validate HTML
+      - name: Validate HTML and internal links
         run: |
+          # htmlproofer validates against the built _site/, resolving every
+          # internal link to its actual generated path. This catches real
+          # broken links (where Jekyll's URL rewriting produces no matching
+          # _site/ file) — including cases where post front-matter `date:`
+          # overrides shift the URL away from the filename's date prefix.
           gem install html-proofer
           htmlproofer ./_site \
             --disable-external \
             --allow-hash-href \
             --ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/,/^mailto:/" \
             --ignore-status-codes "999"
-      
-      - name: Check for broken internal links
-        run: |
-          echo "Checking for broken internal links in markdown files..."
-          BROKEN=$(find _posts -name "*.md" -o -name "*.markdown" | xargs grep -n "](/" | grep -v "http" | grep -v "assets" | wc -l || echo "0")
-          if [ "$BROKEN" -gt 0 ]; then
-            echo "⚠️ Found $BROKEN potential broken internal links"
-            find _posts -name "*.md" -o -name "*.markdown" | xargs grep -n "](/" | grep -v "http" | grep -v "assets" || true
-          else
-            echo "✅ No broken internal links found"
-          fi
-      
+
       - name: Validate YAML front matter
         run: |
           echo "Validating YAML front matter..."


### PR DESCRIPTION
## Summary

Removes the \`Check for broken internal links\` step from \`.github/workflows/test-build.yml\` and updates the surrounding \`Validate HTML\` step with a comment explaining why htmlproofer is the authoritative link gate.

## Why this is the right fix (not a link cleanup)

**The 25 \"broken\" links were all false positives.** The grep-based step counted any internal \`](/ \` reference and labelled it \"potential broken\" — regardless of whether the link actually resolved.

**Verified locally:**

\`\`\`
$ bundle exec jekyll build
$ htmlproofer ./_site --disable-external ...
Checking 39 internal links
Checking internal link hashes in 0 files
Ran on 41 files!
HTML-Proofer finished successfully.
\`\`\`

**Zero broken links.** All 14 unique target slugs flagged by the grep check resolve correctly. Three of them (\`the-hidden-technical-debt-of-test-automation\`, \`the-productivity-paradox-of-test-coverage-metrics\`, \`the-real-cost-of-testing-theater-when-quality-metr\`) appear under \`/2026/04/05/\` despite filename prefix \`2026-01-18-\` because each post's front-matter overrides \`date: 2026-04-05\`. Jekyll uses the front-matter date for URL generation. The grep check didn't account for this.

One more (\`the-real-cost-of-test-automation-balancing-speed-and-sustai\`) has a double-dash filename but Jekyll generates a single-dash URL, matching the link.

## What changed in the diff

- Removed lines 41-50 (the grep-based \"Check for broken internal links\" step)
- Updated the surrounding \`Validate HTML\` step name → \`Validate HTML and internal links\` to make its scope explicit
- Added a comment explaining htmlproofer's role (catches Jekyll-date-override cases the naive grep misses)

Net: -13 lines, +7 lines.

## Acceptance criteria

- [x] Misleading check removed
- [x] htmlproofer continues to validate internal links (lines 32-39, unchanged behaviour)
- [x] \`bundle exec jekyll build\` exit 0 (verified locally)
- [x] No posts touched (the \"25 broken links\" never existed as a problem)
- [x] PR carries \`agent:qa-gatekeeper\` label only (touches \`.github/workflows/\` which is qa-gatekeeper-allowed)

## What this PR does NOT do

The originally-filed #1005 also called for "promoting the warning to a failing check." That's now moot — the warning was misleading, not under-strict. htmlproofer (which runs as a hard gate) is the right check, and it's already in place.

## Rollback

\`gh pr revert\` if for some reason teams want the noisy warning back. RTO < 5 min.

Closes #1005