### PR TITLE
ci: anchor Rule 4 agent-label detection via has_label()

### DIFF
--- a/scripts/check-pr-scope.sh
+++ b/scripts/check-pr-scope.sh
@@ -152,13 +152,17 @@ else
   AGENT_LABEL=""
   FORBIDDEN_PATTERN=""
 
-  if echo "$PR_LABELS" | grep -q "agent:creative-director"; then
+  # Exact-match via has_label() (same anchoring as Rules 1–3). Agent labels are
+  # a fixed enum, but an unanchored grep would mis-route a confusable superset
+  # label (e.g. 'agent:qa-gatekeeper-trainee') into a forbidden-zone ruleset.
+  # Precedence (creative-director > qa-gatekeeper > editorial) is preserved.
+  if has_label "agent:creative-director"; then
     AGENT_LABEL="agent:creative-director"
     FORBIDDEN_PATTERN="^\.github/workflows/|^tests/|^scripts/|^_posts/|^_config\.yml$"
-  elif echo "$PR_LABELS" | grep -q "agent:qa-gatekeeper"; then
+  elif has_label "agent:qa-gatekeeper"; then
     AGENT_LABEL="agent:qa-gatekeeper"
     FORBIDDEN_PATTERN="^_sass/|^_layouts/|^_posts/|^_config\.yml$"
-  elif echo "$PR_LABELS" | grep -qE "agent:editorial-chief|agent:editorial-manager"; then
+  elif has_label "agent:editorial-chief" || has_label "agent:editorial-manager"; then
     AGENT_LABEL="agent:editorial-chief"
     FORBIDDEN_PATTERN="^_sass/|^_layouts/|^\.github/workflows/|^tests/|^scripts/|^_config\.yml$"
   fi

--- a/tests/scope-guard.sh
+++ b/tests/scope-guard.sh
@@ -15,6 +15,8 @@
 #   G. 21 files modified, PR_LABELS=bulk-content              → passes (canonical bypass preserved)
 #   H. .github/skills/... modified, PR_LABELS=governance-update → passes (canonical bypass preserved)
 #   I. Static-config invariant: PROTECTED_FILE_UPDATE_BYPASS ⊆ PROTECTED_FILES
+#   J. _sass/ modified, PR_LABELS=agent:qa-gatekeeper → fails (Rule 4 forbidden-zone; canonical agent label)
+#   K. _sass/ modified, PR_LABELS=agent:qa-gatekeeper-trainee (substring superset) → passes (Rule 4 anchored; not an agent label)
 #
 # Dependencies: bash, git. Same constraint as the script under test.
 
@@ -199,6 +201,25 @@ run_case "H: .github/skills/ modified, canonical governance-update label → Rul
   ".github/skills/scope-guard-test/SKILL.md" \
   "0" \
   "governance-update label present — skipping rule 3"
+
+# Rule 4 (agent-scope) anchoring. A _sass/ file is in the forbidden zone for
+# agent:qa-gatekeeper but trips no other rule, so it cleanly isolates Rule 4.
+# Case J pins the canonical exact label still routing into the forbidden-zone
+# ruleset; Case K pins the anchor — a confusable superset ('…-trainee') must
+# NOT be treated as the agent label (an unanchored `grep -q` would mis-route it
+# and wrongly enforce the forbidden zone). Migrated to has_label() alongside
+# Rules 1–3.
+run_case "J: _sass/ modified, canonical agent:qa-gatekeeper label → guard fails on agent-scope" \
+  "agent:qa-gatekeeper" \
+  "_sass/scope-guard-test.scss" \
+  "1" \
+  "VIOLATION [agent-scope/agent:qa-gatekeeper]"
+
+run_case "K: _sass/ modified, confusable agent:qa-gatekeeper-trainee substring label → not an agent label, guard passes" \
+  "agent:qa-gatekeeper-trainee" \
+  "_sass/scope-guard-test.scss" \
+  "0" \
+  "no agent label found in PR_LABELS"
 
 # Static-config invariant: every entry in PROTECTED_FILE_UPDATE_BYPASS must
 # also appear in PROTECTED_FILES. The two arrays live adjacent in the script


### PR DESCRIPTION
## What

Rule 4 (agent-scope) in `scripts/check-pr-scope.sh` was the **only** label check still using unanchored `grep -q`/`grep -qE`. Rules 1–3 migrated to the exact-match `has_label()` helper in #989; this brings Rule 4 in line.

Under the old match a confusable superset label (e.g. `agent:qa-gatekeeper-trainee`) would be treated as `agent:qa-gatekeeper` and mis-route a PR into a forbidden-zone ruleset. Low real-world risk (agent labels are a fixed enum) but an inconsistency worth closing.

## Changes

- `scripts/check-pr-scope.sh` — three Rule 4 branches now use `has_label()`. Precedence (creative-director > qa-gatekeeper > editorial) and the editorial-chief/manager OR are preserved.
- `tests/scope-guard.sh` — new fixture cases:
  - **Case J** — canonical `agent:qa-gatekeeper` on a `_sass/` file still trips agent-scope (exit 1).
  - **Case K** — confusable `agent:qa-gatekeeper-trainee` is **not** treated as an agent label; guard passes (exit 0). Under the old unanchored grep this case would fail — verified the regression bites.

A `_sass/` file is in the forbidden zone for `agent:qa-gatekeeper` but trips no other rule, so it cleanly isolates Rule 4.

## Verification

`bash tests/scope-guard.sh` → **11 passed, 0 failed** (Cases A–K + static-config invariant).

Closes backlog **P1b** (agent-evals & governance gap-closure epic). `governance-update` label applied per the epic's routing intent — note this PR touches only `scripts/`+`tests/`, not the `.github/skills/` governance surface, so the label is signalling, not a Rule 3 bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)