### PR TITLE
fix: advertise the production sitemap in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -11,7 +11,7 @@ Disallow: /.github/
 Disallow: /docs/
 
 # Sitemap location
-Sitemap: http://localhost:4000/sitemap.xml
+Sitemap: https://www.viney.ca/sitemap.xml
 
 # Crawl delay (optional, helps with server load)
 Crawl-delay: 1

--- a/tests/playwright-agents/seo-jsonld.spec.ts
+++ b/tests/playwright-agents/seo-jsonld.spec.ts
@@ -11,6 +11,16 @@ import { test, expect } from '@playwright/test';
 
 test.describe('@content @links SEO JSON-LD Structured Data @REQ-CONTENT-01', () => {
 
+  test('robots.txt advertises the production sitemap without localhost references', async ({ request }) => {
+    const response = await request.get('/robots.txt');
+
+    expect(response.ok()).toBe(true);
+
+    const robotsTxt = await response.text();
+    expect(robotsTxt).toContain('Sitemap: https://www.viney.ca/sitemap.xml');
+    expect(robotsTxt).not.toContain('localhost');
+  });
+
   test('BreadcrumbList JSON-LD is present on the homepage', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

- replace the localhost sitemap URL in `robots.txt` with the canonical production URL
- add a Playwright regression test that verifies `/robots.txt` is available, advertises `https://www.viney.ca/sitemap.xml`, and contains no localhost reference

Closes #1048

## Lifecycle

- `/spec`: Issue #1048 defines the production defect and acceptance criteria
- `/plan`: Limited to `robots.txt` and the existing SEO Playwright spec
- `/build`: Updated the sitemap directive
- `/test`: Added the regression test RED before implementation, then verified GREEN
- `/review`: Five-axis review found no correctness, readability, architecture, security, or performance concerns
- `/ship`: This PR; production verification will follow merge and deployment

## Verification

- RED: focused test failed against `Sitemap: http://localhost:4000/sitemap.xml`
- GREEN: focused Playwright regression test: 1 passed
- Full SEO Playwright spec, Desktop Chrome: 6 passed
- `bundle exec jekyll build`: passed
- `bash scripts/check-pr-scope.sh`: passed (2 changed files)
- `git diff --check`: passed

## Production check after merge

- `https://www.viney.ca/robots.txt` returns 200 and contains the production sitemap directive
- `https://www.viney.ca/sitemap.xml` returns 200