### PR TITLE
docs(GH-1031): fix phantom convention-doc references in AI_CODING_GUIDELINES

### DIFF
--- a/docs/AI_CODING_GUIDELINES.md
+++ b/docs/AI_CODING_GUIDELINES.md
@@ -21,8 +21,8 @@ This file provides guidance for AI coding assistants (like GitHub Copilot, Claud
 
 When writing, editing, refactoring, or reviewing code:
 - Always follow `docs/conventions/software-design.md`
-- Look for standard implementation patterns in `docs/conventions/standard-patterns.md`
-- Avoid patterns listed in `docs/conventions/anti-patterns.md`
+- Look for standard implementation patterns in the "Standard Patterns" section of `docs/conventions/software-design.md`
+- Avoid patterns listed in the "Anti-Patterns to Avoid" section of `docs/conventions/software-design.md`
 - Respect the codebase structure defined in `docs/conventions/codebase-structure.md`
 - Follow testing conventions in `docs/conventions/testing.md`
 


### PR DESCRIPTION
Addresses the one genuine broken reference from #1031. (Recreated from #1088, which got wedged after a force-push.)

`docs/AI_CODING_GUIDELINES.md` pointed agents at `docs/conventions/standard-patterns.md` and `anti-patterns.md` — neither exists. That content lives in `docs/conventions/software-design.md` under its **Standard Patterns** / **Anti-Patterns to Avoid** sections; both bullets now redirect there. The audit's noisy Check 3 heuristic was hardened in #1089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)