### PR TITLE
fix(#1001): exclude worktree checkouts from doc-audit scans

### DIFF
--- a/scripts/doc-audit.sh
+++ b/scripts/doc-audit.sh
@@ -221,6 +221,8 @@ done < <(find . \
   -not -path './node_modules/*' \
   -not -path './vendor/*' \
   -not -path './_site/*' \
+  -not -path './worktrees/*' \
+  -not -path './.worktrees/*' \
   -name '*.md' \
   | sort)
 
@@ -416,6 +418,8 @@ done < <(find . \
   -not -path './node_modules/*' \
   -not -path './vendor/*' \
   -not -path './_site/*' \
+  -not -path './worktrees/*' \
+  -not -path './.worktrees/*' \
   -name '*.md' \
   | sort)
 
@@ -461,6 +465,8 @@ done < <(find . \
   -not -path './node_modules/*' \
   -not -path './vendor/*' \
   -not -path './_site/*' \
+  -not -path './worktrees/*' \
+  -not -path './.worktrees/*' \
   -name '*.md' \
   | sort)
 


### PR DESCRIPTION
## Summary

Closes #1001. The doc-audit was filing false positives by scanning gitignored git-worktree checkouts.

## Root cause

`scripts/doc-audit.sh`'s three repo-wide `find` commands (Check 1 internal links, Check 3 back-tick paths, Check 4 workflow refs) excluded `./vendor/*`, `./node_modules/*`, `./_site/*`, `./.git/*` — but **not** `./worktrees/*` or `./.worktrees/*`. Those are gitignored worktree checkouts (added in #1009), each containing a full `vendor/bundle/` of third-party gem READMEs. The audit descended into them and filed **56 false-positive "missing workflow" findings** (issue #1001), every one under `worktrees/` or `.worktrees/`.

Note `-not -path './vendor/*'` only matches the *top-level* vendor dir, so `./worktrees/issue-798/vendor/...` slipped through.

## Fix

Add `-not -path './worktrees/*'` and `-not -path './.worktrees/*'` to the three `find` commands, matching the existing exclusion intent.

## Verification

- `bash -n scripts/doc-audit.sh` → OK
- All 3 `find` blocks now carry both exclusions
- The post-fix scan set contains **0** worktree paths
- **0** missing-workflow references remain in tracked non-vendor docs → a fresh `doc-audit.yml` run reports nothing and auto-closes #1001
- Pre-commit Jekyll build green

## Scope

1 file, +6 lines — atomic. Out of scope: the broken-link work (#970/PR #861); broadening vendor/node_modules excludes to nested paths (the worktrees exclusion already removes 100% of findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)