### PR TITLE
feat(GH-1055): unique core-page descriptions; noindex Search [BLOG-004]

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
   {% assign display_site_title = site.display_title | default: plain_site_title %}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {%- if page.noindex -%}<meta name="robots" content="noindex, nofollow">{%- endif -%}
   {%- comment -%}
     Title, meta description, and canonical are emitted by jekyll-seo-tag (the
     seo tag rendered below) — the single authoritative source — so they are

--- a/about.md
+++ b/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About
 permalink: /about/
+description: Ouray Viney — Quality Engineering leader with 20+ years in software testing and automation, writing on test strategy, automation ROI, and quality metrics.
 ---
 
 # About

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Quality Engineering
+description: Coverage of software quality, test automation, and engineering leadership — practical analysis for practitioners and technical leaders.
 ---
 
 <div class="econ-topic-page">

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Quality Engineering Insights
+description: Two decades of software and quality engineering distilled into practical insights on test strategy, automation ROI, and engineering leadership.
 ---
 
 <div class="homepage">

--- a/search.html
+++ b/search.html
@@ -2,6 +2,10 @@
 layout: default
 title: Search
 permalink: /search/
+# Search-results pages carry no SEO value and Google discourages indexing them
+# (GH-1055). Keep it usable but out of the index and the sitemap.
+noindex: true
+sitemap: false
 ---
 
 <div class="topic-page">

--- a/security-topic.md
+++ b/security-topic.md
@@ -2,6 +2,7 @@
 layout: default
 title: Security
 permalink: /security/
+description: Reporting and analysis on security debt, enterprise defence, and the operational trade-offs that shape resilient systems.
 ---
 
 <div class="topic-page">

--- a/software-engineering.md
+++ b/software-engineering.md
@@ -2,6 +2,7 @@
 layout: default
 title: Software Engineering
 permalink: /software-engineering/
+description: Systematic methods, architectural decisions, and engineering practices that distinguish sustainable software from ad-hoc coding.
 ---
 
 <div class="topic-page">

--- a/test-automation.md
+++ b/test-automation.md
@@ -2,6 +2,7 @@
 layout: default
 title: Test Automation
 permalink: /test-automation/
+description: Strategies, frameworks, and practices for building test automation that delivers lasting value.
 ---
 
 <div class="topic-page">

--- a/tests/playwright-agents/seo-metadata-uniqueness.spec.ts
+++ b/tests/playwright-agents/seo-metadata-uniqueness.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Core-page SEO metadata uniqueness (GH-1055 / BLOG-004)
+ *
+ * About, Blog, the homepage, and the topic pages previously reused the generic
+ * site description. Each indexable core page must now expose a unique,
+ * non-generic meta description, and the Search results page must be noindex
+ * (it carries no SEO value) rather than competing for the generic description.
+ */
+
+// The generic fallback from _config.yml `description:`. No indexable core page
+// should still be emitting this.
+const GENERIC_SITE_DESCRIPTION =
+  'A blog for Software Engineering, Quality Engineering, Test Automation, Performance Engineering and more.';
+
+const INDEXABLE_CORE_PAGES = [
+  { path: '/', label: 'Homepage' },
+  { path: '/about/', label: 'About' },
+  { path: '/blog/', label: 'Blog' },
+  { path: '/test-automation/', label: 'Test Automation' },
+  { path: '/software-engineering/', label: 'Software Engineering' },
+  { path: '/security/', label: 'Security' },
+];
+
+async function metaDescription(page): Promise<string> {
+  return (
+    (await page.locator('head meta[name="description"]').getAttribute('content')) ?? ''
+  ).trim();
+}
+
+test.describe('@seo Core-page metadata is unique and non-generic @REQ-CONTENT-01', () => {
+  test('each indexable core page has a unique, non-generic meta description', async ({ page }) => {
+    const seen = new Map<string, string>(); // description -> first page that used it
+
+    for (const { path, label } of INDEXABLE_CORE_PAGES) {
+      const response = await page.goto(path);
+      expect(response?.ok(), `${path} should load`).toBe(true);
+
+      const description = await metaDescription(page);
+      expect(description.length, `${label} (${path}) must set a meta description`).toBeGreaterThan(0);
+      expect(
+        description,
+        `${label} (${path}) must not reuse the generic site description`,
+      ).not.toBe(GENERIC_SITE_DESCRIPTION);
+
+      const priorPage = seen.get(description);
+      expect(
+        priorPage,
+        `${label} (${path}) duplicates the description already used by ${priorPage}`,
+      ).toBeUndefined();
+      seen.set(description, label);
+    }
+  });
+
+  test('Search results page is marked noindex', async ({ page }) => {
+    const response = await page.goto('/search/');
+    expect(response?.ok(), '/search/ should load').toBe(true);
+
+    const robots = page.locator('head meta[name="robots"]');
+    await expect(robots, '/search/ should declare a robots meta').toHaveCount(1);
+    expect((await robots.getAttribute('content'))?.toLowerCase()).toContain('noindex');
+  });
+});


### PR DESCRIPTION
Closes #1055 (BLOG-004). Builds on #1054 (BLOG-003).

## Problem

About, Blog, the homepage, and the topic pages all reused the generic `site.description`, and Search competed for it too — so core pages had duplicate, non-descriptive search snippets.

## Changes

- **Unique descriptions** (grounded in copy already on each page / the author bio):
  - Home, About, Blog — new front-matter `description:`
  - Test Automation, Software Engineering, Security — lifted each page's existing in-body topic description into front matter
- **Search** (`search.html`) — `noindex: true` + `sitemap: false`. Search-results pages carry no SEO value and Google discourages indexing them.
- **`default.html`** — emits `<meta name="robots" content="noindex, nofollow">` when `page.noindex` is set (reusable flag).

All descriptions flow through jekyll-seo-tag (the single source from #1054), so every page still emits exactly one title/description/canonical.

### Owner decisions baked in
- **About stays expertise-framed**, not a consulting pitch — consulting positioning is deferred to Phase 2 (BLOG-006/007) when a services page exists.
- **Search is noindex** (vs. given metadata).

## Verification

- Production build: six **unique, non-generic** descriptions across Home/About/Blog/3 topics; Search is `noindex` and **absent from the sitemap**; `/`, `/about/`, `/blog/`, topic pages remain crawlable.
- New `seo-metadata-uniqueness.spec.ts` + existing `seo-metadata-dedupe.spec.ts` + `sitemap-exclusions.spec.ts`: **11/11 pass**.

## Scope

- 9 files; no protected files. Cross-cutting (content + layout + test), so no single agent persona owns the change — opened label-less so `check-pr-scope.sh` applies only the universal rules (protected files, 15-file cap), both of which pass. Same pattern as #1061.

## Acceptance criteria

- [x] Homepage metadata communicates audience and value offered.
- [x] About metadata describes Ouray's expertise (consulting framing deferred per owner).
- [x] Blog and topic pages describe their specific editorial coverage.
- [x] Search marked `noindex`.
- [x] Titles and descriptions concise and unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)