### PR TITLE
fix(#1016): bump tmp override to >=0.2.6 to clear GHSA-ph9p-34f9-6g65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6381,9 +6381,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/oviney/blog#readme",
   "overrides": {
     "lodash": "^4.18.1",
-    "tmp": ">=0.2.3",
+    "tmp": ">=0.2.6",
     "basic-ftp": "5.3.1",
     "ws": "^8.20.1",
     "qs": "^6.15.2",


### PR DESCRIPTION
## Problem

Closes #1016. The **Quality Tests → 🔒 Security Audit** job (`npm audit --audit-level=moderate`) has failed on `main` every night since **2026-05-27** (last green run 05-26). Root cause: advisory **GHSA-ph9p-34f9-6g65** (path traversal in `tmp <0.2.6`) was published 05-27.

`tmp` is a transitive dependency: `@lhci/cli → inquirer → external-editor → tmp`.

The existing override `"tmp": ">=0.2.3"` still permitted the vulnerable **0.2.5**, which is what actually resolved — so the pin was effectively a no-op against this advisory.

## Fix

Bump the override to `"tmp": ">=0.2.6"`, pulling **tmp 0.2.7**. This clears all 4 high-severity findings with **no breaking downgrade** of `@lhci/cli` (stays at 0.15.1) — unlike `npm audit fix --force`, which would drop it to 0.1.0.

## Verification

```
$ npm audit --audit-level=moderate
found 0 vulnerabilities   # exit 0

$ npm ls tmp --all
@lhci/cli@0.15.1 overridden
├─ inquirer@6.5.2 → external-editor@3.1.0 → tmp@0.2.7 deduped
└─ tmp@0.2.7 overridden
```

Local Jekyll build passes (pre-commit gate). Diff is 2 files: `package.json`, `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)