### PR TITLE
fix(a11y): keep share controls clear of fixed chrome at 320px (#1101)

### DIFF
--- a/_sass/economist-theme.scss
+++ b/_sass/economist-theme.scss
@@ -3445,4 +3445,16 @@ article.topic-card h2 a,
   .main-content {
     padding-bottom: calc(#{$bottom-nav-height} + env(safe-area-inset-bottom));
   }
+
+  // WCAG 2.4.11 (Focus Not Obscured): the fixed bottom nav overlaps the lower
+  // ~63px of the viewport, and the fixed reading-progress bar sits at the top.
+  // When a keyboard user Tabs to a share/copy-link control the browser scrolls
+  // it minimally into view, which can leave it resting beneath the fixed nav.
+  // scroll-margin reserves clearance on both edges so focused share controls
+  // are never obscured by fixed chrome (see issue #1101).
+  .action-btn,
+  .share-btn {
+    scroll-margin-bottom: calc(#{$bottom-nav-height} + #{$spacing-md} + env(safe-area-inset-bottom));
+    scroll-margin-top: $spacing-md;
+  }
 }


### PR DESCRIPTION
## What

Adds `scroll-margin` to `.action-btn` and `.share-btn` (scoped to the `<=767px` bottom-nav breakpoint) so focused share / copy-link controls always scroll clear of fixed page chrome.

## Why

Fixes #1101. At `<=767px` the fixed `.bottom-nav` overlaps the lower ~63px of the viewport (and the fixed reading-progress bar sits at the top). When a keyboard user Tabs to the top **Share** / copy-link control (`#copy-link-btn-top`), the browser scrolls it minimally into view — aligning its bottom edge to the viewport bottom — which leaves the control's centre point resting **beneath** the fixed bottom nav. That is a WCAG 2.4.11 (Focus Not Obscured) violation and the root cause of the pre-existing `@REQ-A11Y-02 › article share controls show visible focus and stay unobscured` failure on the Mobile Chrome project.

I reproduced the defect at the 320×568 Mobile Chrome viewport: after a minimal (bottom-aligned) scroll the button centre landed at y≈546 inside the fixed nav (y 504–568), and `document.elementFromPoint(centre)` returned `.bottom-nav__label` (obscured). The `scroll-margin-bottom` (bottom-nav height + gutter + safe-area inset) reserves clearance so the same scroll now rests the button centre at y≈466, fully clear of the nav; `scroll-margin-top` clears the fixed progress bar for the scroll-up case.

## Verification

- `bundle exec jekyll build` — green; `scroll-margin-bottom` present in compiled `_site/assets/css/styles.css`.
- Reproduced the obscuring and confirmed the fix geometrically at the 320px viewport (bottom-aligned + top-aligned scroll cases both unobscured).
- Ran `tests/playwright-agents/interactive-elements.spec.ts` on the **Mobile Chrome** (320×568) project against the built site: **29/29 passed**, including the previously-failing `article share controls show visible focus and stay unobscured`. That existing 320px test is the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)