### PR TITLE
fix(GH-1068): restore aspect ratio for in-content chart images [BLOG-017b]

### DIFF
--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -594,6 +594,7 @@ blockquote {
 
   img[src*="/charts/"] {
     max-width: 500px !important; // Override any other styles
+    height: auto; // Preserve aspect ratio against intrinsic width/height attrs (BLOG-017b)
     margin: $spacing-md auto; // Center with reduced margins
     border-radius: $radius-sm;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Hotfix for a live visual regression introduced by #1069.

## Problem (live on production)

#1069 injected intrinsic `width`/`height` into in-content chart `<img>` tags. But the `.article-content img[src*="/charts/"]` selector had no paired `height: auto`, so the literal `height` attribute was used as the rendered height — **charts rendered ~5× too tall** (a 2400×1650 chart displayed at 500×1650 instead of 500×344, overflowing mobile viewports).

## Fix

Add `height: auto` to that selector so the aspect ratio from the width/height attributes drives the height — matching what BLOG-017 already does for hero/card images. The attributes still reserve layout space for CLS; the image now scales correctly.

```scss
.article-content img[src*="/charts/"] {
  max-width: 500px !important;
+ height: auto; // preserve aspect ratio against intrinsic width/height attrs
  ...
}
```

## Verification (real browser, headless Chromium)

- Rendered chart height **1650→344px** (PNG), **400→250px** (SVG) — correct aspect ratio restored.
- `bundle exec jekyll build` passes; only `_sass/economist-theme.scss` touched (1 line).

## Note for reviewers

Real-browser CLS measurement showed the in-content charts were **never the CLS source** — article-page CLS (0.25 on mobile, 0.01 on desktop) comes from a separate **mobile-nav reflow**, not images. That's a pre-existing issue to be filed separately; this PR only fixes the stretch regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)