### PR TITLE
docs(GH-1031): fix phantom convention-doc references in AI_CODING_GUIDELINES

### DIFF
--- a/docs/AI_CODING_GUIDELINES.md
+++ b/docs/AI_CODING_GUIDELINES.md
@@ -21,8 +21,8 @@ This file provides guidance for AI coding assistants (like GitHub Copilot, Claud
 
 When writing, editing, refactoring, or reviewing code:
 - Always follow `docs/conventions/software-design.md`
-- Look for standard implementation patterns in `docs/conventions/standard-patterns.md`
-- Avoid patterns listed in `docs/conventions/anti-patterns.md`
+- Look for standard implementation patterns in the "Standard Patterns" section of `docs/conventions/software-design.md`
+- Avoid patterns listed in the "Anti-Patterns to Avoid" section of `docs/conventions/software-design.md`
 - Respect the codebase structure defined in `docs/conventions/codebase-structure.md`
 - Follow testing conventions in `docs/conventions/testing.md`
 


### PR DESCRIPTION
Partially addresses #1031.

## The one genuine finding
`docs/AI_CODING_GUIDELINES.md` instructed agents to follow `docs/conventions/standard-patterns.md` and `docs/conventions/anti-patterns.md` — **neither file exists**. That content actually lives in `docs/conventions/software-design.md` under its **Standard Patterns** and **Anti-Patterns to Avoid** sections. This PR redirects both bullets there, so the guidance resolves to real content.

## Context on the rest of #1031
Of the 228 paths the doc-audit flagged, this is the **only** genuine broken reference. The remainder are false positives from `doc-audit.sh` Check 3's backtick-path heuristic:
- relative links (`../../../CLAUDE.md`) and absolute site paths (`/assets/...`) it never resolved,
- git branch names (`feat/990-...`), org/repo refs (`oviney/blog`), GitHub Action shorthands (`actions/cache`, `nick-fields/retry`),
- concept tokens (`try/catch`, `ci/cd`), `file:line` refs, npm scoped packages (`@playwright/test`),
- illustrative example paths and placeholders (`_posts/YYYY-MM-DD-title.md`), and archived `tasks/**` scratch records.

Hardening (or removing) Check 3 so it stops auto-filing ~227 false positives is a separate decision — tracked in follow-up. This PR keeps scope to the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)