### PR TITLE
fix(GH-1071): eliminate mobile-nav reflow CLS by marking JS active pre-paint

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,70 +1,60 @@
-# SPEC — GH-1075: Restore the green `main` Quality Tests gate (Security Audit)
+# SPEC — GH-1071: Eliminate mobile-nav reflow CLS on article pages
 
-**Stream:** CI / repo health · **Priority:** P0 (broken `main` gate) · **Scope:** XS
-**Date:** 2026-06-23 · **Label:** `agent:qa-gatekeeper` · **Issue:** #1075
+**Stream:** Core Web Vitals / perf · **Priority:** P1 (POOR CLS on mobile) · **Scope:** XS
+**Date:** 2026-06-25 · **Label:** `agent:qa-gatekeeper`, `performance` · **Issue:** #1071
 
 ---
 
 ## 1. Objective
 
-The scheduled **Quality Tests (Visual, Accessibility, Performance, Security)**
-workflow (`test-quality.yml`) has failed on `main` every day since ~2026-06-16
-(#1075, `needs-human-review`). The only failing job is **🔒 Security Audit**,
-whose step `npm run test:security` (`npm audit --audit-level=moderate`) now exits
-1: **22 advisories (20 moderate, 2 high)**.
-
-Restore a green `main` gate **without weakening the documented policy**
-(`SECURITY.md`: "builds fail on moderate or higher") and **without breaking the
-Lighthouse CI tooling**.
+Article pages shifted **CLS 0.252 (POOR)** on mobile (390px), 0.143 on tablet,
+0.011 on desktop. A single layout shift fires ~200ms into load: `main-content`
+moves up ~245px. The fix must bring mobile article CLS to **GOOD (≤ 0.1)** with
+no loss of navigation function and no desktop regression.
 
 ## 2. Root cause
 
-`"dependencies": {}` is empty — every advisory is in **dev-only CI tooling**, none
-ships to the static Jekyll site:
+`_layouts/default.html` renders `<nav class="site-nav">` desktop-first
+(`display:flex`, full height on every viewport). The mobile collapse rule
+`.js-nav-enabled .site-nav { display:none }` only activates once an inline script
+at the **bottom of `<body>`** adds `js-nav-enabled`. That runs *after* first
+paint, so on mobile the nav paints at ~245px and then collapses, reflowing
+`main` upward — the entire CLS. (Confirmed not image-related: BLOG-017/017b hero
++ chart dims are correct.)
 
-- **2 high** — `undici`, `ws` (transitive dev-deps). Cleared by the lockfile
-  update; `ws` pinned via override to `^8.21.0` (patched line).
-- **20 moderate** — `js-yaml` (under `@lhci/utils`) and ~17 `@opentelemetry/*` +
-  `@sentry/node` advisories, all chaining from `lighthouse → @sentry/node`.
-  `@lhci/cli@0.15.1` is already latest and bundles `lighthouse@12.6.1 →
-  @sentry/node@7.120.4`; npm's only offered fix is a `--force` **downgrade to
-  `@lhci/cli@0.3.5`** (a 12-major regression — rejected).
+## 3. Approach
 
-## 3. Approach — precedent-aligned `overrides`
+Set the JS-active marker **before first paint** so the mobile nav is collapsed
+from the very first layout — no render-then-collapse window:
 
-Follow the existing `package.json` `overrides` pattern (lodash, tmp, basic-ftp,
-ws, qs, puppeteer) endorsed by `tasks/lessons.md` L3 for transitive CVEs. Force
-the patched lines:
+1. Add `<script>document.documentElement.classList.add('js-nav-enabled')</script>`
+   in `<head>` (runs before `<body>` is parsed/painted).
+2. Move the open/close toggle from `document.body` to `document.documentElement`
+   so the existing `.js-nav-enabled.nav-open .site-nav` selector keeps matching
+   (all nav selectors are element-agnostic; `<html>` is an ancestor of nav/toggle).
+3. Remove the now-redundant body-tail `classList.add('js-nav-enabled')`.
 
-- `js-yaml` → `^4.2.0` (minimal patched bump; our `lighthouserc.json` is JSON, so
-  `@lhci/utils`' removed-in-4.x `safeLoad` branch is never executed).
-- `@sentry/node` → `^10.54.0` (patches the sentry advisory and cascades the whole
-  `@opentelemetry/*` instrumentation cluster to patched versions).
-- `ws` → `^8.21.0` (tighten from `^8.20.1`, which permitted the vulnerable
-  `8.20.1`, so the high advisory cannot regress on a future install).
-
-No threshold change, no new tooling, no `@lhci/cli` downgrade. Only
-`package.json` + `package-lock.json` change.
+Progressive enhancement preserved: without JS, no `js-nav-enabled` class is set,
+so the nav stays visible and reachable.
 
 ## 4. Acceptance criteria
 
-- [x] **AC-1** `npm run test:security` (`npm audit --audit-level=moderate`) exits 0
-      — `found 0 vulnerabilities`.
-- [x] **AC-2** No threshold weakening: `test:security` still runs
-      `--audit-level=moderate` (SECURITY.md policy intact).
-- [x] **AC-3** Lighthouse CI tooling still loads: `npx lhci --version` and
-      `npx lhci healthcheck` pass; `lighthouse` and `@lhci/utils` `require` cleanly.
-- [x] **AC-4** Resolved patched versions: `@sentry/node@10.x`, `js-yaml@4.2.0`,
-      `ws@8.21.0`.
+- [x] **AC-1** Mobile (390px) article CLS ≤ 0.1. Measured **0.2521 → 0.0000**
+      (POOR → GOOD) on the same real-browser harness that reproduces the baseline
+      (`isMobile:false`, width 390, `layout-shift` PerformanceObserver).
+- [x] **AC-2** No desktop regression: desktop CLS 0.0112 (unchanged, GOOD).
+- [x] **AC-3** Hamburger still works: nav hidden initially, opens on click
+      (`aria-expanded=true`), closes on toggle/link — verified in real browser.
+- [x] **AC-4** `bundle exec jekyll build` exits 0; head script present in output,
+      body no longer adds the class.
 - [x] **AC-5** No protected file touched (`_config.yml`, `Gemfile`,
       `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
-- [x] **AC-6** Change is atomic: only `package.json` + `package-lock.json`.
 
 ## 5. Commands
 
 ```bash
-npm install                                   # regenerate lockfile with overrides
-npm run test:security                         # AC-1/AC-2 — expect exit 0
-npx lhci healthcheck                          # AC-3 — expect "Healthcheck passed!"
-npm ls @sentry/node js-yaml ws                # AC-4
+bundle exec jekyll build                                   # AC-4
+# Real-browser before/after (reproducing harness): isMobile:false, 390px,
+# PerformanceObserver{type:'layout-shift',buffered:true}, sum !hadRecentInput
+#   BEFORE: Mobile-390 CLS=0.2521 POOR   AFTER: Mobile-390 CLS=0.0000 GOOD
 ```

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,15 @@
   {% assign display_site_title = site.display_title | default: plain_site_title %}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {%- comment -%}
+    Mark JS as active on the document element BEFORE first paint so the mobile
+    nav is collapsed behind the hamburger from the very first layout. Setting
+    this later (e.g. in a body-tail script) lets `.site-nav` render at full
+    height and then collapse, reflowing `main` upward — a ~0.25 CLS on mobile
+    article pages (GH-1071). The matching `.nav-open` toggle also targets the
+    document element so the `.js-nav-enabled.nav-open` selector stays intact.
+  {%- endcomment -%}
+  <script>document.documentElement.classList.add('js-nav-enabled');</script>
   {%- if page.noindex -%}<meta name="robots" content="noindex, nofollow">{%- endif -%}
   {%- comment -%}
     Title, meta description, and canonical are emitted by jekyll-seo-tag (the
@@ -118,20 +127,24 @@
   <!-- Hamburger navigation toggle -->
   <script>
     (function () {
-      // Progressive enhancement: mark body so nav is hidden behind hamburger only when JS is active
-      document.body.classList.add('js-nav-enabled');
+      // Progressive enhancement: `js-nav-enabled` is added to the document
+      // element in <head> before first paint (see GH-1071) so the mobile nav is
+      // collapsed from the first layout with no reflow. The open/close state is
+      // toggled on the same element to keep the `.js-nav-enabled.nav-open`
+      // selector matching.
+      var root = document.documentElement;
 
       var toggle = document.querySelector('.nav-toggle');
       var nav = document.getElementById('site-navigation');
       if (toggle && nav) {
         toggle.addEventListener('click', function () {
-          var isOpen = document.body.classList.toggle('nav-open');
+          var isOpen = root.classList.toggle('nav-open');
           toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
           toggle.setAttribute('aria-label', isOpen ? 'Close navigation menu' : 'Open navigation menu');
         });
         nav.querySelectorAll('a').forEach(function (link) {
           link.addEventListener('click', function () {
-            document.body.classList.remove('nav-open');
+            root.classList.remove('nav-open');
             toggle.setAttribute('aria-expanded', 'false');
             toggle.setAttribute('aria-label', 'Open navigation menu');
           });

--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -1338,9 +1338,10 @@ table {
     display: flex;
   }
 
-  // Hide nav by default on mobile; shown when .nav-open is set on body.
-  // Only applies when JS is active (.js-nav-enabled) — progressive enhancement:
-  // without JS the nav remains visible so users can always reach navigation.
+  // Hide nav by default on mobile; shown when .nav-open is set on the document
+  // element. Only applies when JS is active (.js-nav-enabled, set in <head>
+  // before first paint — GH-1071) — progressive enhancement: without JS the nav
+  // remains visible so users can always reach navigation.
   .js-nav-enabled .site-nav {
     display: none;
     border-bottom: 1px solid $border-color;


### PR DESCRIPTION
Closes #1071.

## Problem

Real-browser measurement on `/2025/12/31/testing-times/` showed mobile article **CLS 0.252 (POOR)** — a single layout shift ~200ms into load where `main-content` moves up ~245px.

## Root cause

`_layouts/default.html` renders `<nav class="site-nav">` desktop-first (`display:flex`, full height on every viewport). The mobile collapse rule `.js-nav-enabled .site-nav { display:none }` only activates once an inline script at the **bottom of `<body>`** adds `js-nav-enabled` — which runs **after first paint**. So on mobile the nav paints at ~245px, then collapses, reflowing `main` upward. (Confirmed *not* image-related — BLOG-017/017b dims are correct.)

## Fix

Set the JS-active marker **before first paint**:

1. `<script>document.documentElement.classList.add('js-nav-enabled')</script>` in `<head>` — applies the mobile `display:none` from the first layout, so there's no render-then-collapse window.
2. Toggle `nav-open` on the document element (not `body`) so the existing `.js-nav-enabled.nav-open .site-nav` selector keeps matching. All nav selectors are element-agnostic and `<html>` is an ancestor of the nav/toggle, so no CSS selector changes are needed.
3. Drop the now-redundant body-tail `classList.add`.

Progressive enhancement preserved: without JS, no class is set → nav stays visible.

## Verification (real browser)

Harness reproduces the production baseline (`isMobile:false`, 390px, `PerformanceObserver{type:'layout-shift',buffered:true}`, sum `!hadRecentInput`):

| Viewport | Before | After |
|---|---|---|
| **Mobile 390** | **0.2521 POOR** (shift @ ~281ms) | **0.0000 GOOD** |
| Desktop 1280 | 0.0112 GOOD | 0.0112 GOOD (unchanged) |

Hamburger verified: nav hidden initially, opens on click (`aria-expanded=true`), closes on toggle/link. `bundle exec jekyll build` exits 0; head script present in output, body no longer adds the class. 2 source files + rolling SPEC; no protected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)