### PR TITLE
qa(GH-1105): add axe runner alongside htmlcs in pa11y CI (WCAG 2.2)

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -7,7 +7,8 @@
       "args": ["--no-sandbox", "--disable-setuid-sandbox"]
     },
     "runners": [
-      "htmlcs"
+      "htmlcs",
+      "axe"
     ]
   },
   "urls": [


### PR DESCRIPTION
## Summary
Closes #1105. From Research Sweep #1074 (Section 3). Adds the bundled `axe` runner to `.pa11yci.json` so pa11y checks both HTML_CodeSniffer and axe-core — htmlcs lags on WCAG 2.2 criteria, axe-core is the more actively maintained engine. **Config-only, no dependency bump** (axe ships with the installed pa11y-ci 4.1.x).

## Testing
- `npx pa11y-ci` with `["htmlcs","axe"]` → **0 errors** on `/` and `/blog/`; no new violations to triage.
- `.github/skills/jekyll-qa/SKILL.md` documents no runner set, so no skill update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)