### PR TITLE
fix(GH-1054): emit exactly one SEO metadata set per page [BLOG-003]

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,10 +5,14 @@
   {% assign display_site_title = site.display_title | default: plain_site_title %}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ plain_site_title }}</title>
-  <meta name="description" content="{{ page.description | default: page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+  {%- comment -%}
+    Title, meta description, and canonical are emitted by jekyll-seo-tag (the
+    seo tag rendered below) — the single authoritative source — so they are
+    intentionally NOT hand-rolled here. Re-adding them would duplicate every
+    page's SEO metadata (GH-1054). Per-page titles/descriptions come from front
+    matter and are rendered by seo-tag.
+  {%- endcomment -%}
   <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="{{ '/favicon.svg' | relative_url }}">

--- a/tests/playwright-agents/seo-metadata-dedupe.spec.ts
+++ b/tests/playwright-agents/seo-metadata-dedupe.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * SEO metadata de-duplication regression (GH-1054 / BLOG-003)
+ *
+ * `_layouts/default.html` used to hand-roll <title>, meta description, and
+ * canonical AND also invoke {% seo %} (jekyll-seo-tag), so every page emitted
+ * two of each. jekyll-seo-tag is now the single authoritative source. These
+ * tests assert each representative page emits exactly one title, one meta
+ * description, and one canonical, while Open Graph and Twitter metadata from
+ * seo-tag remain present and valid.
+ */
+
+const REPRESENTATIVE_PAGES = [
+  { path: '/', label: 'Homepage' },
+  { path: '/about/', label: 'About' },
+  { path: '/blog/', label: 'Blog' },
+  { path: '/search/', label: 'Search' },
+  { path: '/test-automation/', label: 'Topic page' },
+  { path: '/2026/01/02/self-healing-tests-myth-vs-reality/', label: 'Article' },
+];
+
+test.describe('@seo SEO metadata is emitted exactly once @REQ-CONTENT-01', () => {
+  for (const { path, label } of REPRESENTATIVE_PAGES) {
+    test(`${label} (${path}) emits one title/description/canonical and valid OG+Twitter`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response?.ok(), `${path} should load`).toBe(true);
+
+      // Exactly one of each — no duplication between custom markup and seo-tag.
+      await expect(page.locator('head title'), `${path}: one <title>`).toHaveCount(1);
+      await expect(
+        page.locator('head meta[name="description"]'),
+        `${path}: one meta description`,
+      ).toHaveCount(1);
+      await expect(
+        page.locator('head link[rel="canonical"]'),
+        `${path}: one canonical`,
+      ).toHaveCount(1);
+
+      // Surviving values are non-empty and the canonical is an absolute URL.
+      expect((await page.title()).trim().length, `${path}: title not empty`).toBeGreaterThan(0);
+      const description = await page.locator('head meta[name="description"]').getAttribute('content');
+      expect(description?.trim().length, `${path}: description not empty`).toBeGreaterThan(0);
+      const canonical = await page.locator('head link[rel="canonical"]').getAttribute('href');
+      expect(canonical, `${path}: canonical is absolute`).toMatch(/^https?:\/\//);
+
+      // Open Graph and Twitter metadata from seo-tag remain present and valid.
+      await expect(
+        page.locator('head meta[property="og:title"]'),
+        `${path}: has og:title`,
+      ).toHaveCount(1);
+      const ogTitle = await page.locator('head meta[property="og:title"]').getAttribute('content');
+      expect(ogTitle?.trim().length, `${path}: og:title not empty`).toBeGreaterThan(0);
+      await expect(
+        page.locator('head meta[name="twitter:card"]'),
+        `${path}: has twitter:card`,
+      ).toHaveCount(1);
+    });
+  }
+});


### PR DESCRIPTION
Closes #1054 (BLOG-003). Unblocks #1055 (BLOG-004).

## Problem

`_layouts/default.html` hand-rolled `<title>`, `<meta name="description">`, and `<link rel="canonical">` **and** also invoked `{% seo %}` (jekyll-seo-tag). Every built page therefore emitted **two** of each — confirmed across the homepage, About, Blog, Search, a topic page, and an article (2 title / 2 description / 2 canonical each).

## Fix

Make **jekyll-seo-tag the single authoritative source**: remove the three custom tags from the layout, keep `{% seo %}`.

- **Canonical URLs are byte-identical** between the two former sources, so **no public URL changes**.
- **Descriptions match** (site description / per-page description fallback chain).
- **Title separator** changes from `" - "` to seo-tag's `" | "` — cosmetic; no test asserts the separator and the `<head>` title isn't user-facing chrome.
- **Open Graph + Twitter** metadata were only ever emitted by seo-tag, so they're unaffected.

This also sets up **BLOG-004 (#1055)**: per-page titles/descriptions now flow through one path (front matter → seo-tag).

## Verification

- Production build now emits **exactly 1** title / description / canonical on all six representative pages (was 2 each); OG (6–7) and `twitter:card` intact.
- New `tests/playwright-agents/seo-metadata-dedupe.spec.ts` (6 pages): **pass**.
- Existing `seo-jsonld.spec.ts`: **pass** (no regression).
- 2 files changed; no protected files.

## Acceptance criteria

- [x] Every representative page emits exactly one `<title>`.
- [x] Every indexable representative page emits exactly one meta description.
- [x] Every indexable representative page emits exactly one canonical URL.
- [x] Open Graph and Twitter metadata remain present and valid.
- [x] Automated tests cover homepage, About, Blog, Search, one topic page, and one article.
- [x] `bundle exec jekyll build` passes.
- [x] Relevant Playwright tests and scope guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)