### PR TITLE
chore(#1021): add content-inventory script + fix drifted ROADMAP metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ and engineering leaders.
 
 | Metric | Current | Target | Timeframe |
 |--------|---------|--------|-----------|
-| Published posts | 23 | 30 | End of 2026 |
+| Published posts | 24 | 30 | End of 2026 |
 | Post cadence | Ad-hoc | 2 per month | Ongoing |
 
 **Topic priorities** (current distribution is improving, but still uneven):
@@ -18,7 +18,9 @@ and engineering leaders.
 - **Security** (3 posts) — still the thinnest category; make this the next 2-post priority so the archive is less lopsided
 - **Software Engineering** (5 posts) — second priority; add 1–2 strong essays to close the gap with the two testing-heavy categories
 - **Test Automation** (7 posts) — maintain a steady cadence, but avoid letting it crowd out the smaller categories
-- **Quality Engineering** (8 posts) — best-covered topic today; publish selectively when there is a distinct data point or strong contrarian angle
+- **Quality Engineering** (9 posts) — best-covered topic today; publish selectively when there is a distinct data point or strong contrarian angle
+
+_Post counts above are generated from `_posts/` front matter — regenerate with `bash scripts/content-inventory.sh` (run `--check` to detect drift)._
 
 The [economist-agents](https://github.com/oviney/economist-agents) pipeline can
 generate 2–3 drafts per week; the bottleneck is human review, not production.

--- a/scripts/content-inventory.sh
+++ b/scripts/content-inventory.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# content-inventory.sh — regenerate published-post metrics for ROADMAP.md
+#
+# Published-post counts and the category mix in ROADMAP.md are maintained by
+# hand, which makes drift likely. This script recomputes them from _posts/
+# front matter so the numbers can be regenerated instead of edited manually.
+#
+# Usage:
+#   bash scripts/content-inventory.sh             # human-readable report
+#   bash scripts/content-inventory.sh --markdown  # Markdown table (paste into ROADMAP.md)
+#   bash scripts/content-inventory.sh --check      # compare against ROADMAP.md; exit 1 on drift
+#
+# "Published" = every *.md / *.markdown file under _posts/ (Jekyll publishes
+# all of them; no future-dated posts exist today). Categories are read from the
+# inline front-matter form `categories: ["A", "B"]`; a post may count toward
+# more than one category.
+#
+# Portable to bash 3.2 (macOS): no mapfile / associative arrays.
+#
+# Exit codes: 0 = success (or --check found no drift), 1 = --check found drift.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POSTS_DIR="$REPO_ROOT/_posts"
+ROADMAP="$REPO_ROOT/ROADMAP.md"
+
+MODE="report"
+case "${1:-}" in
+  --markdown) MODE="markdown" ;;
+  --check)    MODE="check" ;;
+  "")         MODE="report" ;;
+  *) echo "Unknown option: $1" >&2; echo "Usage: $0 [--markdown|--check]" >&2; exit 1 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Compute metrics from _posts/ front matter.
+# ---------------------------------------------------------------------------
+TOTAL_POSTS=$(find "$POSTS_DIR" -maxdepth 1 \( -name "*.md" -o -name "*.markdown" \) | wc -l | tr -d ' ')
+
+# Emit one category name per line, across all posts.
+all_categories() {
+  find "$POSTS_DIR" -maxdepth 1 \( -name "*.md" -o -name "*.markdown" \) -print0 \
+    | xargs -0 awk '
+        FNR == 1 { fm = 0 }
+        /^---[[:space:]]*$/ { fm++; next }
+        fm == 1 && /^categories:/ {
+          line = $0
+          sub(/^categories:[[:space:]]*/, "", line)
+          gsub(/[][]/, "", line)                       # strip [ ]
+          n = split(line, arr, ",")
+          for (i = 1; i <= n; i++) {
+            v = arr[i]
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v) # trim
+            gsub(/^["'\'']|["'\'']$/, "", v)           # strip surrounding quotes
+            if (v != "") print v
+          }
+          next
+        }
+        fm >= 2 { nextfile }
+      '
+}
+
+# "count<TAB>name" lines, sorted by count desc then name asc.
+CATEGORY_TABLE="$(all_categories | sort | uniq -c \
+  | sort -k1,1nr -k2 \
+  | sed -E 's/^[[:space:]]*([0-9]+)[[:space:]]+(.*)$/\1	\2/')"
+
+actual_count_for() {
+  awk -F'\t' -v n="$1" '$2 == n { print $1; found = 1 } END { if (!found) print 0 }' <<<"$CATEGORY_TABLE"
+}
+
+# ---------------------------------------------------------------------------
+# Output modes.
+# ---------------------------------------------------------------------------
+case "$MODE" in
+  report)
+    echo "Content inventory — $TOTAL_POSTS published posts"
+    echo "------------------------------------------------"
+    while IFS=$'\t' read -r count name; do
+      [[ -n "$name" ]] && printf '  %-24s %s\n' "$name" "$count"
+    done <<<"$CATEGORY_TABLE"
+    ;;
+
+  markdown)
+    echo "| Category | Posts |"
+    echo "|----------|-------|"
+    while IFS=$'\t' read -r count name; do
+      [[ -n "$name" ]] && printf '| %s | %s |\n' "$name" "$count"
+    done <<<"$CATEGORY_TABLE"
+    echo
+    echo "_Total published posts: ${TOTAL_POSTS}. Regenerate with \`bash scripts/content-inventory.sh\`._"
+    ;;
+
+  check)
+    [[ -f "$ROADMAP" ]] || { echo "ROADMAP.md not found at $ROADMAP" >&2; exit 1; }
+    DRIFT=0
+
+    # Documented total: the "| Published posts | N |" table row.
+    DOC_TOTAL=$(grep -oE '^\| Published posts \| *[0-9]+' "$ROADMAP" | grep -oE '[0-9]+$' || true)
+    if [[ "$DOC_TOTAL" != "$TOTAL_POSTS" ]]; then
+      echo "DRIFT: published posts — ROADMAP says '${DOC_TOTAL:-<none>}', actual is ${TOTAL_POSTS}"
+      DRIFT=1
+    fi
+
+    # Documented per-category: "- **Name** (N posts)" lines under Topic priorities.
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      name=$(sed -E 's/.*\*\*([^*]+)\*\*.*/\1/' <<<"$line")
+      doc_count=$(grep -oE '\(([0-9]+) posts?\)' <<<"$line" | grep -oE '[0-9]+')
+      actual=$(actual_count_for "$name")
+      if [[ "$doc_count" != "$actual" ]]; then
+        echo "DRIFT: ${name} — ROADMAP says ${doc_count}, actual is ${actual}"
+        DRIFT=1
+      fi
+    done < <(grep -oE '\*\*[^*]+\*\* \([0-9]+ posts?\)' "$ROADMAP")
+
+    if [[ "$DRIFT" -eq 0 ]]; then
+      echo "OK: ROADMAP.md metrics match _posts/ (${TOTAL_POSTS} posts)."
+      exit 0
+    fi
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Closes #1021. Implements ROADMAP.md **Tech Debt #2** — the hand-maintained content metrics had drifted, so this adds a script to regenerate them and corrects the stale numbers.

(Tech Debt #1 — Sass `@import` → `@use` — is already complete, so this was the top remaining lifecycle-executable roadmap item.)

## The drift this fixes

| Metric | ROADMAP said | Actual |
|--------|--------------|--------|
| Published posts | 23 | **24** |
| Quality Engineering | 8 | **9** |
| Test Automation | 7 | 7 ✓ |
| Software Engineering | 5 | 5 ✓ |
| Security | 3 | 3 ✓ |

## Changes

- **`scripts/content-inventory.sh`** (new) — recomputes metrics from `_posts/` front matter; matches existing script conventions (`#!/usr/bin/env bash`, `set -euo pipefail`, `REPO_ROOT`, Usage + Exit-code header). Portable to bash 3.2 (no `mapfile`/associative arrays).
  - default → human-readable report
  - `--markdown` → table for pasting into ROADMAP
  - `--check` → compares against ROADMAP.md, exit 1 on drift (gate-ready; **not** wired into CI here)
- **`ROADMAP.md`** — corrected `23→24` and `QE 8→9`, plus a one-line "regenerate with…" note.

## Verification

```
$ bash scripts/content-inventory.sh
Content inventory — 24 published posts
  Quality Engineering      9
  Test Automation          7
  Software Engineering     5
  Security                 3

$ bash scripts/content-inventory.sh --check   # after the fix
OK: ROADMAP.md metrics match _posts/ (24 posts).   # exit 0
```

- `--check` correctly detected both drifts before the fix (exit 1), passes after (exit 0)
- `bash scripts/validate-posts.sh --all` passes; Jekyll build (pre-commit) green; no site output change
- Unknown args exit 1 with usage

## Scope

2 files — atomic. No new workflows, no CI wiring, no in-place ROADMAP auto-editing (out of scope per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)