### PR TITLE
docs(#996): note grep-window over awk-range for Markdown-list AC verification

### DIFF
--- a/.github/skills/spec-driven-development/SKILL.md
+++ b/.github/skills/spec-driven-development/SKILL.md
@@ -163,6 +163,17 @@ Break the plan into discrete, implementable tasks:
   - Files: [Which files will be touched]
 ```
 
+**Writing reliable `Verify:` commands for Markdown structures.** When a
+verification step counts items in a Markdown list, prefer
+`grep -A <N> "<header>" <file> | grep -c "^- "` over an `awk` range. An `awk`
+range such as `awk '/^\*\*Header:\*\*/,/^$/'` terminates on the *first* blank
+line — so when a blank line separates a bold header from its bullet list (common
+in agent prose), the range closes before any bullet is matched and the count
+returns `0` instead of the real total. The `grep -A` form reads a fixed window of
+lines past the header and is unaffected by the intervening blank line. Example
+that correctly counts the bullets under a bold header:
+`grep -A 6 "Never persist to memory" .claude/agents/code-reviewer.md | grep -c "^- "`.
+
 ### Phase 4: Implement
 
 Execute tasks one at a time following the repo's `build` and `test` workflows,


### PR DESCRIPTION
## Summary

Adds a one-paragraph note to the `spec-driven-development` scaffolding (Phase 3: Tasks, right after the task template's `Verify:` line) explaining how to write reliable verification commands that count items in a Markdown list.

## Background

PR #990's SPEC §4 AC-4 / §5 prescribed an `awk`-range command to count forbidden-content bullets:

```awk
awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/code-reviewer.md | grep -c '^- '
```

This returns **0**, not the expected ≥3 — the `awk` range terminates on the blank line that separates the bold header from its bullet list, before any bullet is matched. The `/build` phase used a working alternative (`grep -A N "<header>" | grep -c "^- "`). This was a one-PR verification-command bug, but the same broken pattern could be copied into future specs.

## Change

A single note in `.github/skills/spec-driven-development/SKILL.md` steering future specs toward the `grep -A` window form, with the dogfooded example.

## Verification

```
# documented pattern → correct count
$ grep -A 6 "Never persist to memory" .claude/agents/code-reviewer.md | grep -c "^- "
4
# warned-against awk range → wrong count
$ awk '/^\*\*Never persist to memory:\*\*/,/^$/' .claude/agents/code-reviewer.md | grep -c '^- '
0
```

- `bundle exec jekyll build` → exit 0

## Acceptance criteria

- [x] A spec/scaffolding doc has a one-paragraph note on the awk-vs-grep verification pattern
- [x] The note gives the corrected pattern so a future similar spec uses it from the start

## Scope / labels

- Touches `.github/skills/` → carries **`governance-update`** per the repo scope-guard convention.
- Out of scope (per issue): backfilling already-merged SPECs; auto-linting verification commands.

Closes #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
