### PR TITLE
fix(GH-1053): exclude internal utility pages from search indexing [BLOG-002]

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: Senior code reviewer for viney.ca blog. Evaluates changes across correctness, style, architecture, security, and accessibility. Use for thorough PR review before merge.
+published: false  # internal agent persona, not an audience-facing page — keep out of the built site & sitemap (GH-1053)
 ---
 
 # Senior Code Reviewer

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,6 +1,7 @@
 ---
 name: security-auditor
 description: Security engineer focused on vulnerability detection, threat modeling, and hardening guidance. Use for security review, dependency risk checks, or validating trust boundaries before merge.
+published: false  # internal agent persona, not an audience-facing page — keep out of the built site & sitemap (GH-1053)
 ---
 
 # Security Auditor

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,6 +1,7 @@
 ---
 name: test-engineer
 description: QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing verification, adding tests, or evaluating whether a change is proven.
+published: false  # internal agent persona, not an audience-facing page — keep out of the built site & sitemap (GH-1053)
 ---
 
 # Test Engineer

--- a/dashboard/agents.html
+++ b/dashboard/agents.html
@@ -1,8 +1,17 @@
+---
+# Internal observability page: keep crawlable for direct links but out of the
+# sitemap and search index (GH-1053). Pin the permalink so adding front matter
+# does not move the URL off /dashboard/agents.html under the site's pretty-URL
+# permalink style.
+permalink: /dashboard/agents.html
+sitemap: false
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
   <title>Agent Observability Dashboard — The Economist Blog</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <style>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,8 +1,14 @@
+---
+# Internal observability page: keep crawlable for direct links but out of the
+# sitemap and search index (GH-1053).
+sitemap: false
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
     <title>Playwright Healing Dashboard</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>

--- a/tests/playwright-agents/sitemap-exclusions.spec.ts
+++ b/tests/playwright-agents/sitemap-exclusions.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Sitemap exclusion regression tests (GH-1053 / BLOG-002)
+ *
+ * Internal utility surfaces — the observability dashboards and the internal
+ * agent-persona pages — must not appear in the generated XML sitemap, and any
+ * utility page that stays publicly reachable must be non-indexable. Editorial
+ * content (posts, topic pages, core pages, pagination) must remain present.
+ */
+
+const EXCLUDED_SITEMAP_PATHS = [
+  '/dashboard/',
+  '/dashboard/agents.html',
+  '/agents/code-reviewer/',
+  '/agents/security-auditor/',
+  '/agents/test-engineer/',
+];
+
+const RETAINED_SITEMAP_PATHS = [
+  '/',
+  '/about/',
+  '/blog/',
+  '/blog/page2/',
+  '/test-automation/',
+  '/2026/01/02/self-healing-tests-myth-vs-reality/',
+];
+
+test.describe('@seo @links Sitemap utility-page exclusions @REQ-CONTENT-01', () => {
+  test('excluded utility URLs are absent from the sitemap', async ({ request }) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.ok()).toBe(true);
+
+    const sitemap = await response.text();
+    const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+
+    for (const path of EXCLUDED_SITEMAP_PATHS) {
+      const leaked = locs.filter((loc) => new URL(loc).pathname === path);
+      expect(leaked, `sitemap should not advertise ${path}`).toHaveLength(0);
+    }
+  });
+
+  test('editorial and core URLs remain present in the sitemap', async ({ request }) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.ok()).toBe(true);
+
+    const sitemap = await response.text();
+    const paths = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1]).pathname);
+
+    for (const path of RETAINED_SITEMAP_PATHS) {
+      expect(paths, `sitemap should still advertise ${path}`).toContain(path);
+    }
+  });
+
+  test('dashboard pages that stay reachable are non-indexable', async ({ page }) => {
+    for (const path of ['/dashboard/', '/dashboard/agents.html']) {
+      const response = await page.goto(path);
+      expect(response?.ok(), `${path} should still be reachable`).toBe(true);
+
+      const robots = page.locator('head meta[name="robots"]');
+      await expect(robots, `${path} should declare a robots meta`).toHaveCount(1);
+      expect((await robots.getAttribute('content'))?.toLowerCase()).toContain('noindex');
+    }
+  });
+});


### PR DESCRIPTION
Closes #1053 (BLOG-002).

## Problem

The generated XML sitemap advertised internal, non-editorial surfaces — the observability dashboards (`/dashboard/`, `/dashboard/agents.html`) and the internal agent-persona pages (`/agents/code-reviewer/`, `/agents/security-auditor/`, `/agents/test-engineer/`). These are implementation/observability artifacts, not audience-facing content.

## Changes

- **Agent-persona pages** (`agents/*.md`): set `published: false`. They rendered as bare, unlinked HTML fragments (no layout/`<head>`), and the runtime personas live in `.claude/agents/`, so the root copies are removed from the build entirely — absent from the sitemap and not deployed. This is the sanctioned "exclude from deployment" path; no protected config touched.
- **Dashboards** (`dashboard/index.html`, `dashboard/agents.html`): kept reachable (they are documented in `ARCHITECTURE.md` / `GETTING_STARTED.md`) but dropped from the sitemap (`sitemap: false`) and marked `noindex, nofollow`. Pinned `permalink: /dashboard/agents.html` so adding front matter does not move the URL under the site's pretty-URL style.
- **Regression test** (`tests/playwright-agents/sitemap-exclusions.spec.ts`): asserts the excluded utility URLs are absent from `sitemap.xml`, representative editorial/core URLs remain, and the dashboards declare a `noindex` robots meta.

## Verification

- Production `jekyll build` passes; `_site/sitemap.xml` has zero `/dashboard/*` and `/agents/*/` entries; all editorial posts, `/`, `/blog/`, topic pages, About, and pagination retained.
- `_site/agents/` removed; both dashboards still deploy with `noindex` and original URLs.
- New Playwright spec: 3/3 pass.
- 6 files changed (under the 15-file scope cap); no protected files modified.

## Acceptance criteria

- [x] `/dashboard/`, `/dashboard/agents.html`, `/agents/*/` absent from sitemap
- [x] Remaining public utility pages not indexable
- [x] Editorial posts, `/`, `/blog/`, topic pages, About, pagination retained
- [x] Automated regression test for excluded + retained URLs
- [x] `bundle exec jekyll build` passes
- [x] Playwright tests and `bash scripts/check-pr-scope.sh` pass

## Dependencies

Builds on #1048 / #1052 (BLOG-001, production sitemap advertised in robots) — merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)