### PR TITLE
test(#1006): add Case I — PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES invariant

### DIFF
--- a/tests/scope-guard.sh
+++ b/tests/scope-guard.sh
@@ -14,6 +14,7 @@
 #   F. .github/skills/... modified, PR_LABELS=governance-update-experimental → fails (Rule 3 trips; pins #987 anchor)
 #   G. 21 files modified, PR_LABELS=bulk-content              → passes (canonical bypass preserved)
 #   H. .github/skills/... modified, PR_LABELS=governance-update → passes (canonical bypass preserved)
+#   I. Static-config invariant: PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES
 #
 # Dependencies: bash, git. Same constraint as the script under test.
 
@@ -198,6 +199,35 @@ run_case "H: .github/skills/ modified, canonical governance-update label → Rul
   ".github/skills/scope-guard-test/SKILL.md" \
   "0" \
   "governance-update label present — skipping rule 3"
+
+# Static-config invariant: every entry in PROTECTED_FILE_UPDATE_BYPASS must
+# also appear in PROTECTED_FILES. The two arrays live adjacent in the script
+# and the bypass is meaningless for any entry not in the protected list (the
+# Rule 1 loop only enters the per-file bypass check after the file matched
+# the protected list). A future PR that adds an entry to the bypass without
+# adding it to the protected list would silently no-op.
+echo ""
+echo "Case: I: PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES (static-config invariant)"
+PROD_PROTECTED=$(awk '/^PROTECTED_FILES=\(/{f=1; next} f && /^\)$/{f=0} f' "$PROD_SCRIPT" | grep -oE '"[^"]+"' | tr -d '"')
+PROD_BYPASS=$(awk '/^PROTECTED_FILE_UPDATE_BYPASS=\(/{f=1; next} f && /^\)$/{f=0} f' "$PROD_SCRIPT" | grep -oE '"[^"]+"' | tr -d '"')
+
+case_ok=1
+while IFS= read -r entry; do
+  [ -z "$entry" ] && continue
+  if ! printf '%s\n' "$PROD_PROTECTED" | grep -qx "$entry"; then
+    echo "  FAIL: bypass entry '$entry' is not in PROTECTED_FILES"
+    case_ok=0
+  fi
+done <<EOF
+$PROD_BYPASS
+EOF
+
+if [ "$case_ok" = "1" ]; then
+  echo "  PASS — all bypass entries are in the protected list ($(printf '%s\n' "$PROD_BYPASS" | grep -c .) / $(printf '%s\n' "$PROD_BYPASS" | grep -c .))"
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
 
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Adds Case I to \`tests/scope-guard.sh\` — a static-config invariant check that asserts every entry in \`PROTECTED_FILE_UPDATE_BYPASS\` is also in \`PROTECTED_FILES\`. Closes the last remaining item from this morning's staff-engineer top-5 recommendations.

## Why this matters

\`scripts/check-pr-scope.sh:43-66\` defines two arrays:

\`\`\`bash
PROTECTED_FILES=( "_config.yml" "Gemfile" ... "AGENTS.md" "ARCHITECTURE.md" )
PROTECTED_FILE_UPDATE_BYPASS=( "AGENTS.md" "ARCHITECTURE.md" )
\`\`\`

The bypass list **must** be a subset of the protected list — adding \`ROADMAP.md\` to the bypass list without adding it to \`PROTECTED_FILES\` would silently no-op. The Rule 1 loop only enters the per-file bypass check after the file matched the protected list, so an orphan bypass entry has no effect.

Code-reviewer flagged this risk during the #988 /ship review. Originally deferred per SPEC §11. Closed today.

## How Case I works

Static-config check (not a behavioral test — no temp git repo needed):

1. \`awk\` extracts both arrays from the production \`scripts/check-pr-scope.sh\`
2. Iterate the bypass list, assert each entry matches a line in the protected list via \`grep -qx\`
3. Increment \`PASS\`/\`FAIL\` counters consistent with the rest of the harness

## Validation

\`\`\`
$ bash tests/scope-guard.sh
...
Case: I: PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES (static-config invariant)
  PASS — all bypass entries are in the protected list (2 / 2)

Summary: 9 passed, 0 failed
\`\`\`

Harness now reports **9/9 PASS** (was 8/8 post-#999).

## Closes the staff-engineer top-5

| # | Finding | PR |
|---|---|---|
| 1 | Phantom \`build\` check | #1008 ✓ |
| 2 | gitignore worktrees | #1009 ✓ |
| 3 | Broken-link warning noise | #1012 ✓ (turned out to be all false positives) |
| 4 | Bypass-subset invariant | **#1013 (this PR)** ✓ |
| 5 | Workflow ROI | #1010 ✓ |

Closes #1006