### PR TITLE
test: regression guards for two already-fixed P1 defects (head-meta, agents leak)

### DIFF
--- a/tests/playwright-agents/seo-jsonld.spec.ts
+++ b/tests/playwright-agents/seo-jsonld.spec.ts
@@ -168,6 +168,20 @@ test.describe('@content @links SEO JSON-LD Structured Data @REQ-CONTENT-01', () 
     expect(articleDescription.length).toBeLessThanOrEqual(160);
   });
 
+  test('head has exactly one title, canonical, and meta description (no seo-tag/manual duplicates) @REQ-CONTENT-01', async ({ page }) => {
+    // Guard against GH-1054 regression: _layouts/default.html must NOT hand-roll
+    // <title>, <meta name="description">, or <link rel="canonical"> — those are
+    // owned solely by jekyll-seo-tag ({% seo %}). Re-adding the manual tags would
+    // emit two of each on every page. Asserted WITHOUT .first() so a duplicate
+    // fails the toHaveCount(1) check.
+    await page.goto('/2026/04/05/building-a-test-strategy-that-works/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('head title')).toHaveCount(1);
+    await expect(page.locator('link[rel="canonical"]')).toHaveCount(1);
+    await expect(page.locator('meta[name="description"]')).toHaveCount(1);
+  });
+
   test('Meta description tag is present on post pages', async ({ page }) => {
     await page.goto('/2026/04/05/building-a-test-strategy-that-works/');
     await page.waitForLoadState('networkidle');

--- a/tests/playwright-agents/sitemap-exclusions.spec.ts
+++ b/tests/playwright-agents/sitemap-exclusions.spec.ts
@@ -17,6 +17,16 @@ const EXCLUDED_SITEMAP_PATHS = [
   '/agents/test-engineer/',
 ];
 
+// Internal agent-persona definitions live in the repo-root `agents/` dir and
+// carry `published: false`. They must never build into reachable site pages —
+// a 200 here means the front-matter guard was removed and the internal agent
+// prompts leaked back into the published site (GH-1053 root cause).
+const INTERNAL_AGENT_PATHS = [
+  '/agents/code-reviewer/',
+  '/agents/security-auditor/',
+  '/agents/test-engineer/',
+];
+
 const RETAINED_SITEMAP_PATHS = [
   '/',
   '/about/',
@@ -49,6 +59,15 @@ test.describe('@seo @links Sitemap utility-page exclusions @REQ-CONTENT-01', () 
 
     for (const path of RETAINED_SITEMAP_PATHS) {
       expect(paths, `sitemap should still advertise ${path}`).toContain(path);
+    }
+  });
+
+  test('internal agent-persona pages are not served as built site pages', async ({ page }) => {
+    for (const path of INTERNAL_AGENT_PATHS) {
+      const response = await page.goto(path);
+      // published:false means Jekyll never builds these — the route must not
+      // resolve to a 200/styled page. A 200 here is the leak regression.
+      expect(response?.ok(), `${path} must not be served as a built page`).toBe(false);
     }
   });
 


### PR DESCRIPTION
## Regression guards for two P1 defects that were **already fixed** on `main`

The visual audit flagged these two as P1, but its `_site` snapshot lagged `origin/main`. The adversarial fix workflow (code-reviewer verification) caught that both were already remediated — so this PR adds **only the missing regression guards**, no source changes:

1. **Duplicate `<head>` metadata** — already fixed by **GH-1054** (`_layouts/default.html` delegates `<title>`/description/canonical solely to `{% seo %}`). Guard added to `seo-jsonld.spec.ts`: asserts `toHaveCount(1)` (no `.first()`) for `head title`, `link[rel=canonical]`, `meta[name=description]`.
2. **`/agents/*` page leak** — already fixed by **#1056 (GH-1053)** (`published: false` on the three `agents/*.md`). Guard added to `sitemap-exclusions.spec.ts`: asserts the agent-persona routes are not served as built pages.

These lock in the fixes so the defects can't silently return. No protected files touched; both test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
