### PR TITLE
fix(visual P2): inline charts shrink to fit phones (no horizontal scroll)

### DIFF
--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -569,7 +569,7 @@ blockquote {
     // Reduce margins and limit size for chart images
     &[src*="/charts/"] {
       margin: $spacing-md 0;
-      max-width: 500px; // Reasonable chart size for content
+      max-width: min(500px, 100%); // Cap at 500px on desktop, shrink on small screens (no page overflow)
       border-radius: $radius-sm;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
       margin-left: auto;
@@ -593,7 +593,7 @@ blockquote {
   }
 
   img[src*="/charts/"] {
-    max-width: 500px !important; // Override any other styles
+    max-width: min(500px, 100%) !important; // Cap at 500px on desktop, shrink on small screens (no page overflow)
     height: auto; // Preserve aspect ratio against intrinsic width/height attrs (BLOG-017b)
     margin: $spacing-md auto; // Center with reduced margins
     border-radius: $radius-sm;

--- a/tests/playwright-agents/responsive.spec.ts
+++ b/tests/playwright-agents/responsive.spec.ts
@@ -512,6 +512,46 @@ test.describe('@visual Image Responsiveness @REQ-VISUAL-01', () => {
 
 });
 
+test.describe('@visual Inline Chart Overflow @REQ-VISUAL-01', () => {
+
+  // Guard for P2: inline /charts/ images must shrink below their 500px desktop
+  // cap on narrow phones so the page never gains horizontal scroll. Fails on
+  // origin/main (fixed max-width: 500px) and passes once the chart rule uses
+  // max-width: min(500px, 100%).
+  const chartPost = '/2026/01/19/the-surprising-economics-of-test-automation-roi/';
+  const narrowViewports = [
+    { width: 320, height: 568 },
+    { width: 390, height: 844 },
+  ];
+
+  for (const viewport of narrowViewports) {
+    test(`charts do not cause horizontal overflow at ${viewport.width}px`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await page.goto(chartPost);
+      await page.waitForLoadState('networkidle');
+
+      // No horizontal page scroll (allow 1px rounding tolerance).
+      const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
+
+      // Every inline chart image must fit within the viewport width.
+      const charts = page.locator('.article-content img[src*="/charts/"]');
+      const chartCount = await charts.count();
+      expect(chartCount).toBeGreaterThan(0);
+
+      for (let i = 0; i < chartCount; i++) {
+        const box = await charts.nth(i).boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.width).toBeLessThanOrEqual(viewport.width + 1);
+      }
+    });
+  }
+
+});
+
 test.describe('@accessibility Interactive Elements Touch Targets @REQ-A11Y-02 @REQ-NAV-01', () => {
 
   test.use({ viewport: viewports.mobile });


### PR DESCRIPTION
## P2 — inline charts overflow the screen on phones

**Defect** (catalog): chart images were fixed at `max-width: 500px`, so on screens narrower than ~520px the whole page got horizontal scroll and the chart was clipped off the right.

**Fix** (`_sass/economist-theme.scss`): both `/charts/` image rules now use `max-width: min(500px, 100%)` — still caps at 500px on desktop, shrinks to fit on phones. No new magic numbers.

**Guard test:** `responsive.spec.ts` at 320px and 390px asserts the page has no horizontal scroll and each chart fits the viewport — fails on `main`, passes here.

Reviewed by a code-reviewer agent: build green, no protected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
