### PR TITLE
fix(visual P2): hero captions render in sentence case, not ALL CAPS

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -41,7 +41,7 @@ layout: default
     {% assign _hero_alt = page.image_alt | default: page.title %}
     {% include responsive-image.html src=page.image alt=_hero_alt %}
     {% if page.image_caption %}
-    <figcaption class="image-credit">{{ page.image_caption | upcase }}</figcaption>
+    <figcaption class="image-credit">{{ page.image_caption }}</figcaption>
     {% else %}
     <figcaption class="image-credit">ILLUSTRATION</figcaption>
     {% endif %}

--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -499,14 +499,15 @@ blockquote {
     display: block;
   }
 
-  // Image credit caption (Economist style: "ILLUSTRATION: ROB FARMER")
+  // Image credit caption — renders in the authored sentence case so full
+  // captions stay readable (short credits can still be authored in caps).
   .image-credit {
     font-family: $font-sans;
     font-size: 0.6875rem;
     color: $text-tertiary;
     margin-top: $spacing-xs;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    text-transform: none;
+    letter-spacing: 0.02em;
     font-style: normal;
     font-weight: 400;
   }

--- a/tests/playwright-agents/content-edge-cases.spec.ts
+++ b/tests/playwright-agents/content-edge-cases.spec.ts
@@ -652,3 +652,32 @@ test.describe('@content @navigation Related Posts and Content Discovery @REQ-CON
   });
 
 });
+
+test.describe('@content Hero image caption casing @REQ-CONTENT-CAPTION-CASE', () => {
+
+  // Guard for the all-caps hero caption defect (P2): the authored sentence-case
+  // caption must NOT be forced to ALL CAPS — neither by a Liquid `| upcase`
+  // filter in _layouts/post.html nor by a `text-transform: uppercase` rule on
+  // the .image-credit figcaption in _sass/economist-theme.scss.
+  test('hero figcaption renders in authored sentence case, not ALL CAPS', async ({ page }) => {
+    await page.goto('/2026/01/02/self-healing-tests-myth-vs-reality/');
+
+    const caption = page.locator('.article-hero-image figcaption.image-credit').first();
+    await expect(caption).toBeVisible();
+
+    const text = (await caption.textContent() || '').trim();
+    expect(text.length).toBeGreaterThan(0);
+
+    // The caption contains lowercase-capable letters, so a sentence-case string
+    // must differ from its own uppercased form. Catches the `| upcase` filter.
+    expect(text).not.toEqual(text.toUpperCase());
+
+    // The CSS must not visually re-uppercase the caption. Catches a
+    // text-transform: uppercase rule that would defeat the layout fix.
+    const transform = await caption.evaluate(
+      (el) => getComputedStyle(el).textTransform
+    );
+    expect(transform).not.toBe('uppercase');
+  });
+
+});


### PR DESCRIPTION
## P2 — hero image captions are hard-to-read ALL CAPS

**Defect** (catalog): every hero caption rendered as a letter-spaced ALL-CAPS full sentence, wrapping over several lines on mobile.

**Fix:** two compounding causes removed —
- `_layouts/post.html`: dropped the `| upcase` filter so captions render in their authored sentence case.
- `_sass/economist-theme.scss`: `.image-credit` set to `text-transform: none` and tighter `letter-spacing` (short credits can still be authored in caps).

**Guard test:** `content-edge-cases.spec.ts` asserts the rendered caption isn't all-caps (catches both the filter and the CSS) — fails on `main`, passes here.

Reviewed by a code-reviewer agent: build green, no protected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
