### PR TITLE
fix(visual P2): category thumbnails use WebP via responsive-image include

### DIFF
--- a/security-topic.md
+++ b/security-topic.md
@@ -19,7 +19,7 @@ description: Reporting and analysis on security debt, enterprise defence, and th
       <article class="topic-card">
         {% if post.image %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
+          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
         </a>
         {% else %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">

--- a/software-engineering.md
+++ b/software-engineering.md
@@ -19,7 +19,7 @@ description: Systematic methods, architectural decisions, and engineering practi
       <article class="topic-card">
         {% if post.image %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
+          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
         </a>
         {% else %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">

--- a/test-automation.md
+++ b/test-automation.md
@@ -19,7 +19,7 @@ description: Strategies, frameworks, and practices for building test automation 
       <article class="topic-card">
         {% if post.image %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
+          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
         </a>
         {% else %}
         <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">

--- a/tests/playwright-agents/category-webp.spec.ts
+++ b/tests/playwright-agents/category-webp.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Guard test for the category-page WebP regression (P2).
+ *
+ * Category pages (/security/, /software-engineering/, /test-automation/)
+ * previously emitted raw <img src="...png"> thumbnails, bypassing the
+ * responsive-image include (and its WebP <source>) used by /blog/. That
+ * served multi-MB PNGs instead of the ~0.6MB WebP variants.
+ *
+ * This test asserts the card thumbnails are now wrapped in <picture> with a
+ * WebP <source>, and that no raw PNG <img> with an available WebP sibling
+ * remains on the category pages.
+ */
+
+const categoryPages = ['/security/', '/software-engineering/', '/test-automation/'];
+
+test.describe('Category page WebP thumbnails', () => {
+  for (const url of categoryPages) {
+    test(`${url} serves card thumbnails via <picture>/WebP`, async ({ page }) => {
+      await page.goto(url);
+
+      const cardImages = page.locator('.topic-card-image');
+      const cardCount = await cardImages.count();
+
+      // The fix only applies to cards that have a post image. If a category has
+      // image-bearing posts, at least one <picture> with a WebP source must exist.
+      const pictures = page.locator('.topic-card-image picture');
+      const webpSources = page.locator('.topic-card-image picture source[type="image/webp"]');
+
+      if (cardCount > 0 && (await pictures.count()) > 0) {
+        expect(await webpSources.count()).toBeGreaterThan(0);
+      }
+
+      // No raw PNG <img> should remain directly under a card image link.
+      // (PNG-backed thumbnails must be routed through <picture> with WebP.)
+      const rawPngImgCount = await page
+        .locator('.topic-card-image > img[src$=".png"]')
+        .count();
+      expect(rawPngImgCount).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## P2 — category thumbnails ship as multi-MB PNGs

**Defect** (catalog): category pages (`/security/`, `/software-engineering/`, `/test-automation/`) served raw `<img>` PNGs (~5.8MB) instead of the WebP `<picture>` (~0.6MB) used everywhere else — slow, worst on mobile.

**Fix:** route the three category card images through the existing `{% include responsive-image.html %}` (same include the blog index already uses), which emits WebP `<picture>` from the existing assets. **No binary/image files added.**

**Guard test:** `category-webp.spec.ts` asserts the category pages emit `<picture>` rather than a raw PNG `<img>`.

Reviewed by a code-reviewer agent: build green, no protected files. Note: touches the same 3 category files as #1098 but on different lines (image vs. excerpt) — auto-merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
