### PR TITLE
docs: reconcile backlog — P1b shipped, Active queue drained

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -33,11 +33,11 @@ duplicate the queue.
 > P1 was already fixed in #989 (verified; reduced to a comment cleanup, #1045),
 > P2 shipped in #1049, P3 in #1050. Optional polish **P4** (risk-tier branch-protection
 > policy) and **P5** (memory-guard rephrasing-hardening) were **cut** as low-value —
-> match complexity to scale. The lone survivor is the standalone low-priority item below.
+> match complexity to scale. The lone survivor (Rule 4 anchor) shipped in #1064.
 
 | Pri | Task | Scope / label | Status | Ref |
 |----|------|---------------|--------|-----|
-| Low | **Anchor Rule 4 agent-label detection.** `check-pr-scope.sh` lines ~155–161 still use unanchored `grep -q`/`grep -qE` for agent-label detection — the only spot not on `has_label()`. Low risk (agent labels are a fixed enum) but inconsistent. | `agent:qa-gatekeeper`, `governance-update` | Not started | was epic P1b |
+| _(none)_ | Active queue drained. | | | |
 
 ---
 
@@ -53,6 +53,7 @@ duplicate the queue.
 
 | Task | Resolution | Date |
 |------|------------|------|
+| Anchor Rule 4 agent-label detection (epic P1b) | [#1064](https://github.com/oviney/blog/pull/1064) merged — three Rule 4 branches moved to `has_label()`; scope-guard Cases J/K pin canonical + substring-superset behaviour | 2026-06-14 |
 | Post editorial-quality promoted to a CI merge gate (epic P3) | [#1050](https://github.com/oviney/blog/pull/1050) merged — errors block, warnings advisory; 24/24 posts clean at gate-on | 2026-06-13 |
 | Agent-quality rubric enforced in agent-eval workflow (epic P2) | [#1049](https://github.com/oviney/blog/pull/1049) merged — scorecard comment + hard gate on scope/coverage/churn | 2026-06-13 |
 | Scope-guard Case E/F stale-comment cleanup (epic P1) | [#1045](https://github.com/oviney/blog/pull/1045) merged — bug already fixed in #989; comments were misleading | 2026-06-13 |


### PR DESCRIPTION
Follows the merge of #1064 (Rule 4 agent-label anchoring), the lone surviving item of the agent-evals & governance gap-closure epic.

- Moves the Rule 4 anchor task from **Active** to **Recently shipped** (#1064, 2026-06-14).
- Marks the Active queue **drained** — the epic is fully closed (P1 #1045, P2 #1049, P3 #1050, P1b #1064; P4/P5 cut as low-value).

Hand-maintained docs only; no code or governance surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)