### PR TITLE
qa(GH-1107): escape user-facing fields in client-side search rendering

### DIFF
--- a/search.html
+++ b/search.html
@@ -81,10 +81,10 @@ sitemap: false
       var article = document.createElement('article');
       article.className = 'search-result';
       article.innerHTML =
-        '<span class="search-result-category">' + (post.categories[0] || '') + '</span>' +
-        '<h3 class="search-result-title"><a href="' + post.url + '">' + post.title + '</a></h3>' +
-        '<p class="search-result-excerpt">' + post.content + '</p>' +
-        '<span class="search-result-date">' + post.date + '</span>';
+        '<span class="search-result-category">' + escapeHtml(post.categories[0] || '') + '</span>' +
+        '<h3 class="search-result-title"><a href="' + escapeHtml(post.url) + '">' + escapeHtml(post.title) + '</a></h3>' +
+        '<p class="search-result-excerpt">' + escapeHtml(post.content) + '</p>' +
+        '<span class="search-result-date">' + escapeHtml(post.date) + '</span>';
       resultsContainer.appendChild(article);
     });
   }

--- a/tests/playwright-agents/search-escaping.spec.ts
+++ b/tests/playwright-agents/search-escaping.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Search result rendering must escape user-facing fields (GH-1107).
+ * The client builds result cards via innerHTML; post.title/content/url/etc.
+ * must be HTML-escaped so a title containing markup renders as literal text
+ * and cannot inject elements or run script.
+ */
+test.describe('@content @REQ-SEARCH-01 Search rendering escapes user fields', () => {
+  test('post fields with HTML metacharacters render as literal text, not markup', async ({ page }) => {
+    const malicious = [{
+      title: 'XSS <img src=x onerror="window.__pwned=1"> & "quoted"',
+      url: '/2026/01/01/escaping-test/',
+      content: 'Body with <b>bold</b> & <script>window.__pwned=1<\/script> about security',
+      categories: ['<em>Security</em>'],
+      date: 'Jan 1, 2026',
+    }];
+
+    // Mock the search index before the page requests it.
+    await page.route('**/search.json', (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(malicious) })
+    );
+
+    await page.goto('/search/');
+    await page.waitForLoadState('networkidle');
+
+    // Query matches the injected post's content ("security").
+    await page.fill('#search-input', 'security');
+
+    const title = page.locator('.search-result-title');
+    await expect(title).toBeVisible();
+
+    // No injected elements may exist anywhere in the results.
+    await expect(page.locator('#search-results img')).toHaveCount(0);
+    await expect(page.locator('#search-results script')).toHaveCount(0);
+    await expect(page.locator('.search-result-excerpt b')).toHaveCount(0);
+    await expect(page.locator('.search-result-category em')).toHaveCount(0);
+
+    // The raw markup must be visible as literal text.
+    await expect(title).toContainText('<img src=x');
+    await expect(page.locator('.search-result-excerpt')).toContainText('<script>');
+
+    // The injection flag must never have been set.
+    const pwned = await page.evaluate(() => (window as Window & { __pwned?: number }).__pwned);
+    expect(pwned).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #1107. From Research Sweep #1074 (Section 4). `search.html` injected `post.title`/`content`/`url`/category/date into result cards via `innerHTML` unescaped. Live XSS risk was low (server-side `strip_html` on `search.json`), but the client trusted that invariant implicitly and titles with `<`/`&` rendered as broken markup. Now every interpolated field goes through the existing `escapeHtml()`.

## Testing
- New `tests/playwright-agents/search-escaping.spec.ts` mocks `search.json` with a malicious payload (`<img onerror>`, `<script>`, `&`, quotes) and asserts **zero injected elements** + no script execution.
- **Prove-It:** the test fails against the pre-fix code (`#search-results img` count = 1) and passes after the fix.
- Green on all 5 Playwright projects (Desktop/Tablet/Mobile Chrome, Firefox, WebKit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)