### PR TITLE
fix(visual P1): card teasers use description, not the Source: auto-excerpt

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -159,7 +159,7 @@ layout: default
       <h3 class="related-title">
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       </h3>
-      <p class="related-excerpt">{{ post.excerpt | strip_html | truncate: 100, "…" }}</p>
+      <p class="related-excerpt">{{ post.description | default: post.excerpt | strip_html | truncate: 100, "…" }}</p>
       <time class="related-meta" datetime="{{ post.date | date_to_xmlschema }}">
         {{ post.date | date: "%b %-d, %Y" }}
       </time>
@@ -198,7 +198,7 @@ layout: default
       {% endif %}
       <div class="featured-content">
         <h3><a href="{{ featured.url | relative_url }}">{{ featured.title }}</a></h3>
-        <p class="featured-excerpt">{{ featured.excerpt | strip_html | truncatewords: 25 }}</p>
+        <p class="featured-excerpt">{{ featured.description | default: featured.excerpt | strip_html | truncatewords: 25 }}</p>
       </div>
     </article>
 
@@ -213,7 +213,7 @@ layout: default
         {% endif %}
         <div class="item-content">
           <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-          <p class="item-excerpt">{{ post.excerpt | strip_html | truncatewords: 15 }}</p>
+          <p class="item-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 15 }}</p>
         </div>
       </article>
       {% endfor %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -34,7 +34,7 @@ description: Coverage of software quality, test automation, and engineering lead
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       </h2>
 
-      <p class="econ-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+      <p class="econ-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
 
       {% include byline.html author=post.author container_class="econ-card-author" text_class="econ-card-author-name" %}
 

--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ description: Two decades of software and quality engineering distilled into prac
       {% endif %}
 
       <!-- Deliberately longer than discovery cards so the homepage hero stays distinct. -->
-      <p class="hero-post-excerpt">{{ hero_post.excerpt | strip_html | truncatewords: 40 }}</p>
+      <p class="hero-post-excerpt">{{ hero_post.description | default: hero_post.excerpt | strip_html | truncatewords: 40 }}</p>
 
       <div class="hero-post-meta">
         <time datetime="{{ hero_post.date | date_to_xmlschema }}">
@@ -128,7 +128,7 @@ description: Two decades of software and quality engineering distilled into prac
           <h3 class="topic-card-title">
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
           </h3>
-          <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
           {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
           <div class="topic-card-meta">
             <span class="topic-meta-item">{{ post.date | date: "%B %-d, %Y" }}</span>

--- a/security-topic.md
+++ b/security-topic.md
@@ -40,7 +40,7 @@ description: Reporting and analysis on security debt, enterprise defence, and th
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
           </h2>
 
-          <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
           {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">

--- a/software-engineering.md
+++ b/software-engineering.md
@@ -42,7 +42,7 @@ description: Systematic methods, architectural decisions, and engineering practi
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
           </h2>
 
-          <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
           {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">

--- a/test-automation.md
+++ b/test-automation.md
@@ -42,7 +42,7 @@ description: Strategies, frameworks, and practices for building test automation 
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
           </h2>
 
-          <p class="topic-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
           {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
 
           <div class="topic-card-meta">

--- a/tests/playwright-agents/excerpt-source-regression.spec.ts
+++ b/tests/playwright-agents/excerpt-source-regression.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' });
+
+// Guard against regression where a post body opens with a chart image + an
+// italic "*Source: …*" caption, causing Jekyll's AUTO excerpt to start with
+// "Source:". Teaser cards must prefer the human-written front-matter
+// `description` so no card lede reads "Source: …".
+const surfaces: { name: string; path: string; selector: string }[] = [
+  { name: 'homepage', path: '/', selector: '.hero-post-excerpt, .topic-card-excerpt' },
+  { name: 'blog index', path: '/blog/', selector: '.econ-card-excerpt' },
+  { name: 'security topic', path: '/security/', selector: '.topic-card-excerpt' },
+];
+
+test.describe('@content Teaser excerpts never lead with chart "Source:" @REQ-CONTENT-03', () => {
+  for (const { name, path, selector } of surfaces) {
+    test(`${name} cards do not render a "Source:" lede`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      const cards = page.locator(selector);
+      const count = await cards.count();
+      expect(count, `expected at least one teaser card on ${path}`).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const text = ((await cards.nth(i).textContent()) || '').trim();
+        expect(text, `teaser #${i} on ${path} leads with "Source:"`).not.toMatch(/^source:/i);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## P1 — teaser cards open with "Source:" instead of the article lede

**Defect** (catalog #2): ~half of all listing/teaser cards (`/`, `/blog/`, category pages, in-post rails) opened with chart citation text like "Source: GitClear…" because posts begin with a chart image + an italic `*Source: …*` caption, so Jekyll's auto `page.excerpt` starts with "Source:".

**Fix (template-level — no posts mass-edited):** all 24 posts already carry a human-written `description:` front-matter lede, so every card surface now renders `description | default: excerpt`:
- `blog/index.html`, `index.md` (hero + "From the Blog"), `security-topic.md`, `software-engineering.md`, `test-automation.md`, and the related/featured/more-from rails in `_layouts/post.html`.

**Guard test:** new `excerpt-source-regression.spec.ts` asserts no card teaser on `/`, `/blog/`, `/security/` matches `/^Source:/i` — fails on `main`, passes here.

Reviewed by a code-reviewer agent: build green, fallback keeps the auto-excerpt for any post lacking a description. Follow-up worth noting: RSS/SEO meta still derive from the raw excerpt (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
