### PR TITLE
docs(backlog): reconcile the local queue with six weeks of untracked work

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,7 +1,13 @@
 # Backlog — viney.ca blog
 
 The **local work queue for in-session / interactive Claude Code work**. This file
-is the source of truth a `/goal` "pull the highest-priority task" loop reads.
+is the source of truth for a "pull the highest-priority task" session — read it
+first, take the top **Active** row, run it through `spec → plan → build → ship`.
+
+> There is no `/goal` skill in this repo. Earlier wording here implied one; the
+> loop is the convention described under **How to use**, driven by the callable
+> lifecycle skills in `.claude/commands/` (`/spec`, `/plan`, `/build`, `/test`,
+> `/review`, `/ship`).
 
 ## Why a local file (not GitHub Issues)
 
@@ -35,9 +41,20 @@ duplicate the queue.
 > policy) and **P5** (memory-guard rephrasing-hardening) were **cut** as low-value —
 > match complexity to scale. The lone survivor (Rule 4 anchor) shipped in #1064.
 
+> **Epic — Visual-quality gate hardening** — **Gaps A, C, D, E shipped; Gap B in review.**
+> Driven by [`docs/agents/visual-quality-review.goal.md`](agents/visual-quality-review.goal.md)
+> and the 20-defect Phase-0 catalog in [`docs/agents/visual-audit-findings.md`](agents/visual-audit-findings.md).
+> This epic was never tracked here — it ran entirely through GitHub Issues/PRs
+> while this file read "Active queue drained." Recorded now so the local queue
+> reflects reality. Gap B (#1138) is the last open gap.
+
 | Pri | Task | Scope / label | Status | Ref |
 |----|------|---------------|--------|-----|
-| _(none)_ | Active queue drained. | | | |
+| P2 | Decouple category visual baselines from post publication — full-page `toHaveScreenshot` on `/security/`, `/software-engineering/`, `/test-automation/` re-baselines on **every** publish, so the gate bills a rebaseline as the price of shipping content. Clip to header + first grid row, or mask the card grid. | `agent:qa-gatekeeper` | Not started — surfaced by the #1138 failure | — |
+| P3 | Refresh `.github/skills/code-review/SKILL.md` and `.github/skills/economist-theme/SKILL.md` (>90-day staleness clock). One PR, `governance-update` label. | `governance-update` | Not started | [#1140](https://github.com/oviney/blog/issues/1140), [#1142](https://github.com/oviney/blog/issues/1142), [#1166](https://github.com/oviney/blog/issues/1166) |
+| P3 | ADR: adopt / defer / hybrid on `.github/agents/*.agent.md` native custom agents vs `agent:*` label routing. Decision only — avoid two competing routing systems. | `governance-update` | Not started | [#1110](https://github.com/oviney/blog/issues/1110) |
+| — | Real newsletter signup (BLOG-005). **Blocked:** `ROADMAP.md:71` lists email subscription as Out of Scope; owner must move it in-scope first. | `enhancement` | Blocked on owner decision | [#1063](https://github.com/oviney/blog/issues/1063) |
+| — | Publish decision on `_review/review-queue-throughput-tax-42d2fbb4.md`. Assets present; carries the same B-017 slop tells cleared from the flaky-tests post in #1168 (2 spaced em-dashes, one "not merely", 4 doubled blank lines after headings). | `agent:editorial-chief` | Awaiting editorial review | — |
 
 ---
 
@@ -45,7 +62,16 @@ duplicate the queue.
 
 | Task | PR | Gate |
 |------|----|------|
-| _(none)_ | | |
+| Remediate the `brace-expansion` advisory; drop the allowlist exception | [#1170](https://github.com/oviney/blog/pull/1170) | Merge — **land first**, it unreds the 🔒 Security Audit check on every other open PR |
+| Bump `@playwright/test` 1.61.1 → 1.62.0 | [#1162](https://github.com/oviney/blog/pull/1162) | Merge — rebase onto #1170 first |
+| Close Gap B — visual coverage for uncovered page types | [#1138](https://github.com/oviney/blog/pull/1138) | Merge — needs a rebase onto #1170 + #1162, then a baseline re-seed (see note below) |
+| Refresh agent observability dashboard data | [#1167](https://github.com/oviney/blog/pull/1167) | Merge — automated data refresh, no checks configured |
+
+> **Gap B (#1138) sequencing.** Its two red category baselines are stale by 23px
+> because the flaky-tests post published into those categories on 2026-07-24,
+> after the baselines were seeded. Re-seed **after** #1162 lands — Playwright
+> 1.62 ships a newer bundled Chromium, so seeding first would only force a
+> second re-seed.
 
 ---
 
@@ -53,6 +79,12 @@ duplicate the queue.
 
 | Task | Resolution | Date |
 |------|------------|------|
+| Visual epic Gap A — no blocking pixel gate existed at all | [#1119](https://github.com/oviney/blog/pull/1119) merged — blocking Playwright `toHaveScreenshot` gate at 3 viewports; BackstopJS retired (contributor docs followed in [#1136](https://github.com/oviney/blog/pull/1136)) | 2026-07-02 |
+| Visual epic Gap E — container width never asserted against its design token | [#1131](https://github.com/oviney/blog/pull/1131) merged — listing width asserted against the 1040px token | 2026-07-01 |
+| Visual epic Gap D — no content/markup-quality assertions on built HTML | [#1130](https://github.com/oviney/blog/pull/1130) merged | 2026-07-01 |
+| Visual epic Gap C — no viewport-overflow assertion anywhere | [#1122](https://github.com/oviney/blog/pull/1122) merged — 320/390px overflow guard; fixed the live dashboard sideways-scroll | 2026-06-30 |
+| Visual epic — Phase-0 defect catalog (20 confirmed defects) | [#1094](https://github.com/oviney/blog/pull/1094) merged; individual fixes in #1097, #1098, #1102, #1103, #1104, #1123, #1125, #1132 | 2026-06-27 |
+| Handoff Packet convention in `AGENTS.md` | [#1137](https://github.com/oviney/blog/pull/1137) merged; issue [#1109](https://github.com/oviney/blog/issues/1109) closed as stale-open 2026-07-31 | 2026-07-13 |
 | Anchor Rule 4 agent-label detection (epic P1b) | [#1064](https://github.com/oviney/blog/pull/1064) merged — three Rule 4 branches moved to `has_label()`; scope-guard Cases J/K pin canonical + substring-superset behaviour | 2026-06-14 |
 | Post editorial-quality promoted to a CI merge gate (epic P3) | [#1050](https://github.com/oviney/blog/pull/1050) merged — errors block, warnings advisory; 24/24 posts clean at gate-on | 2026-06-13 |
 | Agent-quality rubric enforced in agent-eval workflow (epic P2) | [#1049](https://github.com/oviney/blog/pull/1049) merged — scorecard comment + hard gate on scope/coverage/churn | 2026-06-13 |


### PR DESCRIPTION
## What & why

`docs/BACKLOG.md` reads **"Active queue drained"** while the visual-quality gate epic ran to near-completion entirely through GitHub Issues and PRs. Any session that trusted this file as the local work queue — which is its whole stated purpose, per its own header — would have concluded there was nothing to do. Reconciled against `main` @ `59af4c3`.

## Changes (1 file, `docs/BACKLOG.md`)

**Records the visual-quality epic.** Gaps A (#1119), C (#1122), D (#1130) and E (#1131) move to *Recently shipped*, alongside the Phase-0 catalog (#1094) and its eight individual defect fixes (#1097, #1098, #1102, #1103, #1104, #1123, #1125, #1132). Gap B (#1138) is the one remaining open gap.

**Populates "In review"** with the four open PRs and — importantly — the order they must land in:

| PR | Note |
|----|------|
| #1170 | **Land first** — unreds the 🔒 Security Audit check on every other open PR |
| #1162 | Rebase onto #1170 |
| #1138 | Rebase onto #1170 + #1162, then re-seed baselines |
| #1167 | Automated data refresh, no checks configured |

**Files the follow-up that #1138's failure exposed.** Full-page `toHaveScreenshot` on the three category pages re-baselines on *every* post publication — #1138 went red purely because the flaky-tests post published into those categories on 2026-07-24. The gate currently bills a rebaseline as the price of shipping content. Logged as P2 with two candidate fixes (clip to header + first grid row, or mask the card grid).

**Carries forward live issue-backed work** — #1140/#1142/#1166 (skill staleness, one PR) and #1110 (routing ADR) — and marks #1063 explicitly **blocked** on the `ROADMAP.md:71` out-of-scope decision rather than leaving it to look actionable.

**Notes the pending review draft** `_review/review-queue-throughput-tax-42d2fbb4.md` and the B-017 slop tells it still carries (2 spaced em-dashes, one "not merely", 4 doubled blank lines after headings) — the same class cleared from the flaky-tests post in #1168.

**Drops the `/goal` skill reference.** No such skill exists in this repo — `.claude/commands/` has `spec`, `plan`, `build`, `test`, `review`, `ship`, `code-simplify` and nothing else. The header now describes the convention instead of implying a callable command.

## Verification

- `bundle exec jekyll build` — succeeds
- `scripts/check-pr-scope.sh` — clean (single doc file, no protected paths, no forbidden zones)
- Every PR/issue number cross-checked against `gh` before being written down

## Scope note

Docs-only, one file. No `governance-update` or `protected-file-update` label needed — `docs/BACKLOG.md` is neither a protected file nor under `.github/skills/` or `.github/instructions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)