### PR TITLE
docs: reconcile backlog, add burn-down goal, decompose evals epic

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,11 +28,20 @@ duplicate the queue.
 
 ## Active (priority order)
 
+> **Epic — Agent evals & governance gap-closure** (decomposed 2026-06-13 from
+> memory `project-agent-evals`). The governance stack is ~80% built; these tasks
+> close the specific gaps where governance is *claimed but not enforced*. P4/P5
+> are optional/low. Scoped against existing machinery: `check-pr-scope.sh`,
+> `check-agent-memory-discipline.sh` (#1030), `agent-eval.yml`, `validate-posts.sh`.
+
 | Pri | Task | Scope / label | Status | Ref |
 |----|------|---------------|--------|-----|
-| P1 | **Decide `SECURITY.md` fate.** Working tree has an uncommitted rewrite of the GitHub security-policy file into a Jekyll topic page (`layout`/`permalink` front matter + `category == 'Security'` grid). This breaks GitHub's Security-tab policy rendering. Decide: (a) `git checkout SECURITY.md` to restore the policy, or (b) move the topic-page content to a new `security.md` page so policy + landing page coexist. | `agent:creative-director` or `general` | **Needs decision** (blocked on owner) | local working-tree change |
-| P2 | **CI guard: agent memory-block regression check.** Add a CI check ensuring every `.claude/agents/*.md` retains its `Never persist to memory` / `## Memory Discipline` block, so the post-#999 guardrails can't silently regress. Suggested by the security-auditor during the #997 `/ship` audit. | `agent:qa-gatekeeper`, `governance-update` | Not started | memory `reference-subagent-memory` |
-| P3 | **Agent quality evals + boundary enforcement + governance policies.** Stand up evals for agent output quality, scope/boundary enforcement, and governance policy. Stated strategic next priority; likely an epic to decompose into smaller specs. | `agent:qa-gatekeeper` | Not started (epic — decompose first) | memory `project-agent-evals` |
+| ~~P1~~ | ~~Fix label-bypass substring bug.~~ **Already fixed in #989** — Rules 1–3 use `has_label()`; scope-guard Cases A–I all pass. Verified 2026-06-13. Reduced to a stale-comment cleanup in `tests/scope-guard.sh` (Cases E/F no longer say "will be GREEN once migrated"). | `agent:qa-gatekeeper` | **Done** (comment cleanup PR pending) | epic ↑ |
+| P1b | _(candidate)_ **Anchor Rule 4 agent-label detection.** `check-pr-scope.sh` lines ~155–161 still use unanchored `grep -q`/`grep -qE` for agent-label detection — the only spot not on `has_label()`. Low risk (agent labels are a fixed enum) but inconsistent. | `agent:qa-gatekeeper`, `governance-update` | Not started (low) | epic ↑ |
+| P2 | **Automate the agent-quality rubric.** Wire `scripts/eval-agent-pr.sh` hard thresholds (protected-file touch, code>50 LOC w/ 0 tests, >2 post-review force-pushes) into `agent-eval.yml` — post scorecard comment, hard-fail on breach. | `agent:qa-gatekeeper` | Not started | epic ↑ |
+| P3 | **Promote post-quality to a CI gate.** Add `validate-post-quality.sh` (error-level only) to the `validate-editorial` job; precede with a `--all` backfill audit to fix/triage existing failures first. | `agent:qa-gatekeeper` | Not started | epic ↑ |
+| P4 | _(optional)_ **Codify risk-tier policy.** Document branch protection so `risk:high` is a hard human-review block + thin CI gate failing `risk:high` PRs with no approving review. | `agent:qa-gatekeeper` | Not started (optional) | epic ↑ |
+| P5 | _(optional)_ **Harden memory-guard against rephrasing.** Make `check-agent-memory-discipline.sh` marker check tolerant of heading level / synonyms, or document accepted brittleness. | `agent:qa-gatekeeper`, `governance-update` | Not started (optional) | epic ↑ |
 
 ---
 
@@ -40,8 +49,7 @@ duplicate the queue.
 
 | Task | PR | Gate |
 |------|----|------|
-| ADR-009 — split-scope sequential issues over mixed-scope PRs (#972) | [#1027](https://github.com/oviney/blog/pull/1027) | Review / merge |
-| Spec AC-verification note: prefer `grep -A` over `awk` range (#996) | [#1028](https://github.com/oviney/blog/pull/1028) | Review / merge |
+| _(none)_ | | |
 
 ---
 
@@ -49,6 +57,8 @@ duplicate the queue.
 
 | Task | Resolution | Date |
 |------|------------|------|
+| CI guard: agent memory-block regression check | [#1030](https://github.com/oviney/blog/pull/1030) merged | 2026-06-13 |
+| Decide `SECURITY.md` fate (case collision + topic page) | Resolved by [#1038](https://github.com/oviney/blog/pull/1038) — security topic page renamed to end the `SECURITY.md` case collision | 2026-06-13 |
 | Tighten `~/.claude/projects/*/` perms to 700 (#995) | Done on host (all 7 dirs → `700`); resolution comment posted, awaiting issue close | 2026-05-31 |
 
 ---

--- a/docs/agents/burn-backlog.goal.md
+++ b/docs/agents/burn-backlog.goal.md
@@ -1,0 +1,63 @@
+# Goal: Burn down the backlog using the agent-skills lifecycle
+
+A reusable in-session goal for local Claude Code work. Drives `docs/BACKLOG.md`
+to empty by running each task through the lifecycle backbone, stopping at every
+human gate. Paste the **Goal prompt** below into a session (or `/loop` it).
+
+## How it works
+
+- The queue is `docs/BACKLOG.md` — one `Read`, highest-priority-first.
+- The backbone is the **local lifecycle skills** (`/spec → /plan → /build →
+  /test → /review → /ship`), with the upstream `agent-skills:*` guides as
+  reference (per `CLAUDE.md`).
+- Every iteration ends at a human gate (decomposition, PR-ready, or a task
+  flagged "needs decision"). The loop never self-merges.
+
+## Goal prompt
+
+```
+GOAL: Burn down docs/BACKLOG.md using the agent-skills lifecycle.
+
+Each iteration:
+1. Read docs/BACKLOG.md. Pull the TOP unchecked task in "Active" (highest
+   priority first). If Active is empty, stop and report "backlog drained."
+2. If the task is tagged "epic — decompose first": run /spec to break it into
+   smaller atomic tasks, propose them as Active rows in priority order, then
+   STOP for my review before writing them or building. Do not self-approve a
+   decomposition.
+3. Otherwise run the task through the backbone, invoking the LOCAL lifecycle
+   skills in order and consulting the upstream agent-skills:* guides as
+   reference:
+     /spec   -> approved spec (GitHub issue ONLY if it needs a Copilot cloud
+                agent; otherwise keep it local in the backlog)
+     /plan   -> atomic task breakdown
+     /build  -> implement one slice at a time on a branch (never on main)
+     /test   -> Playwright + pa11y + Lighthouse + jekyll build must pass
+     /review -> five-axis review before merge
+     /ship   -> commit (atomic), push branch, open PR
+4. STOP at the PR gate. Do NOT admin-merge — surface the PR for my review.
+   When I confirm a merge, move the item to "Recently shipped" with its PR
+   number, then continue.
+
+Hard rules (from CLAUDE.md + memory):
+- NEVER push directly to main; everything lands via PR (admin-merge is MY call).
+- Atomic commits — split by concern, one reviewable change per PR.
+- Don't touch protected files: _config.yml, Gemfile, Gemfile.lock,
+  .github/CODEOWNERS, .github/copilot-instructions.md.
+- Respect the scope guard (<=15 files; governance-update / protected-file-update
+  / bulk-content labels only with explicit justification).
+- Match complexity to scale — one script beats three workflows.
+- Pause for me at: epic decompositions, PR-ready gates, and any task the backlog
+  marks "needs decision".
+
+End each iteration with a one-line status: task pulled, skill phase reached,
+gate hit, and what you need from me to continue.
+```
+
+## Notes
+
+- **First run is a decomposition, not a build.** The current top task (the
+  agent-evals epic) is tagged "decompose first," so iteration 1 runs `/spec`
+  and stops for review — no code yet.
+- Fold any pending working-tree cleanup (e.g. a backlog reconciliation) into the
+  first `/ship` rather than leaving it dangling.


### PR DESCRIPTION
## What

- **Reconcile `docs/BACKLOG.md`** against shipped work: P1 SECURITY.md (resolved by #1038) and P2 memory-discipline CI guard (#1030) move to *Recently shipped*; stale *In review* rows (#1027/#1028, both closed unmerged) cleared.
- **Add `docs/agents/burn-backlog.goal.md`** — a reusable in-session goal that drives the queue through the agent-skills lifecycle (`/spec → /plan → /build → /test → /review → /ship`), stopping at every human gate.
- **Decompose the agent-evals epic** into gap-closure tasks (P1–P5), scoped against the existing governance stack (`check-pr-scope.sh`, `check-agent-memory-discipline.sh`, `agent-eval.yml`, `validate-posts.sh`) so only net-new work is queued.

## Notes

- P1 was **verified already-fixed in #989** (Rules 1–3 use `has_label()`; scope-guard 9/9 green). It reduced to a stale-comment cleanup, shipped as a **separate test-only PR**.
- Added **P1b** (anchor Rule 4 agent-label detection — the one remaining unanchored `grep -q`).
- Real buildable work now starts at **P2** (automate the agent-quality rubric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)