### PR TITLE
feat(GH-1082): add URL slug policy + build-time truncation gate [BLOG-024]

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,60 +1,54 @@
-# SPEC — GH-1071: Eliminate mobile-nav reflow CLS on article pages
+# SPEC — BLOG-024: Durable URL slug policy + truncation gate
 
-**Stream:** Core Web Vitals / perf · **Priority:** P1 (POOR CLS on mobile) · **Scope:** XS
-**Date:** 2026-06-25 · **Label:** `agent:qa-gatekeeper`, `performance` · **Issue:** #1071
+**Stream:** GROWTH_DESIGN_BACKLOG · **Priority:** P2 · **Scope:** S · **Dependencies:** None
+**Date:** 2026-06-25 · **Label:** `agent:qa-gatekeeper`
 
 ---
 
 ## 1. Objective
 
-Article pages shifted **CLS 0.252 (POOR)** on mobile (390px), 0.143 on tablet,
-0.011 on desktop. A single layout shift fires ~200ms into load: `main-content`
-moves up ~245px. The fix must bring mobile article CLS to **GOOD (≤ 0.1)** with
-no loss of navigation function and no desktop regression.
+Some early article slugs were truncated mid-word by an upstream tool (e.g.
+`…-and-sustai`, `…-maintenance-savi`, `…-industrial-revolut`). Those URLs are
+indexed and immutable. Establish a documented slug convention and a build-time
+check that **detects accidental truncation in new posts** without changing any
+existing URL.
 
-## 2. Root cause
+## 2. Approach
 
-`_layouts/default.html` renders `<nav class="site-nav">` desktop-first
-(`display:flex`, full height on every viewport). The mobile collapse rule
-`.js-nav-enabled .site-nav { display:none }` only activates once an inline script
-at the **bottom of `<body>`** adds `js-nav-enabled`. That runs *after* first
-paint, so on mobile the nav paints at ~245px and then collapses, reflowing
-`main` upward — the entire CLS. (Confirmed not image-related: BLOG-017/017b hero
-+ chart dims are correct.)
+The site permalink is `/:year/:month/:day/:title/`; the slug is the post filename
+minus the `YYYY-MM-DD-` prefix and extension. `jekyll-redirect-from` is absent and
+`Gemfile` is protected, so existing slugs cannot be renamed — they are
+grandfathered.
 
-## 3. Approach
+1. Document the policy in `docs/URL_SLUG_POLICY.md`: lowercase-hyphen, complete
+   words, target ≤50 / soft cap 55 / hard cap 60 chars, no double hyphens,
+   existing-URLs-immutable rule.
+2. Extend `scripts/validate-post-quality.sh` (which already has a 0/1/2
+   ERROR/WARNING model wired into CI) with a slug check:
+   - **ERROR** if slug length > 60 (hard cap — no existing post exceeds 60, so
+     CI is not retroactively broken; new over-long slugs are blocked).
+   - **WARNING** if slug length ≥ 55 (truncation-prone) or contains `--`.
+3. No protected files; no existing post renamed; warnings are non-blocking
+   (both workflows gate only on exit 1).
 
-Set the JS-active marker **before first paint** so the mobile nav is collapsed
-from the very first layout — no render-then-collapse window:
+## 3. Acceptance criteria
 
-1. Add `<script>document.documentElement.classList.add('js-nav-enabled')</script>`
-   in `<head>` (runs before `<body>` is parsed/painted).
-2. Move the open/close toggle from `document.body` to `document.documentElement`
-   so the existing `.js-nav-enabled.nav-open .site-nav` selector keeps matching
-   (all nav selectors are element-agnostic; `<html>` is an ancestor of nav/toggle).
-3. Remove the now-redundant body-tail `classList.add('js-nav-enabled')`.
-
-Progressive enhancement preserved: without JS, no `js-nav-enabled` class is set,
-so the nav stays visible and reachable.
-
-## 4. Acceptance criteria
-
-- [x] **AC-1** Mobile (390px) article CLS ≤ 0.1. Measured **0.2521 → 0.0000**
-      (POOR → GOOD) on the same real-browser harness that reproduces the baseline
-      (`isMobile:false`, width 390, `layout-shift` PerformanceObserver).
-- [x] **AC-2** No desktop regression: desktop CLS 0.0112 (unchanged, GOOD).
-- [x] **AC-3** Hamburger still works: nav hidden initially, opens on click
-      (`aria-expanded=true`), closes on toggle/link — verified in real browser.
-- [x] **AC-4** `bundle exec jekyll build` exits 0; head script present in output,
-      body no longer adds the class.
-- [x] **AC-5** No protected file touched (`_config.yml`, `Gemfile`,
+- [x] **AC-1** Maximum practical slug length + naming convention documented
+      (`docs/URL_SLUG_POLICY.md`).
+- [x] **AC-2** Guidance present so new posts use concise, complete,
+      keyword-relevant slugs.
+- [x] **AC-3** Existing URLs unchanged (no `_posts/` renames; legacy slugs
+      grandfathered as non-blocking warnings).
+- [x] **AC-4** The publishing workflow detects accidental truncation: slug > 60
+      → build error; ≥ 55 or `--` → advisory warning.
+- [x] **AC-5** Build-time validation added and CI-wired (the gate already runs in
+      `test-build.yml` and `test-quality.yml`); verified exit 2 on current posts
+      (0 errors, 5 warnings) so `main` CI stays green.
+- [x] **AC-6** No protected file touched (`_config.yml`, `Gemfile`,
       `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
 
-## 5. Commands
+## 4. Commands
 
 ```bash
-bundle exec jekyll build                                   # AC-4
-# Real-browser before/after (reproducing harness): isMobile:false, 390px,
-# PerformanceObserver{type:'layout-shift',buffered:true}, sum !hadRecentInput
-#   BEFORE: Mobile-390 CLS=0.2521 POOR   AFTER: Mobile-390 CLS=0.0000 GOOD
+bash scripts/validate-post-quality.sh    # AC-4/AC-5 — expect exit 2 (warnings only)
 ```

--- a/docs/GROWTH_DESIGN_BACKLOG.md
+++ b/docs/GROWTH_DESIGN_BACKLOG.md
@@ -714,12 +714,18 @@ professional Person profile.
 Some article URLs contain awkward or truncated slugs. Existing indexed URLs
 should remain stable, while future URLs should be concise and intentional.
 
+**Status (2026-06-25): Shipped.** Policy documented in
+[`docs/URL_SLUG_POLICY.md`](URL_SLUG_POLICY.md); `scripts/validate-post-quality.sh`
+now errors on slugs > 60 chars and warns at ≥ 55 chars or on double hyphens.
+Existing slugs are grandfathered (no `jekyll-redirect-from`; `Gemfile` protected),
+so no live URL changes.
+
 **Acceptance criteria:**
 
-- [ ] Document a maximum practical slug length and naming convention.
-- [ ] New posts use concise, complete, keyword-relevant slugs.
-- [ ] Existing URLs are not changed without permanent redirects.
-- [ ] The publishing workflow detects accidental truncation.
+- [x] Document a maximum practical slug length and naming convention.
+- [x] New posts use concise, complete, keyword-relevant slugs.
+- [x] Existing URLs are not changed without permanent redirects.
+- [x] The publishing workflow detects accidental truncation.
 
 **Verification:**
 

--- a/docs/URL_SLUG_POLICY.md
+++ b/docs/URL_SLUG_POLICY.md
@@ -1,0 +1,80 @@
+# URL Slug Policy
+
+**Status:** Active · **Owner:** editorial + qa-gatekeeper · **Tracks:** BLOG-024
+
+This document defines the naming convention for viney.ca article URLs and the
+build-time check that enforces it.
+
+## Why this exists
+
+Article URLs are derived from the post filename. The site permalink is:
+
+```yaml
+# _config.yml
+permalink: /:year/:month/:day/:title/
+```
+
+so a file `_posts/2026-04-05-ai-quality-testing-automation.md` publishes at
+`/2026/04/05/ai-quality-testing-automation/`. The **slug** is the filename with
+the leading `YYYY-MM-DD-` date prefix and the `.md`/`.markdown` extension
+removed.
+
+Several early posts were published with slugs that an upstream tool **truncated
+mid-word** at a fixed length (e.g. `…-and-sustai`, `…-maintenance-savi`,
+`…-industrial-revolut`). Those URLs are already indexed by search engines, so we
+cannot rename them — but we can stop new ones from being created.
+
+## Convention
+
+For every **new** post:
+
+1. **Lowercase, hyphen-separated** words only (`a-z`, `0-9`, `-`). This matches
+   Jekyll's slug normalisation.
+2. **Complete words** — never cut a word mid-way. A slug must read as a finished
+   phrase, not a truncated title.
+3. **Length:** target **≤ 50 characters**; **55 is a soft cap** (warning); **60
+   is the hard cap** (build error). Shorter, keyword-relevant slugs are better
+   for sharing and SEO.
+4. **No double hyphens** (`--`). Collapse to a single hyphen between words.
+5. **Drop filler** — omit stop words (`the`, `a`, `of`, `and`, `to`) where the
+   slug still reads clearly. Keep the keywords a reader would search for.
+
+Examples:
+
+| Good | Avoid |
+|------|-------|
+| `ai-quality-testing-automation` | `the-practical-applications-of-ai-in-software-developm` (truncated) |
+| `test-coverage-productivity-paradox` | `the-productivity-paradox-of-test-coverage-metrics-and-more` (>60) |
+
+## Existing URLs are immutable
+
+`jekyll-redirect-from` is **not** installed and `Gemfile` is a protected file, so
+there is no redirect mechanism. Therefore:
+
+- **Never rename an existing post's slug.** Doing so breaks the live URL and any
+  inbound links with no redirect to catch them.
+- The legacy truncated slugs are **grandfathered**. They surface as non-blocking
+  warnings (see below) to document the debt, not to demand a fix.
+- If a URL migration is ever genuinely required, it must be an owner-approved
+  change that first adds `jekyll-redirect-from` (a `Gemfile` edit) and backfills
+  `redirect_from:` front matter on the affected post.
+
+## Enforcement
+
+`scripts/validate-post-quality.sh` checks every post's slug:
+
+| Condition | Severity | CI effect |
+|-----------|----------|-----------|
+| slug length > 60 chars | **ERROR** (exit 1) | **blocks merge** |
+| slug length ≥ 55 chars | warning (exit 2) | advisory, non-blocking |
+| slug contains `--` | warning (exit 2) | advisory, non-blocking |
+
+The hard cap is set at 60 so no existing URL is retroactively invalidated (the
+longest current slug is exactly 60). New posts that would introduce an over-long
+or truncation-prone slug are caught before they ship.
+
+Run locally:
+
+```bash
+bash scripts/validate-post-quality.sh
+```

--- a/scripts/validate-post-quality.sh
+++ b/scripts/validate-post-quality.sh
@@ -303,6 +303,34 @@ for post in $POSTS; do
     fi
   fi
 
+  # ------------------------------------------------------------------
+  # 15. URL slug policy — length + truncation signals
+  #     [ERROR > 60 chars, WARNING >= 55 chars or double-hyphen]
+  #     The slug is the post filename minus the YYYY-MM-DD- date prefix and
+  #     extension (permalink is /:year/:month/:day/:title/). Existing indexed
+  #     URLs are immutable — there is no jekyll-redirect-from — so this gate
+  #     guards NEW slugs against the truncation that produced the legacy
+  #     60-char slugs. See docs/URL_SLUG_POLICY.md.
+  # ------------------------------------------------------------------
+  slug="$(basename "$post")"
+  slug="${slug%.*}"                                              # strip extension
+  slug="${slug#[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-}"     # strip date prefix
+  slug_len=${#slug}
+  if [[ $slug_len -gt 60 ]]; then
+    echo "❌  $rel — slug is ${slug_len} chars (hard cap 60); shorten to a concise, complete phrase (docs/URL_SLUG_POLICY.md)"
+    ERRORS=$((ERRORS + 1))
+    post_errors=$((post_errors + 1))
+  elif [[ $slug_len -ge 55 ]]; then
+    echo "⚠️   $rel — slug is ${slug_len} chars (truncation-prone, soft cap 55); verify it is a complete phrase, not cut mid-word"
+    WARNINGS=$((WARNINGS + 1))
+    post_warnings=$((post_warnings + 1))
+  fi
+  if [[ "$slug" == *--* ]]; then
+    echo "⚠️   $rel — slug contains a double hyphen ('--'); use single hyphens between words"
+    WARNINGS=$((WARNINGS + 1))
+    post_warnings=$((post_warnings + 1))
+  fi
+
   # Print pass marker for clean posts
   if [[ $post_errors -eq 0 && $post_warnings -eq 0 ]]; then
     echo "✅  $rel"


### PR DESCRIPTION
Closes #1082. Implements **BLOG-024** (durable URL slug policy).

## Problem

Several early article slugs were truncated mid-word by an upstream tool — e.g. `…-test-automation--balancing-speed-and-sustai`, `…-on-maintenance-savi`, `…-the-new-industrial-revolut`. Those URLs are indexed and must stay stable, but new posts shouldn't repeat the defect.

## Fix

**1. Policy doc — `docs/URL_SLUG_POLICY.md`** (AC-1/AC-2/AC-3): lowercase-hyphen, complete words, target ≤50 / soft cap 55 / hard cap 60 chars, no double hyphens, and an explicit *existing-URLs-are-immutable* rule (no `jekyll-redirect-from`; `Gemfile` is protected).

**2. Build-time gate — `scripts/validate-post-quality.sh`** (AC-4/AC-5): the slug is derived from the filename (`permalink: /:year/:month/:day/:title/`).

| Condition | Severity | CI effect |
|---|---|---|
| slug > 60 chars | **ERROR** (exit 1) | blocks merge |
| slug ≥ 55 chars | warning (exit 2) | advisory |
| slug contains `--` | warning (exit 2) | advisory |

The hard cap is **60** so no existing URL is retroactively invalidated (the longest current slug is exactly 60). Legacy truncated slugs are **grandfathered** — they surface as non-blocking warnings to document the debt, not demand a rename.

## Verification

```
$ bash scripts/validate-post-quality.sh
  Errors:   0
  Warnings: 5     # 3 legacy 60-char slugs + 2 double-hyphens
RESULT: PASSED with 5 warning(s) (non-blocking).   # exit 2
```

Both `test-build.yml` and `test-quality.yml` gate only on exit 1, so `main` CI stays green. No protected file touched; no `_posts/` renamed. Scope: `scripts/` + `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)