### PR TITLE
ci: promote post editorial-quality check to a merge gate

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -86,6 +86,23 @@ jobs:
       - name: Validate post front matter and image paths
         run: bash scripts/validate-posts.sh --all
 
+      - name: Validate post editorial quality (errors block, warnings advisory)
+        run: |
+          # validate-post-quality.sh exit codes: 0 = clean, 1 = ERROR, 2 = warnings only.
+          # Gate on ERRORs only; warnings are surfaced but never block the merge.
+          set +e
+          bash scripts/validate-post-quality.sh --all
+          code=$?
+          set -e
+          if [ "$code" -eq 1 ]; then
+            echo "::error::Post editorial quality check found blocking errors (see log above)."
+            exit 1
+          fi
+          if [ "$code" -eq 2 ]; then
+            echo "::warning::Post editorial quality passed with non-blocking warnings (see log above)."
+          fi
+          exit 0
+
   check-agent-scope:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'


### PR DESCRIPTION
## What (backlog P3)

Promotes `scripts/validate-post-quality.sh` from an on-demand script to an enforced CI gate by adding it to the `validate-editorial` job in `test-build.yml`, right after the front-matter validator.

## Errors block, warnings don't
The script exits `0`=clean, `1`=ERROR, `2`=warnings-only. The step gates on **errors only** — exit 2 (warnings) is surfaced as a `::warning::` annotation but never blocks merge, per the approved scope.

| Exit | Meaning | CI result |
|------|---------|-----------|
| 0 | clean | ✅ pass |
| 1 | error(s) | ❌ block |
| 2 | warnings only | ⚠️ pass (annotated) |

## Backfill audit first
Ran `validate-post-quality.sh --all` against the existing corpus before wiring the gate: **24 posts, 0 errors, 0 warnings**. The gate goes in green — no posts need fixing.

## Validation
- Workflow YAML parses.
- Gate exit-code logic verified: 0→pass, 1→block, 2→warn-pass.
- Real `--all` run exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)