### PR TITLE
test(gap-d): guard content/markup quality on built HTML

### DIFF
--- a/scripts/validate-post-quality.sh
+++ b/scripts/validate-post-quality.sh
@@ -143,6 +143,24 @@ for post in $POSTS; do
     post_errors=$((post_errors + 1))
   fi
 
+  # ------------------------------------------------------------------
+  # 3b. image_caption length — credit budget (~40 chars)  [WARNING]
+  #
+  # _layouts/post.html renders `figcaption.image-credit` from image_caption
+  # (upcased). A hero credit should read like a short attribution, not a
+  # full letter-spaced ALL-CAPS sentence that wraps over several mobile lines
+  # (visual-audit defect #11). Soft-flag anything past a ~40-char credit
+  # budget so long descriptive captions get trimmed toward a real credit.
+  # ------------------------------------------------------------------
+  if [[ -n "$caption_clean" ]]; then
+    caption_len=${#caption_clean}
+    if [[ $caption_len -gt 40 ]]; then
+      echo "⚠️   $rel — image_caption is ${caption_len} chars (credit budget ~40); trim to a short attribution"
+      WARNINGS=$((WARNINGS + 1))
+      post_warnings=$((post_warnings + 1))
+    fi
+  fi
+
   if [[ -n "${image_abs:-}" && -f "${image_abs:-}" && "$image_abs" == *.svg ]]; then
     if grep -qi '<text[[:space:]>]' "$image_abs"; then
       echo "❌  $rel — SVG hero contains embedded text"
@@ -168,6 +186,27 @@ for post in $POSTS; do
       ERRORS=$((ERRORS + 1))
       post_errors=$((post_errors + 1))
     fi
+  fi
+
+  # ------------------------------------------------------------------
+  # 4b. Chart-"Source:" opener without a description override  [ERROR]
+  #
+  # Root cause of visual-audit defect #4/#5: a post body that opens with a
+  # markdown image immediately followed by an italic `*Source: …*` credit,
+  # before any prose paragraph. When such a post has no front-matter
+  # `description`, Jekyll's AUTO excerpt begins with "Source:", so every
+  # teaser card for it reads "Source: …" instead of a lede. A `description`
+  # overrides the auto-excerpt and neutralises the defect — so reject the
+  # opener only when there is nothing to override it.
+  # ------------------------------------------------------------------
+  first_body_line=$(body_content "$post" | grep -m1 '[^[:space:]]' || true)
+  second_body_line=$(body_content "$post" | grep '[^[:space:]]' | sed -n '2p' || true)
+  if [[ "$first_body_line" == '!['* ]] \
+     && echo "$second_body_line" | grep -Eqi '^\*[[:space:]]*source:' \
+     && [[ -z "$desc_clean" ]]; then
+    echo "❌  $rel — body opens with an image + '*Source:*' credit and has no description to override the auto-excerpt (teaser would lead with \"Source:\")"
+    ERRORS=$((ERRORS + 1))
+    post_errors=$((post_errors + 1))
   fi
 
   # ------------------------------------------------------------------

--- a/tests/playwright-agents/content-quality.spec.ts
+++ b/tests/playwright-agents/content-quality.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' });
+
+/**
+ * Gap D — content/markup-quality assertions on built HTML.
+ *
+ * See docs/agents/visual-audit-findings.md §3 "Gap D". The blocking specs
+ * historically checked structure/role/byline but never the *content* of the
+ * built markup: teaser text, <head> tag uniqueness, the newsletter allowlist,
+ * or raw-PNG usage where a WebP sibling exists. These four describe blocks
+ * guard the already-fixed defects (#4/#5, #3-metadata, #16, #8) so they cannot
+ * silently regress.
+ */
+
+// Listing surfaces that render post-teaser cards, with the excerpt selector
+// each surface uses. Home mixes a hero excerpt with topic cards.
+const LISTING_SURFACES: { name: string; path: string; excerptSelector: string }[] = [
+  { name: 'homepage', path: '/', excerptSelector: '.hero-post-excerpt, .topic-card-excerpt' },
+  { name: 'blog index', path: '/blog/', excerptSelector: '.econ-card-excerpt' },
+  { name: 'security topic', path: '/security/', excerptSelector: '.topic-card-excerpt' },
+  { name: 'software-engineering topic', path: '/software-engineering/', excerptSelector: '.topic-card-excerpt' },
+  { name: 'test-automation topic', path: '/test-automation/', excerptSelector: '.topic-card-excerpt' },
+];
+
+// ---------------------------------------------------------------------------
+// (a) No teaser lede reads "Source:" (defect #4/#5 — chart "Source:" caption
+//     leaking into the auto-excerpt). Teasers must prefer the human-written
+//     front-matter `description`.
+// ---------------------------------------------------------------------------
+test.describe('@content Teaser ledes never start with "Source:" @REQ-CONTENT-03', () => {
+  for (const { name, path, excerptSelector } of LISTING_SURFACES) {
+    test(`${name} (${path}) has no "Source:" teaser lede`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      const cards = page.locator(excerptSelector);
+      const count = await cards.count();
+      expect(count, `expected at least one teaser card on ${path}`).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const text = ((await cards.nth(i).textContent()) || '').trim();
+        expect(text, `teaser #${i} on ${path} leads with "Source:"`).not.toMatch(/^\s*source:/i);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (b) Exactly one <title>, canonical, and meta description per page type
+//     (defect #3 — hand-rolled <head> tags AND {% seo %} both firing). Uses
+//     toHaveCount(1) — never .first() — so a duplicate is a hard failure.
+// ---------------------------------------------------------------------------
+const HEAD_UNIQUENESS_PAGES: { label: string; path: string }[] = [
+  { label: 'Homepage', path: '/' },
+  { label: 'Blog index', path: '/blog/' },
+  { label: 'Category page', path: '/security/' },
+  { label: 'About', path: '/about/' },
+  { label: 'Search', path: '/search/' },
+  { label: 'Article', path: '/2026/01/02/self-healing-tests-myth-vs-reality/' },
+];
+
+test.describe('@content @seo <head> metadata is emitted exactly once @REQ-CONTENT-01', () => {
+  for (const { label, path } of HEAD_UNIQUENESS_PAGES) {
+    test(`${label} (${path}) emits one title/canonical/description`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response?.ok(), `${path} should load`).toBe(true);
+
+      await expect(page.locator('head title'), `${path}: exactly one <title>`).toHaveCount(1);
+      await expect(
+        page.locator('head link[rel="canonical"]'),
+        `${path}: exactly one canonical`,
+      ).toHaveCount(1);
+      await expect(
+        page.locator('head meta[name="description"]'),
+        `${path}: exactly one meta description`,
+      ).toHaveCount(1);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (c) Newsletter signup allowlist (defect #16). The `aside.newsletter-signup`
+//     CTA must appear on content-consumption surfaces and must be absent on the
+//     utility pages (/search/ and /404/) where it has no place.
+//
+//     NOTE: the intended allowlist also includes the blog index, category
+//     pages, and /about/, but the shared-layout fix that would place the CTA
+//     there has NOT yet landed on main (the include lives only in index.md and
+//     _layouts/post.html). Those cases are encoded as `test.fixme` below so the
+//     full contract is documented and flips green once #16 is fixed, without
+//     shipping a red required check today.
+// ---------------------------------------------------------------------------
+const NEWSLETTER = 'aside.newsletter-signup';
+
+const NEWSLETTER_PRESENT_VERIFIED: { label: string; path: string }[] = [
+  { label: 'Homepage', path: '/' },
+  { label: 'Article', path: '/2026/01/02/self-healing-tests-myth-vs-reality/' },
+];
+
+const NEWSLETTER_ABSENT: { label: string; path: string }[] = [
+  { label: 'Search', path: '/search/' },
+  { label: '404', path: '/404/' },
+];
+
+// Intended-present but pending the #16 shared-layout fix.
+const NEWSLETTER_PRESENT_PENDING: { label: string; path: string }[] = [
+  { label: 'Blog index', path: '/blog/' },
+  { label: 'Category page', path: '/security/' },
+  { label: 'About', path: '/about/' },
+];
+
+test.describe('@content Newsletter signup follows the page-type allowlist @REQ-CONTENT-04', () => {
+  for (const { label, path } of NEWSLETTER_PRESENT_VERIFIED) {
+    test(`${label} (${path}) renders the newsletter CTA`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.locator(NEWSLETTER), `${path} should render ${NEWSLETTER}`).toHaveCount(1);
+    });
+  }
+
+  for (const { label, path } of NEWSLETTER_ABSENT) {
+    test(`${label} (${path}) does not render the newsletter CTA`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.locator(NEWSLETTER), `${path} must not render ${NEWSLETTER}`).toHaveCount(0);
+    });
+  }
+
+  for (const { label, path } of NEWSLETTER_PRESENT_PENDING) {
+    test.fixme(`${label} (${path}) renders the newsletter CTA (pending #16 shared-layout fix)`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.locator(NEWSLETTER), `${path} should render ${NEWSLETTER}`).toHaveCount(1);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (d) No card/listing thumbnail is a raw <img> PNG when a WebP sibling exists
+//     (defect #8 — category cards bypassing the responsive-image WebP include).
+//     A PNG <img> nested inside a <picture> that offers a WebP <source> is the
+//     correct fallback and is allowed; only *raw* PNGs outside any <picture>
+//     that have a same-name .webp on disk are a regression.
+// ---------------------------------------------------------------------------
+const CARD_SURFACES = ['/', '/blog/', '/security/', '/software-engineering/', '/test-automation/'];
+
+test.describe('@content Listing thumbnails prefer WebP over raw PNG @REQ-CONTENT-02', () => {
+  for (const path of CARD_SURFACES) {
+    test(`${path} has no raw PNG <img> with a WebP sibling`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      // Collect PNG <img> sources that are NOT inside a <picture> element.
+      const rawPngSrcs = await page.$$eval('img', (imgs) =>
+        imgs
+          .filter((img) => !img.closest('picture'))
+          .map((img) => img.getAttribute('src') || '')
+          .filter((src) => /\.png(?:$|\?)/i.test(src)),
+      );
+
+      const withWebpSibling: string[] = [];
+      for (const src of rawPngSrcs) {
+        const webp = src.replace(/\.png(\?.*)?$/i, '.webp');
+        const res = await page.request.head(webp);
+        if (res.ok()) withWebpSibling.push(src);
+      }
+
+      expect(
+        withWebpSibling,
+        `${path}: these raw PNG <img> have a WebP sibling and must be routed through <picture>: ${withWebpSibling.join(', ')}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## What & why

Closes **Gap D** from `docs/agents/visual-audit-findings.md` §3 — "No content/markup-quality assertions on built HTML." The blocking suite checked structure/role/byline but never the *content* of the emitted markup, so the already-fixed content defects (#3 head metadata, #4/#5 "Source:" ledes, #8 raw-PNG cards, #11 caption length, #16 newsletter allowlist) could regress unnoticed. These are **regression guards**, not re-fixes.

## Changes

**`tests/playwright-agents/content-quality.spec.ts`** (new)
- **(a)** No teaser lede matches `/^\s*Source:/i` across `/`, `/blog/`, and all three category pages (defect #4/#5).
- **(b)** Exactly one `head title` / `link[rel=canonical]` / `meta[name=description]` per representative page type via `toHaveCount(1)` — never `.first()` (defect #3).
- **(c)** `aside.newsletter-signup` present on home + posts, absent on `/search/` and `/404/`. The intended presence on blog-index/category/about is encoded as `test.fixme` because the shared-layout move (defect #16) has **not** landed on `main` — this documents the full contract and flips green when #16 is fixed, without shipping a red required check today.
- **(d)** No raw `<img>` PNG *outside* a `<picture>` that has a WebP sibling, on the listing/card surfaces (defect #8). PNG `<img>` fallbacks inside `<picture>` are correct and allowed.

**`scripts/validate-post-quality.sh`** (extended; option parsing, output format, and 0/1/2 exit-code conventions unchanged)
- **ERROR:** body opens with an image immediately followed by an italic `*Source: …*` credit **and** the post has no front-matter `description` to override the auto-excerpt — the exact root cause of #4/#5. Dormant on current posts (all 13 image+`*Source:*` openers carry a description), fires on the regression.
- **WARNING:** `image_caption` longer than a ~40-char credit budget (defect #11).

## Verification

- `bundle exec jekyll build` — green.
- `bash scripts/validate-post-quality.sh` — exit 2 (non-blocking warnings), 0 errors, 24 caption-length warnings; confirmed the new ERROR fires on a throwaway fixture that opens with image+`*Source:*` and omits `description`, and stays silent once a description is present.
- Empirically confirmed against the built `_site`: 0 "Source:" ledes on all five listing pages; the only raw PNGs with WebP siblings are two inline *chart* images in post bodies (a separate charts concern), while all card/thumbnail surfaces are clean.
- `node_modules` absent in this worktree, so `npx playwright test --list` was not run (per instructions); spec authored to match existing specs (baseURL `http://localhost:4000`) and CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)