### PR TITLE
fix(visual P1): unstick category grid from the 900px article cap

### DIFF
--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -214,6 +214,15 @@ body {
     max-width: 100%;
     padding: 0;
   }
+
+  // For category/topic listing pages, escape the 900px article reading cap so
+  // the 3-column .topic-grid gets its intended ~1040px width (the wrappers
+  // supply their own max-width and side padding).
+  &:has(.topic-page),
+  &:has(.econ-topic-page) {
+    max-width: 100%;
+    padding: 0;
+  }
 }
 
 .page-wide {
@@ -2005,8 +2014,8 @@ table {
 
 .topic-page {
   max-width: 1040px;
-  margin: 0;
-  padding: $spacing-xl 148px $spacing-xl 148px;
+  margin: 0 auto;
+  padding: $spacing-xl $spacing-lg;
 }
 
 .topic-header {

--- a/tests/playwright-agents/responsive.spec.ts
+++ b/tests/playwright-agents/responsive.spec.ts
@@ -276,6 +276,35 @@ test.describe('@visual Responsive Layout Adaptation @REQ-NAV-01 @REQ-VISUAL-01',
 
 });
 
+test.describe('@visual Category Listing Grid Width @REQ-VISUAL-01', () => {
+
+  // Guard for the regression where category/topic listing pages inherited the
+  // 900px article reading cap (plus a 148px fixed side padding), crushing the
+  // 3-column .topic-grid into a ~556px centered column on wide desktops.
+  test('Category page grid uses the full listing width at desktop', async ({ page }) => {
+    await page.setViewportSize(viewports.desktop);
+    await page.goto('/security/');
+    await page.waitForLoadState('networkidle');
+
+    const wrapper = page.locator('.topic-page, .econ-topic-page').first();
+    await expect(wrapper).toBeVisible();
+
+    const wrapperBox = await wrapper.boundingBox();
+    expect(wrapperBox).not.toBeNull();
+    // The listing wrapper must escape the 900px article cap (target ~1040px).
+    expect(wrapperBox!.width).toBeGreaterThanOrEqual(1000);
+
+    const firstCard = page.locator('.topic-card').first();
+    await expect(firstCard).toBeVisible();
+
+    const cardBox = await firstCard.boundingBox();
+    expect(cardBox).not.toBeNull();
+    // Each of the 3 columns needs >= 280px for the card design to hold.
+    expect(cardBox!.width).toBeGreaterThanOrEqual(280);
+  });
+
+});
+
 test.describe('@visual Typography Responsiveness @REQ-VISUAL-01', () => {
 
   test('Font sizes scale appropriately across viewports', async ({ page }) => {


### PR DESCRIPTION
## P1 — category listing grid crushed into a ~556px column

**Defect** (catalog #1): `/security/`, `/software-engineering/`, `/test-automation/` rendered their 3-column `.topic-grid` in a centered ~556px column with ~442px empty gutters each side at every desktop width >1024px — cards ~153px wide, titles wrapping 3–4 lines.

**Root cause:** the `.topic-page` wrapper inherited `.main-content`'s 900px *article reading* cap, then added `padding: $spacing-xl 148px` on top, strangling the grid.

**Fix** (`_sass/economist-theme.scss`, variables-only):
- Add `.main-content:has(.topic-page), :has(.econ-topic-page) { max-width: 100%; padding: 0 }` — mirrors the existing `:has(.economist-article)` precedent.
- `.topic-page`: `margin: 0 auto` + `padding: $spacing-xl $spacing-lg` (drops the hardcoded `148px`), restoring the intended 1040px wrapper (~293px cards × 3).

**Guard test:** `responsive.spec.ts` @1920px asserts the `.topic-page` wrapper width ≥1000 and first `.topic-card` ≥280 — fails on `main` (~852/~153), passes here.

Reviewed by a code-reviewer agent: build green, variables-only, no protected files. `:has()` degrades gracefully to the 900px cap on legacy browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
