### PR TITLE
fix(ci): stop healing monitor timing out and gating PRs

### DIFF
--- a/.github/workflows/healing-monitor.yml
+++ b/.github/workflows/healing-monitor.yml
@@ -11,12 +11,10 @@ on:
       - 'scripts/healing-monitor.js'
       - 'scripts/alert-system.js'
       - '.github/workflows/healing-monitor.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'tests/playwright-agents/**'
-      - 'scripts/healing-monitor.js'
-      - 'scripts/alert-system.js'
+  # NOTE: intentionally NOT triggered on pull_request. This is an observability
+  # job (it computes a healing success-rate metric and updates the dashboard),
+  # not a quality gate, so it must not red-flag PRs. Correctness on PRs is
+  # already covered by the required Playwright jobs. See GH-1059.
   workflow_dispatch:
     inputs:
       force_analysis:

--- a/scripts/analyze-failures.js
+++ b/scripts/analyze-failures.js
@@ -22,6 +22,20 @@ class FailureAnalyzer {
   }
 
   async runFailureAnalysis() {
+    // Prefer an already-produced results file (e.g. the CI artifact downloaded
+    // into the monitor job). Re-running the suite here would hang against a
+    // dead localhost:4000 when no Jekyll server is up and blow the job timeout
+    // (GH-1059). Only re-run when no results file is present (local use).
+    const resultsPath = path.join(process.cwd(), 'test-results', 'results.json');
+    if (fs.existsSync(resultsPath)) {
+      console.log(`📄 Using existing Playwright results at ${resultsPath} (skipping re-run)`);
+      try {
+        return JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+      } catch (error) {
+        console.warn(`⚠️ Could not parse ${resultsPath}, falling back to a live run: ${error.message}`);
+      }
+    }
+
     console.log('🧪 Running Playwright tests to capture failures...');
 
     try {

--- a/scripts/healing-monitor.js
+++ b/scripts/healing-monitor.js
@@ -89,23 +89,35 @@ class HealingMonitor {
       };
     }
 
-    // Run BackstopJS visual tests (keep existing logic)
-    console.log('🖼️ Running BackstopJS visual tests...');
-    try {
-      execSync('npm run test:visual', { encoding: 'utf8' });
-      results.suites.visual = {
-        passed: 15,
-        failed: 0,
-        successRate: 100,
-        status: 'pass'
-      };
-    } catch (error) {
+    // Run BackstopJS visual tests (skip in CI). BackstopJS needs a running
+    // Jekyll server and browser binaries, neither of which exist in the
+    // monitor job — running it there hangs until the job timeout (GH-1059).
+    if (process.env.CI) {
+      console.log('⏭️ Skipping BackstopJS visual tests in CI monitor job (no server/browsers)');
       results.suites.visual = {
         passed: 0,
-        failed: 15,
+        failed: 0,
         successRate: 0,
-        status: 'fail'
+        status: 'skipped'
       };
+    } else {
+      console.log('🖼️ Running BackstopJS visual tests...');
+      try {
+        execSync('npm run test:visual', { encoding: 'utf8' });
+        results.suites.visual = {
+          passed: 15,
+          failed: 0,
+          successRate: 100,
+          status: 'pass'
+        };
+      } catch (error) {
+        results.suites.visual = {
+          passed: 0,
+          failed: 15,
+          successRate: 0,
+          status: 'fail'
+        };
+      }
     }
 
     // Calculate overall metrics


### PR DESCRIPTION
Closes #1059.

## Problem

The **🎭 Playwright Healing Success Monitor** failed on PRs (it red-flagged #1056) and on its scheduled/main runs. The `🔍 Healing Effectiveness Monitor` job hit its `timeout-minutes: 10` budget and was killed.

**Root cause:** the monitor downloads `test-results/results.json` as an artifact and is designed to consume it, but two leftover calls re-ran server-dependent tests inside a job with **no Jekyll server running**, so they hung/retried against a dead `localhost:4000` until the timeout:
- `scripts/analyze-failures.js:29/70` — re-ran the whole suite + 3 files
- `scripts/healing-monitor.js:95` — re-ran BackstopJS `test:visual`

It is also **not a quality gate** (not in `main`'s required checks), so it should never have blocked PRs in the first place.

## Changes

- **`healing-monitor.yml`** — drop the `pull_request:` trigger. Observability ≠ PR validation; correctness on PRs is covered by the required Playwright jobs. `schedule` (every 4h) + `push: main` + `workflow_dispatch` unchanged.
- **`analyze-failures.js`** — prefer an existing `test-results/results.json`; fall back to a live run only when absent (local use).
- **`healing-monitor.js`** — skip the BackstopJS `test:visual` re-run when `CI` is set.

## Verification

- Workflow YAML parses; triggers are now `schedule`, `push`, `workflow_dispatch` (no `pull_request`).
- `node -c` passes on both scripts.
- With a downloaded `results.json` and `CI=true`, both scripts complete **instantly** with no suite re-run: `analyze-failures.js` logs "Using existing Playwright results (skipping re-run)"; `healing-monitor.js` loads results 130/130 and logs "Skipping BackstopJS visual tests in CI".

## Scope / safety

- 3 files; no protected files; `.github/workflows/` is not a governance-surface path.
- No change to required gates (`build`, `Security Audit`) or the dashboard-data pipeline (the `update-dashboard` job still runs on `push: main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)