### PR TITLE
fix(orchestrator): only count genuine issue refs in duplicate detector

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -118,6 +118,45 @@ jobs:
             }
 
             // ─────────────────────────────────────────────────────────────────
+            // Extract GENUINE issue references from a PR body.
+            //
+            // A bare "#N" mid-sentence is almost always a defect-catalog
+            // reference (e.g. "fixes defect #8") — NOT a GitHub issue — so we
+            // must NOT treat it as one. Counting bare tokens caused the
+            // duplicate-detector to wrongly close unrelated PRs that happened to
+            // cite the same defect number.
+            //
+            // We only count a reference when it is unambiguously a GitHub issue:
+            //   1. A GitHub closing keyword immediately followed by "#N"
+            //      (Closes/Fixes/Resolves and their conjugations, case-insensitive)
+            //   2. A full GitHub issue/PR URL for this repo
+            //      (https://github.com/oviney/blog/issues/N or /pull/N)
+            // ─────────────────────────────────────────────────────────────────
+            function extractIssueRefs(body) {
+              const text = body ?? '';
+              const nums = new Set();
+
+              // 1. Closing keywords: close/closes/closed, fix/fixes/fixed,
+              //    resolve/resolves/resolved — optionally followed by a colon —
+              //    then "#N". "defect #8" has no keyword, so it is ignored.
+              const keywordRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+#(\d+)/gi;
+              for (const m of text.matchAll(keywordRe)) {
+                nums.add(parseInt(m[1], 10));
+              }
+
+              // 2. Full GitHub issue/PR URLs for THIS repo only.
+              const urlRe = new RegExp(
+                `https?://github\\.com/${context.repo.owner}/${context.repo.repo}/(?:issues|pull)/(\\d+)`,
+                'gi'
+              );
+              for (const m of text.matchAll(urlRe)) {
+                nums.add(parseInt(m[1], 10));
+              }
+
+              return [...nums];
+            }
+
+            // ─────────────────────────────────────────────────────────────────
             // 1. PR LIFECYCLE MANAGEMENT
             // ─────────────────────────────────────────────────────────────────
 
@@ -138,11 +177,12 @@ jobs:
                 activeCopilotDraftPRs++;
               }
 
-              // ── Build issue reference map (same-repo refs only) ─────────────
-              // Match bare #NNN references that are NOT preceded by a repo slug
-              // (e.g. "Closes #42" matches, "oviney/other-repo#42" does not).
-              const bodyIssueNums = [...(pr.body ?? '').matchAll(/(?<![/\w])#(\d+)/g)]
-                .map(m => parseInt(m[1], 10));
+              // ── Build issue reference map (genuine refs only) ───────────────
+              // Only count real GitHub issue references — closing keywords
+              // ("Closes #42") or full same-repo issue/PR URLs. A bare "#N"
+              // mid-sentence is a defect-catalog reference, not an issue ref,
+              // and must NOT drive duplicate detection or issue re-opening.
+              const bodyIssueNums = extractIssueRefs(pr.body);
               for (const n of bodyIssueNums) {
                 if (!issueRefMap[n]) issueRefMap[n] = [];
                 issueRefMap[n].push(pr);


### PR DESCRIPTION
## What & why

The CI Orchestrator's "Close duplicate PRs" logic (`.github/workflows/orchestrator.yml`)
built its `issueRefMap` by extracting **every** bare hash-number token from each PR
body and treating any two PRs that shared a token as duplicates of the same issue —
then auto-closing the one with fewer commits.

The problem: a bare hash-number token in a PR body is almost always a **defect-catalog
reference** (e.g. "fixes defect 8"), not a GitHub issue. On the last run this
mis-classification wrongly auto-closed **3 legitimate PRs** that merely happened to
cite the same defect number.

## Fix

`extractIssueRefs(body)` now counts a reference only when it is unambiguously a GitHub
issue:

1. **Closing keywords** — `Closes` / `Fixes` / `Resolves` (and their conjugations
   close/closed, fix/fixed, resolve/resolved), case-insensitive, immediately followed
   by the hash-number, e.g. `Closes #123`.
2. **Full same-repo URLs** — `https://github.com/oviney/blog/issues/N` or
   `https://github.com/oviney/blog/pull/N`.

A bare hash-number mid-sentence (like a defect reference, or "Related to ...") is now
ignored. Same-repo scoping means another repo's issue URL is also ignored.

### Before vs after

- Body `"fixes defect #8"` — **before:** counted as issue 8 → duplicate collision;
  **after:** ignored (no closing keyword).
- Body `"Closes #123"` — **before & after:** counted as issue 123.
- Body `"See https://github.com/oviney/blog/issues/321"` — **before:** not matched
  reliably; **after:** counted as issue 321.

The scoped extractor also feeds the stall-detection path that re-opens source issues,
so that path no longer re-opens defect-catalog numbers. All other orchestrator
behavior is unchanged.

## Verification

- 12-case Node test of the new regex (defect reference vs closing keyword vs full URL
  vs other-repo URL vs bare mid-sentence) — all pass.
- Embedded orchestrator script passes `node --check` after extraction.
- `orchestrator.yml` parses as valid YAML.
- No built site files touched, so a Jekyll build is not required for this
  governance-surface change.

Label: `governance-update` (this is a workflow/governance-surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
