### PR TITLE
docs(GH-996): note grep -A over awk-range for markdown-list AC verification

### DIFF
--- a/.github/skills/spec-driven-development/SKILL.md
+++ b/.github/skills/spec-driven-development/SKILL.md
@@ -163,6 +163,17 @@ Break the plan into discrete, implementable tasks:
   - Files: [Which files will be touched]
 ```
 
+**Writing verification commands for markdown structures.** When a `Verify:`
+step counts items in a markdown list, prefer `grep -A N "<header>" | grep -c "^- "`
+over an awk range like `awk '/^<header>/,/^$/'`. A markdown list is usually
+separated from its bold header by a blank line, and the awk range terminates on
+that first `/^$/` *before* it ever reaches a bullet — so it silently returns `0`
+instead of the real count. Example: to count the bullets under a
+`**Never persist to memory:**` header, use
+`grep -A 6 "Never persist to memory" file.md | grep -c "^- "` (returns the true
+count), not the awk range (returns `0`). Pick the `-A N` window large enough to
+span the list.
+
 ### Phase 4: Implement
 
 Execute tasks one at a time following the repo's `build` and `test` workflows,


### PR DESCRIPTION
Closes #996.

## What
Adds a one-paragraph note to the spec verification guidance in `.github/skills/spec-driven-development/SKILL.md`: when a `Verify:` step counts items in a markdown list, prefer `grep -A N "<header>" | grep -c "^- "` over an `awk` range.

## Why
Per #996 (spawned from PR #990's /ship audit): an `awk '/^header/,/^$/'` range terminates on the blank line that separates a bold header from its list, silently returning `0` instead of the bullet count. The note documents the working `grep -A` pattern so future specs use it from the start.

## Scope / labels
- Docs-only, single file under `.github/skills/` → carries `governance-update` per CLAUDE.md.
- AC #1 (note added) ✅. AC #2 (a future spec uses the pattern) is forward-looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)