### PR TITLE
docs(skills): correct real drift in the two >90-day-stale skill files

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: '5-axis code review framework for all agents. Use when reviewing PRs, evaluating code quality, or providing structured review feedback.'
-version: 1.0.0
+version: 1.1.0
 triggers:
   - Reviewing a pull request
   - Evaluating code quality
@@ -30,11 +30,13 @@ Does the code do what it claims to do?
 - [ ] No regressions introduced to existing behaviour
 - [ ] Error handling is present and appropriate
 - [ ] Build passes (`bundle exec jekyll build`)
+- [ ] Merge-blocking gates are green — 🖼️ Visual Regression, 🔒 Security Audit, 📝 Content Validation, and the Playwright shards all block merge
 
 **Common issues in this repo:**
 - Liquid template errors from malformed YAML front matter
 - Broken internal links after renaming or moving files
 - Missing image assets referenced in post front matter
+- A red 🖼️ Visual Regression check treated as a flake. Since #1119 the pixel gate is blocking and usually correct: either the change altered rendering (re-seed baselines in CI via `test-quality.yml` `workflow_dispatch` with `update_snapshots=true`) or it caught a real regression. Read the diff artefact before dismissing it.
 
 ### Axis 2 — Readability
 
@@ -57,9 +59,20 @@ Does the change fit the system's structure?
 
 - [ ] Change is in the correct file/directory for its domain
 - [ ] No scope creep — only files related to the issue are modified
-- [ ] Protected files are not touched (`_config.yml`, `Gemfile`, `.github/CODEOWNERS`)
+- [ ] Protected files are not touched — the full list is `_config.yml`, `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `Gemfile`, `Gemfile.lock`
+- [ ] Any deliberate-intent label is justified in the PR description, not just applied (see table below)
 - [ ] Agent scope rules are respected (see `AGENTS.md`)
 - [ ] No new dependencies without explicit justification
+
+**Label bypasses — verify intent, because the scope guard cannot.** `scripts/check-pr-scope.sh` honours three labels that relax its rules. The guard has no way to detect misuse, so confirming the bypass is warranted is a reviewer responsibility:
+
+| Label | Relaxes | Reject when |
+|-------|---------|-------------|
+| `governance-update` | Deliberate `.github/skills/` or `.github/instructions/` changes | Applied to an incidental drive-by edit |
+| `bulk-content` | Rule 2, the 15-file scope-explosion cap | Used to avoid splitting unrelated changes, or on any refactor — refactors should be incremental |
+| `protected-file-update` | Rule 1, **for `AGENTS.md` and `ARCHITECTURE.md` only** | Applied to any other protected file (it has no effect there), or without a tracked issue behind it |
+
+Combining `bulk-content` with `governance-update` is allowed but **requires explicit justification in the PR description** naming why both bypasses are needed together. Reject the PR if that justification is missing.
 
 **Common issues in this repo:**
 - Editing files outside the assigned agent's scope
@@ -177,4 +190,5 @@ Use this template when writing a review:
 
 ## Version History
 
+- **1.1.0** (2026-07-31): Completed the protected-file list (was missing `Gemfile.lock` and `.github/copilot-instructions.md`); documented the three scope-guard label bypasses and the reviewer's duty to verify intent; added the blocking CI gates to the Correctness axis
 - **1.0.0** (2026-04-12): Initial skill creation — 5-axis review framework adapted from addyosmani/agent-skills

--- a/.github/skills/economist-theme/SKILL.md
+++ b/.github/skills/economist-theme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: economist-theme
 description: 'Design system for The Economist visual style. Use when modifying CSS, SCSS, layouts, responsive design, typography, or UI components.'
-version: 1.2.0
+version: 1.3.0
 triggers:
   - Adding new styles or components
   - Modifying existing SCSS
@@ -12,7 +12,7 @@ triggers:
 
 ## Context
 
-This blog uses a custom theme inspired by The Economist's visual identity. The design system is implemented in `_sass/economist-theme.scss` (600+ lines) and follows The Economist's editorial standards:
+This blog uses a custom theme inspired by The Economist's visual identity. The design system is implemented in `_sass/economist-theme.scss` and follows The Economist's editorial standards:
 
 **Core Principles**:
 - Clean, readable typography with generous whitespace
@@ -145,6 +145,15 @@ $spacing-unit: 16px;
 4. Test responsive: resize browser to 320px, 768px, 1024px
 5. Check browser console for errors
 6. Verify no visual regressions on other pages
+
+**The pixel gate is blocking — plan for it.** Since #1119, `tests/playwright-agents/visual-snapshot.spec.ts` asserts `toHaveScreenshot` against committed baselines at Mobile (320), Tablet (768) and Desktop (1920) Chromium, and the 🖼️ Visual Regression check **fails the merge** on any diff. BackstopJS was retired in the same PR; `backstop.json` no longer exists.
+
+Consequences for any SCSS change that alters rendering:
+
+- Expect the gate to go red. That is the gate working, not a flake — read the diff artefact before assuming otherwise.
+- Baselines are committed per-platform as `*-linux.png`. They must be re-seeded **in CI**, not locally: run the `test-quality.yml` workflow via `workflow_dispatch` with `update_snapshots=true` on your branch. A macOS-generated baseline will not match the Linux runner, and the specs self-skip off Linux by design.
+- Re-seed **after** rebasing onto the latest `main`. A newer bundled Chromium or newly published content shifts page height, so seeding before a rebase only forces a second re-seed.
+- Baseline commits are bulky. Keep them in their own commit, separate from the SCSS fix, so the diff stays reviewable.
 
 ## Common Pitfalls
 
@@ -354,7 +363,7 @@ assets/images/blog-default.svg
 
 ## Related Files
 
-- [`_sass/economist-theme.scss`](../../../_sass/economist-theme.scss) - Main theme file (600+ lines)
+- [`_sass/economist-theme.scss`](../../../_sass/economist-theme.scss) - Main theme file
 - [`_layouts/default.html`](../../../_layouts/default.html) - Base layout
 - [`_layouts/post.html`](../../../_layouts/post.html) - Article layout
 - [`docs/CURRENT_STATE.md`](../../../docs/CURRENT_STATE.md) - Theme implementation history
@@ -374,5 +383,7 @@ assets/images/blog-default.svg
 
 ## Version History
 
+- **1.3.0** (2026-07-31): Documented the blocking `toHaveScreenshot` pixel gate and its CI-only baseline re-seed procedure (BackstopJS retired in #1119); dropped the stale "600+ lines" claim about the theme file, which had grown to ~3,500 lines
+- **1.2.0** (2026-04-26): Version bumped in front matter without a history entry — recorded here retrospectively; original change not documented
 - **1.1.0** (2026-01-05): Added Economist date format patterns (ordinal suffixes), image fallback strategy, default blog-default.svg asset documentation
 - **1.0.0** (2026-01-05): Initial skill creation from README.md and AI_CODING_GUIDELINES.md


### PR DESCRIPTION
> Supersedes #1172, which GitHub auto-closed during a rebase onto the post-#1170 `main` and refused to reopen (its old head SHA was no longer reachable). Same branch, same single commit, now rebased onto `main` @ #1167. No content change.

## What & why

Closes the staleness triage in #1140, #1142 and #1166. Those issues asked for a review "even if no content changes are needed" — implying a clock reset. Both files turned out to carry **substantive inaccuracies**, so this is a correction, not a touch-to-reset commit.

## `code-review/SKILL.md` (1.0.0 → 1.1.0)

**The protected-file list was incomplete — this is the one that mattered.** The Architecture axis listed three files; `scripts/check-pr-scope.sh` enforces five. A reviewer working the checklist would have waved through changes to **`Gemfile.lock`** and **`.github/copilot-instructions.md`**. The list now matches `PROTECTED_FILES` exactly.

**Added the label-bypass table.** `CLAUDE.md` says the scope guard cannot detect misuse of `governance-update` / `bulk-content` / `protected-file-update` and that reviewers must catch it — but the review skill never told reviewers that. Now documented with reject criteria per label, including that `protected-file-update` is per-file for `AGENTS.md` / `ARCHITECTURE.md` only.

**Correctness axis** now names the merge-blocking gates, and lists "treating a red 🖼️ Visual Regression as a flake" as a common repo mistake.

## `economist-theme/SKILL.md` (1.2.0 → 1.3.0)

**"Testing Visual Changes" was pre-#1119.** It described a purely manual routine — serve, eyeball, resize — and never mentioned that the pixel gate is now blocking. A creative-director agent following it would not know that an SCSS change must clear `toHaveScreenshot`, that baselines are seeded **in CI only** via `test-quality.yml` `workflow_dispatch` (locally-generated ones can't match the Linux runner, and the specs self-skip off Linux), or that re-seeding belongs *after* a rebase.

**Dropped the "600+ lines" claim** about `_sass/economist-theme.scss`, stated twice. The file is **3,475 lines**. Removed rather than re-counted, so it cannot rot again.

**Version-history gap**: front matter said `1.2.0` while the history stopped at `1.1.0`. Recorded rather than silently skipped.

## Verification

- `bundle exec jekyll build` — succeeds
- Every repo-relative path referenced by both skills resolves
- The protected-file list and label→rule mappings were **read back off `scripts/check-pr-scope.sh`**, not written from memory
- Scope guard exercised both ways: `PR_LABELS=""` → `FAILED — 1 violation` (Rule 3, as expected); `PR_LABELS="governance-update"` → `PASSED`

## Scope note

Carries `governance-update` per CLAUDE.md — deliberate governance-surface work driven by three tracked triage issues.

Closes #1140
Closes #1142
Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)