### PR TITLE
fix(security): remediate brace-expansion advisory, unblock the PR queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1633,9 +1633,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/npm-audit-allowlist.json
+++ b/scripts/npm-audit-allowlist.json
@@ -1,12 +1,4 @@
 {
   "$comment": "Advisories consciously accepted by the 🔒 Security Audit gate. Every entry needs a reason and a reviewBy date; check-npm-audit.js fails once an entry expires or stops matching a live advisory, so exceptions cannot rot silently.",
-  "allow": [
-    {
-      "id": 1124334,
-      "package": "brace-expansion",
-      "title": "DoS via unbounded expansion length causing an out-of-memory process crash",
-      "reason": "Reaches us only through pa11y-ci 4.1.1 -> globby 6 -> glob 7 -> minimatch 3. The advisory is patched solely in brace-expansion 5.0.8, which exports { expand } instead of the bare function minimatch 3 calls, so forcing it breaks the accessibility gate at runtime. npm's own remedy downgrades pa11y-ci to 1.2.0, a three-major regression. This repo ships no runtime npm code (package.json dependencies is empty) and pa11y-ci only ever globs our own committed config, so no untrusted pattern reaches the parser.",
-      "reviewBy": "2026-10-31"
-    }
-  ]
+  "allow": []
 }


### PR DESCRIPTION
## What & why

**The 🔒 Security Audit gate is currently red on every open PR.** Discovered while rebasing #1162 onto current `main` — a check that was green on 2026-07-26 now fails, with no change to the PR itself.

GHSA-mh99-v99m-4gvg re-issued the `brace-expansion` DoS advisory as npm ID **1130588**, retiring **1124334**. `scripts/check-npm-audit.js` fails twice over as a result:

```
[security] Allowlist entries need attention:
- brace-expansion #1124334: advisory no longer reported — remove this entry
[security] 1 advisory/advisories at or above "moderate" with no exception:
- [high] brace-expansion #1130588: DoS via unbounded expansion length ...
```

Both failure modes are working as designed — the allowlist is correctly refusing to outlive its rationale.

## The advisory was re-scoped, not just renumbered

This is the part that changes the remedy. The new advisory's vulnerable range is **`<1.1.17`** — upstream **backported the fix to the 1.x line**. The retired exception's whole justification was that no such fix existed:

> The advisory is patched solely in brace-expansion 5.0.8, which exports `{ expand }` instead of the bare function minimatch 3 calls, so forcing it breaks the accessibility gate at runtime.

`brace-expansion@1.1.18` still ships `module.exports = expandTop`. The incompatibility that forced the exception is gone, so this PR **remediates** instead of re-pointing the exception at the new ID.

## Changes (2 files)

1. **`package-lock.json`** — `npm audit fix --package-lock-only` moves the hoisted copy `1.1.16` → `1.1.18`. No direct dependency changes; `package.json` untouched.
2. **`scripts/npm-audit-allowlist.json`** — the entry is **deleted**, not updated. `allow` is now empty; there is no longer anything to consciously accept.

## Verification

All run after a clean `npm ci`:

- `node scripts/check-npm-audit.js` → `[security] No unreviewed advisories at or above "moderate".`, exit 0
- `npm audit` → `found 0 vulnerabilities`
- `require('brace-expansion')` → `typeof function`; `a{b,c}d` → `["abd","acd"]` (bare-function export preserved)
- minimatch 3 matching still correct on the pa11y-ci dependency path
- `require('pa11y-ci')` loads clean — **the accessibility gate is not broken**, which was the original reason for the exception
- `bundle exec jekyll build` succeeds

## Merge order

This should land **first**. #1162 and #1138 both carry the same red Security Audit check and will go green once they rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)