### PR TITLE
feat: B-013 unlisted review-draft collection (noindex, no listings)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,12 @@ author:
       icon: "fab fa-fw fa-linkedin"
       url: "https://linkedin.com/in/ourayviney"
 
+# Unlisted review drafts (B-013) — kept out of listings, feed, and sitemap
+collections:
+  review:
+    output: true
+    permalink: /review/:name/
+
 # Defaults for posts
 defaults:
   - scope:
@@ -85,6 +91,18 @@ defaults:
       related: true
       toc: true
       toc_sticky: true
+  - scope:
+      path: ""
+      type: "review"
+    values:
+      layout: review
+      noindex: true
+      sitemap: false
+      author_profile: false
+      read_time: false
+      comments: false
+      share: false
+      related: false
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -1,0 +1,4 @@
+---
+layout: single
+---
+{{ content }}

--- a/robots.txt
+++ b/robots.txt
@@ -9,6 +9,7 @@ Disallow: /node_modules/
 Disallow: /.git/
 Disallow: /.github/
 Disallow: /docs/
+Disallow: /review/
 
 # Sitemap location
 Sitemap: https://www.viney.ca/sitemap.xml


### PR DESCRIPTION
Blog-side half of **B-013 · live unlisted draft review**. The economist-agents side is already merged (`deploy_to_blog --mode review` + `promote_review.py` / `make publish`).

## What this adds

- **`review` collection** in `_config.yml` — `output: true`, `permalink: /review/:name/`. A separate collection is **not** in `site.posts`, so it never appears on the homepage, archives, or category/tag/author pages.
- **Defaults for the collection** — `noindex: true` (your `_layouts/default.html` already emits `<meta name="robots" content="noindex, nofollow">` from `page.noindex`, so this just activates existing plumbing), `sitemap: false` (jekyll-sitemap honours it → dropped from `sitemap.xml`), and author_profile / read_time / comments / share / related off.
- **`_layouts/review.html`** — thin wrapper over the theme's `single` layout.
- **`robots.txt`** — `Disallow: /review/`.

18 added lines in `_config.yml`, 1 in `robots.txt`, 1 new 4-line layout. No existing config touched; YAML validated.

## After merge — the leak test (acceptance gate)

From economist-agents, deploy one draft with `--host www.viney.ca`, wait for the Pages rebuild, then confirm it appears in **none** of: homepage, `/blog/`, archives, `feed.xml`, `sitemap.xml`, search — and that view-source shows `noindex`. Full checklist: `docs/specs/B-013-blog-side.md`.

Merging this does not publish anything to readers — the collection is unlisted by construction; it just enables the review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
