### PR TITLE
feat(GH-1084): load web fonts via document-level links, not CSS @import [BLOG-019]

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,54 +1,49 @@
-# SPEC — BLOG-024: Durable URL slug policy + truncation gate
+# SPEC — BLOG-019: Replace render-blocking Google Fonts CSS `@import`
 
 **Stream:** GROWTH_DESIGN_BACKLOG · **Priority:** P2 · **Scope:** S · **Dependencies:** None
-**Date:** 2026-06-25 · **Label:** `agent:qa-gatekeeper`
+**Date:** 2026-06-26 · **Label:** `agent:creative-director` · **Issue:** #1084
 
 ---
 
 ## 1. Objective
 
-Some early article slugs were truncated mid-word by an upstream tool (e.g.
-`…-and-sustai`, `…-maintenance-savi`, `…-industrial-revolut`). Those URLs are
-indexed and immutable. Establish a documented slug convention and a build-time
-check that **detects accidental truncation in new posts** without changing any
-existing URL.
+`assets/css/styles.scss` discovers the web fonts (Merriweather + Inter) via a CSS
+`@import`, so the browser cannot fetch them until `styles.css` has downloaded and
+parsed — font discovery is serialised behind the stylesheet, delaying text
+rendering. Move discovery to the document level with no typography change.
 
 ## 2. Approach
 
-The site permalink is `/:year/:month/:day/:title/`; the slug is the post filename
-minus the `YYYY-MM-DD-` prefix and extension. `jekyll-redirect-from` is absent and
-`Gemfile` is protected, so existing slugs cannot be renamed — they are
-grandfathered.
-
-1. Document the policy in `docs/URL_SLUG_POLICY.md`: lowercase-hyphen, complete
-   words, target ≤50 / soft cap 55 / hard cap 60 chars, no double hyphens,
-   existing-URLs-immutable rule.
-2. Extend `scripts/validate-post-quality.sh` (which already has a 0/1/2
-   ERROR/WARNING model wired into CI) with a slug check:
-   - **ERROR** if slug length > 60 (hard cap — no existing post exceeds 60, so
-     CI is not retroactively broken; new over-long slugs are blocked).
-   - **WARNING** if slug length ≥ 55 (truncation-prone) or contains `--`.
-3. No protected files; no existing post renamed; warnings are non-blocking
-   (both workflows gate only on exit 1).
+1. Remove the `@import url('…fonts.googleapis.com/css2?…')` from
+   `assets/css/styles.scss`.
+2. In `_layouts/default.html` `<head>`, before `styles.css`, add:
+   - `<link rel="preconnect" href="https://fonts.googleapis.com">`
+   - `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
+   - `<link rel="stylesheet" href="…css2?family=Merriweather:…&family=Inter:…&display=swap">`
+3. Same families/weights as before → no typography change (BLOG-015 not a
+   dependency). `$font-serif`/`$font-sans` fallback stacks are unchanged.
+4. Individual font files are intentionally not preloaded (Google rotates its
+   versioned gstatic URLs; preconnect is the safe warm-up). Full self-hosting is
+   noted as a future privacy enhancement.
 
 ## 3. Acceptance criteria
 
-- [x] **AC-1** Maximum practical slug length + naming convention documented
-      (`docs/URL_SLUG_POLICY.md`).
-- [x] **AC-2** Guidance present so new posts use concise, complete,
-      keyword-relevant slugs.
-- [x] **AC-3** Existing URLs unchanged (no `_posts/` renames; legacy slugs
-      grandfathered as non-blocking warnings).
-- [x] **AC-4** The publishing workflow detects accidental truncation: slug > 60
-      → build error; ≥ 55 or `--` → advisory warning.
-- [x] **AC-5** Build-time validation added and CI-wired (the gate already runs in
-      `test-build.yml` and `test-quality.yml`); verified exit 2 on current posts
-      (0 errors, 5 warnings) so `main` CI stays green.
-- [x] **AC-6** No protected file touched (`_config.yml`, `Gemfile`,
-      `Gemfile.lock`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`).
+- [x] **AC-1** Font `@import` removed from the compiled stylesheet
+      (`_site/assets/css/styles.css` has no `@import`/`fonts.googleapis`).
+- [x] **AC-2** Fonts loaded via optimised document-level links (preconnect +
+      `<link>` in `<head>`, ahead of `styles.css`).
+- [x] **AC-3** `font-display: swap` retained (readable text during load).
+- [x] **AC-4** No over-preloading: preconnect only; no brittle per-file preload.
+- [x] **AC-5** Fallback stacks retained ($font-serif / $font-sans unchanged);
+      computed fonts still resolve to the Merriweather/Inter stacks; all six
+      weights load; CLS = 0 (no swap regression).
+- [x] **AC-6** No protected file touched; `bundle exec jekyll build` exits 0.
 
 ## 4. Commands
 
 ```bash
-bash scripts/validate-post-quality.sh    # AC-4/AC-5 — expect exit 2 (warnings only)
+bundle exec jekyll build
+grep -c 'fonts.googleapis\|@import' _site/assets/css/styles.css   # expect 0
+# Real-browser: document.fonts shows Inter 400/600/700 + Merriweather 400/400i/700
+# loaded; computed font-family = Merriweather stack; CLS = 0.
 ```

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,20 @@
     page's SEO metadata (GH-1054). Per-page titles/descriptions come from front
     matter and are rendered by seo-tag.
   {%- endcomment -%}
+  {%- comment -%}
+    Web fonts loaded at the document level (not via a CSS @import inside
+    styles.css) so the browser discovers them at first byte and fetches them in
+    parallel with the stylesheet — a CSS @import serialises font discovery behind
+    styles.css and delays text rendering (BLOG-019 / GH-1084). preconnect warms
+    the gstatic connection; display=swap keeps text readable during load; the
+    $font-serif/$font-sans stacks provide the fallbacks. Individual font files
+    are intentionally not preloaded — Google rotates their versioned gstatic
+    URLs, so a hardcoded preload would rot; preconnect is the safe optimisation.
+  {%- endcomment -%}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;1,400&family=Inter:wght@400;500;600;700&display=swap">
+
   <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
 
   <!-- Favicon -->

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -4,5 +4,8 @@
 // The Economist Theme
 @use 'economist-theme';
 
-// Google Fonts - The Economist uses serif for body (CSS @import, not Sass @import)
-@import url('https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;1,400&family=Inter:wght@400;500;600;700&display=swap');
+// Web fonts (Merriweather + Inter) are loaded via document-level <link> tags in
+// _layouts/default.html <head>, with preconnect, so the browser discovers them
+// at first byte instead of waiting for this stylesheet to download and parse
+// (BLOG-019 / GH-1084). A CSS @import here would serialise font discovery behind
+// styles.css and delay text rendering.

--- a/docs/GROWTH_DESIGN_BACKLOG.md
+++ b/docs/GROWTH_DESIGN_BACKLOG.md
@@ -590,13 +590,19 @@ assets for appropriate dimensions and compression.
 
 Fonts are currently discovered through a CSS `@import`, which delays loading.
 
+**Status (2026-06-26): Shipped.** The CSS `@import` was removed from
+`assets/css/styles.scss`; Merriweather + Inter now load via `preconnect` +
+document-level `<link>` in `_layouts/default.html` `<head>`, ahead of
+`styles.css`. Same families/weights, `display=swap` retained, fallback stacks
+unchanged. Self-hosting (fuller privacy win) deferred as a future enhancement.
+
 **Acceptance criteria:**
 
-- [ ] Remove the font `@import` from the compiled stylesheet.
-- [ ] Self-host fonts or load them through optimized document-level links.
-- [ ] Use `font-display` behavior that preserves readable text.
-- [ ] Preload only fonts proven to be critical.
-- [ ] Retain appropriate fallback font stacks.
+- [x] Remove the font `@import` from the compiled stylesheet.
+- [x] Self-host fonts or load them through optimized document-level links.
+- [x] Use `font-display` behavior that preserves readable text.
+- [x] Preload only fonts proven to be critical.
+- [x] Retain appropriate fallback font stacks.
 
 **Verification:**
 


### PR DESCRIPTION
Closes #1084. Implements **BLOG-019**.

## Problem

`assets/css/styles.scss` discovered the web fonts (Merriweather + Inter) through a CSS `@import`, so the browser couldn't fetch them until `styles.css` had downloaded **and parsed** — font discovery was serialised behind the stylesheet, delaying text rendering.

## Fix

- Remove the `@import` from `assets/css/styles.scss`.
- In `_layouts/default.html` `<head>`, **before** `styles.css`, add `preconnect` (googleapis + gstatic) and a document-level `<link rel="stylesheet">` for the same `Merriweather + Inter` families with `display=swap`.

Fonts are now discovered at first byte and fetched in parallel with the stylesheet. Same families/weights → **no typography change** (so BLOG-015 is not a dependency); `$font-serif`/`$font-sans` fallback stacks unchanged. Individual font files are intentionally **not** preloaded — Google rotates its versioned gstatic URLs, so a hardcoded preload would rot; `preconnect` is the safe warm-up. Full self-hosting (deeper privacy win) is noted as a future enhancement.

## Verification (real browser)

- `@import` gone from compiled CSS (`grep -c fonts.googleapis _site/assets/css/styles.css` → 0)
- Font links present in `<head>`, ahead of `styles.css`
- `document.fonts`: **Inter 400/600/700 + Merriweather 400/400-italic/700** all `loaded`
- Computed `font-family` resolves to the Merriweather serif stack (unchanged)
- **CLS = 0** (no font-swap regression)
- `bundle exec jekyll build` exits 0; no protected file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)