### PR TITLE
qa(GH-1105): add axe runner alongside htmlcs in pa11y CI (WCAG 2.2)

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -7,7 +7,8 @@
       "args": ["--no-sandbox", "--disable-setuid-sandbox"]
     },
     "runners": [
-      "htmlcs"
+      "htmlcs",
+      "axe"
     ]
   },
   "urls": [


### PR DESCRIPTION
Closes #1105 (recreated — the prior PR #1114 was accidentally closed unmerged when its branch was deleted). From Research Sweep #1074 §3. Adds the bundled `axe` runner to `.pa11yci.json`; config-only (axe ships with the installed pa11y-ci 4.1.x). Verified `npx pa11y-ci` (htmlcs+axe) → 0 errors on / and /blog/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)