### PR TITLE
docs(ci): correct baseline-seeding steps and finish the setup-node bump

### DIFF
--- a/.github/actions/setup-node-with-puppeteer-cache/action.yml
+++ b/.github/actions/setup-node-with-puppeteer-cache/action.yml
@@ -1,6 +1,6 @@
 name: 'Setup Node with Puppeteer Cache'
 description: >
-  Sets up Node via actions/setup-node@v6, caches puppeteer's Chrome download
+  Sets up Node via actions/setup-node@v7, caches puppeteer's Chrome download
   directory (~/.cache/puppeteer/), and runs `npm ci` with a 3-attempt retry
   loop to tolerate transient CDN failures from puppeteer's post-install
   Chrome downloader. See issue #958 for the flake history that motivated
@@ -22,7 +22,7 @@ runs:
     # 1. Standard Node setup with npm cache (unchanged behaviour from prior
     # inline pattern). cache: 'npm' keys on package-lock.json automatically.
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.npm-cache }}

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -64,7 +64,9 @@ npm run test:security        # Security audit (npm audit)
 
 Visual regression uses Playwright's `toHaveScreenshot` (`tests/playwright-agents/visual-snapshot.spec.ts`), compared against committed `*-Chrome-linux.png` baselines under `tests/playwright-agents/visual-snapshot.spec.ts-snapshots/`. The blocking "🖼️ Visual Regression" CI job runs `npm run test:visual:snap` on every push and PR.
 
-Because baselines are pinned to the Linux CI renderer, seed or refresh them via CI rather than locally: trigger the **Quality Tests** workflow (`.github/workflows/test-quality.yml`) with `workflow_dispatch` and `update_snapshots=true`, download the `visual-snapshots` artifact, and commit it under the snapshots directory. To preview a diff locally you can run `npm run test:visual:snap` (or `npm run test:visual:snap:update` to regenerate your local screenshots).
+Because baselines are pinned to the Linux CI renderer, seed or refresh them via CI rather than locally: trigger the **Quality Tests** workflow (`.github/workflows/test-quality.yml`) with `workflow_dispatch` and `update_snapshots=true` **on your branch**. The job renders the pages and commits the refreshed PNGs straight back to that branch — there is no artifact to download or commit by hand. (A `visual-snapshots` artifact is still uploaded, but only for inspection.) Seeding on `main` is refused, so baselines get reviewed on a branch before they become the reference every later PR is judged against.
+
+Do not regenerate baselines on macOS or Windows. They are committed as `-linux` PNGs, and cross-platform anti-aliasing differences would make the gate permanently flaky — the failure mode that made BackstopJS non-blocking in the first place. `npm run test:visual:snap` compares against the committed baselines locally and is safe to run anywhere; it self-skips off Linux.
 
 ## Pre-commit Hook
 


### PR DESCRIPTION
## Summary

Two loose ends from the PR-queue cleanup, both found while reviewing #1136 and #1150 against the repo's 5-axis framework. Each was flagged at review time as a follow-up rather than a merge blocker.

**Baseline-seeding instructions were stale on arrival.** #1136 rewrote the `GETTING_STARTED.md` seeding section to describe the `workflow_dispatch` + artifact flow — accurate when it was written on 2026-07-08, but superseded by #1160 an hour before it merged. Seed mode now commits refreshed PNGs to the dispatched branch from the same checkout that rendered them, so there is no artifact to download or commit by hand. The section now says to dispatch **on a branch**, notes that seeding on `main` is refused, and carries the macOS/Windows warning that previously lived only in the spec's docblock where contributors were unlikely to find it.

**The setup-node bump was incomplete.** #1150 moved `actions/setup-node` v6 → v7 across seven workflows but missed `.github/actions/setup-node-with-puppeteer-cache/action.yml` — Dependabot does not scan composite actions. That action is what the Quality Tests workflow uses for *every* Node setup, so it was the single remaining v6 pin, and Dependabot would never have raised it. `grep -rn "setup-node@v6" .github/` now returns nothing.

## Agent Checklist

- [x] **Scope**: One docs file, one composite action. No theme, content, or config changes
- [x] **Build**: `bundle exec jekyll build` passes
- [x] **No broken links**: No link changes; the referenced workflow path is verified to exist
- [x] **Skill file consulted**: Reviewed under `.github/skills/code-review` (5-axis); both items were recorded there as follow-ups
- [x] **No out-of-scope changes**: `scripts/check-pr-scope.sh` PASSES — no protected files
- [x] **Conventions followed**: `action.yml` parses as valid YAML; prose matches the surrounding doc voice

## Files Changed

| File | Why |
|------|-----|
| `GETTING_STARTED.md` | Seeding steps now match the automated flow from #1160; adds the `-linux` platform warning |
| `.github/actions/setup-node-with-puppeteer-cache/action.yml` | `setup-node` v6 → v7 (both the `uses:` pin and the description) |

## How to Verify

1. `grep -rn "setup-node@v6" .github/` → no matches.
2. The composite action still parses: `node -e "require('js-yaml').load(require('fs').readFileSync('.github/actions/setup-node-with-puppeteer-cache/action.yml','utf8'))"` → no error.
3. Every CI job that sets up Node exercises the bumped action, so a green run on this PR is the real check.
4. `GETTING_STARTED.md` no longer mentions downloading the `visual-snapshots` artifact as a required step.

## Related

Follow-up to #1136 and #1150. Separately, #1138 still needs `listing: true` on its three category-page scenarios before it can go green — details in [my review there](https://github.com/oviney/blog/pull/1138#issuecomment-5078043945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017FKDTEaoUUN2KCUoAhERGA)_