### PR TITLE
refactor(cards): extract canonical post-card include across listing pages

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,0 +1,58 @@
+{% comment %}
+  Canonical listing post-card partial.
+
+  The single source of truth for the article card used on every post-listing
+  surface (home, blog index, and the category pages). Extracting it collapses
+  the three divergent inline card implementations (defect P2 #9) so every
+  listing renders one consistent 16:9 crop, category-label treatment, and flex
+  framing. The card image is routed through responsive-image.html for the WebP
+  source and CLS-safe intrinsic dimensions.
+
+  Usage:
+    {% include post-card.html post=post %}
+    {% include post-card.html post=post heading="h3" %}
+
+  Parameters:
+    post    — the post object to render (required)
+    heading — heading tag for the card title: "h2" (default) or "h3". Use
+              "h3" when the cards sit under a section <h2> (e.g. the homepage
+              "From the Blog" grid) so the document outline stays valid.
+{% endcomment %}{% assign card_post = include.post %}{% assign card_heading = include.heading | default: 'h2' %}
+<article class="topic-card">
+  {% if card_post.image %}
+  <a href="{{ card_post.url | relative_url }}" class="topic-card-image">
+    {% include responsive-image.html src=card_post.image alt=card_post.title loading="lazy" %}
+  </a>
+  {% else %}
+  <a href="{{ card_post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ card_post.title }}">
+    <div class="placeholder-content" aria-hidden="true">
+      <svg width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4"></path>
+        <polyline points="14 2 14 8 20 8"></polyline>
+        <line x1="16" y1="13" x2="8" y2="13"></line>
+        <line x1="16" y1="17" x2="8" y2="17"></line>
+      </svg>
+    </div>
+  </a>
+  {% endif %}
+
+  <div class="topic-card-content">
+    {% if card_post.categories %}
+    <div class="topic-category">{{ card_post.categories | first }}</div>
+    {% endif %}
+
+    <{{ card_heading }} class="topic-card-title">
+      <a href="{{ card_post.url | relative_url }}">{{ card_post.title }}</a>
+    </{{ card_heading }}>
+
+    <p class="topic-card-excerpt">{{ card_post.description | default: card_post.excerpt | strip_html | truncatewords: 20 }}</p>
+
+    {% include byline.html author=card_post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
+
+    <div class="topic-card-meta">
+      <span class="topic-meta-item">{{ card_post.date | date: "%B %-d, %Y" }}</span>
+      {% assign words = card_post.content | number_of_words %}
+      <span class="topic-meta-item">{{ words | divided_by: 200 | plus: 1 }} min read</span>
+    </div>
+  </div>
+</article>

--- a/blog/index.html
+++ b/blog/index.html
@@ -17,32 +17,9 @@ description: Coverage of software quality, test automation, and engineering lead
     <a href="{{ '/test-automation/' | relative_url }}">Test Automation</a>
   </nav>
 
-  <div class="econ-article-grid">
+  <div class="topic-grid">
     {% for post in paginator.posts %}
-    <article class="econ-article-card">
-      {% if post.image and post.image != "/assets/images/blog-default.svg" %}
-      <a href="{{ post.url | relative_url }}" class="econ-card-image-link">
-        {% include responsive-image.html src=post.image alt=post.title loading="lazy" class="econ-card-image" %}
-      </a>
-      {% endif %}
-
-      {% if post.categories %}
-      <span class="econ-card-category">{{ post.categories | first }}</span>
-      {% endif %}
-
-      <h2 class="econ-card-title">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      </h2>
-
-      <p class="econ-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
-
-      {% include byline.html author=post.author container_class="econ-card-author" text_class="econ-card-author-name" %}
-
-      <div class="econ-card-meta">
-        {% assign words = post.content | number_of_words %}
-        <span>{{ words | divided_by: 200 | plus: 1 }} min read</span>
-      </div>
-    </article>
+    {% include post-card.html post=post %}
     {% endfor %}
   </div>
 

--- a/index.md
+++ b/index.md
@@ -115,26 +115,7 @@ description: Two decades of software and quality engineering distilled into prac
     <h2 class="home-recent-heading" id="recent-posts-heading">From the Blog</h2>
     <div class="topic-grid">
       {% for post in remaining_posts limit: 3 %}
-      <article class="topic-card">
-        {% if post.image %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
-        </a>
-        {% endif %}
-        <div class="topic-card-content">
-          {% if post.categories %}
-          <div class="topic-category">{{ post.categories | first }}</div>
-          {% endif %}
-          <h3 class="topic-card-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h3>
-          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
-          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
-          <div class="topic-card-meta">
-            <span class="topic-meta-item">{{ post.date | date: "%B %-d, %Y" }}</span>
-          </div>
-        </div>
-      </article>
+      {% include post-card.html post=post heading="h3" %}
       {% endfor %}
     </div>
     <p class="view-all"><a href="/blog/">View all posts &rarr;</a></p>

--- a/security-topic.md
+++ b/security-topic.md
@@ -16,39 +16,7 @@ description: Reporting and analysis on security debt, enterprise defence, and th
   {% if security_posts.size > 0 %}
   <div class="topic-grid">
     {% for post in security_posts %}
-      <article class="topic-card">
-        {% if post.image %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
-        </a>
-        {% else %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">
-          <div class="placeholder-content" aria-hidden="true">
-            <svg width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-            </svg>
-          </div>
-        </a>
-        {% endif %}
-
-        <div class="topic-card-content">
-          {% if post.categories %}
-          <div class="topic-category">{{ post.categories | first }}</div>
-          {% endif %}
-
-          <h2 class="topic-card-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-
-          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
-          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
-
-          <div class="topic-card-meta">
-            {% assign words = post.content | number_of_words %}
-            <span class="topic-meta-item">{{ words | divided_by: 200 | plus: 1 }} min read</span>
-          </div>
-        </div>
-      </article>
+      {% include post-card.html post=post %}
     {% endfor %}
   </div>
   {% else %}

--- a/software-engineering.md
+++ b/software-engineering.md
@@ -16,41 +16,7 @@ description: Systematic methods, architectural decisions, and engineering practi
   {% if se_posts.size > 0 %}
   <div class="topic-grid">
     {% for post in se_posts %}
-      <article class="topic-card">
-        {% if post.image %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
-        </a>
-        {% else %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">
-          <div class="placeholder-content" aria-hidden="true">
-            <svg width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="7 10 12 15 17 10"></polyline>
-              <line x1="12" y1="15" x2="12" y2="3"></line>
-            </svg>
-          </div>
-        </a>
-        {% endif %}
-
-        <div class="topic-card-content">
-          {% if post.categories %}
-          <div class="topic-category">{{ post.categories | first }}</div>
-          {% endif %}
-
-          <h2 class="topic-card-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-
-          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
-          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
-
-          <div class="topic-card-meta">
-            {% assign words = post.content | number_of_words %}
-            <span class="topic-meta-item">{{ words | divided_by: 200 | plus: 1 }} min read</span>
-          </div>
-        </div>
-      </article>
+      {% include post-card.html post=post %}
     {% endfor %}
   </div>
   {% else %}

--- a/test-automation.md
+++ b/test-automation.md
@@ -16,41 +16,7 @@ description: Strategies, frameworks, and practices for building test automation 
   {% if ta_posts.size > 0 %}
   <div class="topic-grid">
     {% for post in ta_posts %}
-      <article class="topic-card">
-        {% if post.image %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image">
-          {% include responsive-image.html src=post.image alt=post.title loading="lazy" %}
-        </a>
-        {% else %}
-        <a href="{{ post.url | relative_url }}" class="topic-card-image topic-card-image-placeholder" aria-label="{{ post.title }}">
-          <div class="placeholder-content" aria-hidden="true">
-            <svg width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="7 10 12 15 17 10"></polyline>
-              <line x1="12" y1="15" x2="12" y2="3"></line>
-            </svg>
-          </div>
-        </a>
-        {% endif %}
-
-        <div class="topic-card-content">
-          {% if post.categories %}
-          <div class="topic-category">{{ post.categories | first }}</div>
-          {% endif %}
-
-          <h2 class="topic-card-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-
-          <p class="topic-card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncatewords: 20 }}</p>
-          {% include byline.html author=post.author container_class="topic-card-author" text_class="topic-card-author-name" %}
-
-          <div class="topic-card-meta">
-            {% assign words = post.content | number_of_words %}
-            <span class="topic-meta-item">{{ words | divided_by: 200 | plus: 1 }} min read</span>
-          </div>
-        </div>
-      </article>
+      {% include post-card.html post=post %}
     {% endfor %}
   </div>
   {% else %}

--- a/tests/playwright-agents/byline-regression.spec.ts
+++ b/tests/playwright-agents/byline-regression.spec.ts
@@ -7,7 +7,7 @@ test.describe('@content Byline regression coverage @REQ-CONTENT-01 @REQ-CONTENT-
     await page.goto('/blog/');
     await page.waitForLoadState('networkidle');
 
-    const firstCard = page.locator('.econ-article-card').first();
+    const firstCard = page.locator('.topic-card').first();
     await expect(firstCard).toBeVisible();
 
     const cardByline = firstCard.getByText(/^By\s+\S/).first();

--- a/tests/playwright-agents/excerpt-source-regression.spec.ts
+++ b/tests/playwright-agents/excerpt-source-regression.spec.ts
@@ -8,7 +8,7 @@ test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' }
 // `description` so no card lede reads "Source: …".
 const surfaces: { name: string; path: string; selector: string }[] = [
   { name: 'homepage', path: '/', selector: '.hero-post-excerpt, .topic-card-excerpt' },
-  { name: 'blog index', path: '/blog/', selector: '.econ-card-excerpt' },
+  { name: 'blog index', path: '/blog/', selector: '.topic-card-excerpt' },
   { name: 'security topic', path: '/security/', selector: '.topic-card-excerpt' },
 ];
 


### PR DESCRIPTION
## What

Extract a single canonical `_includes/post-card.html` and route every post-listing surface through it, replacing three divergent inline card implementations.

Converted surfaces (highest-traffic first):
- Home — `index.md` ("From the Blog" grid, cards passed `heading="h3"`)
- Blog index — `blog/index.html`
- Category pages — `security-topic.md`, `software-engineering.md`, `test-automation.md`

The card image is routed through the existing `_includes/responsive-image.html` WebP include. The include accepts the post via `post=` and an optional `heading=` param (`h2` default; `h3` for the homepage grid to keep the document outline valid).

## Why

Addresses **defect P2 #9** in `docs/agents/visual-audit-findings.md`: the same articles rendered as visibly different cards across pages — 3:2 vs 16:9 crop, red vs grey category label, top-border vs white-flex framing. The blog index used the divergent `.econ-article-card` / `.econ-article-grid` system; it now uses the canonical `.topic-card` / `.topic-grid` like every other listing surface.

## Scope notes

- No other live listing surfaces exist (there is no `quality-engineering` page; remaining `.econ-*` references live only in docs/skills/archived tasks and now-unused SCSS). All listing surfaces are converted in this PR — no follow-up surfaces outstanding.
- No SCSS was changed. The `.econ-article-card` / `.econ-card-*` / `.econ-article-grid` rules are now unused on live pages but were left in place (out of scope; safe to prune later).
- Two regression specs that selected the removed classes were retargeted to the canonical selectors: `byline-regression.spec.ts` (`.econ-article-card` → `.topic-card`) and `excerpt-source-regression.spec.ts` (`.econ-card-excerpt` → `.topic-card-excerpt`).
- 8 files changed (under the 15-file scope cap).

## Verification

- `bundle exec jekyll build` — green, no new Sass errors.
- Spot-checked built HTML on every converted surface: home (3 cards, `h3` titles), blog index (6 cards, `.topic-grid`, `h2` titles, WebP `<picture>`), security (3), software-engineering (5), test-automation (16). Rendered card confirmed well-formed with WebP source, category label, byline, and date + min-read meta.
- Playwright specs not executed locally (no `node_modules`); repo CI runs the full Playwright/pa11y/Lighthouse suite.

## Reviewer note

There is **no visual baseline yet** (Gap B is blocked on PR #1119), so this refactor needs careful human visual review before merge — the blog index in particular changes crop (3:2 → 16:9), category-label colour (red → grey), and framing (top-border → white flex) to match the canonical card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)