### PR TITLE
fix(qa): repair the five failures the non-blocking Playwright gate was hiding

### DIFF
--- a/dashboard/agents.html
+++ b/dashboard/agents.html
@@ -136,7 +136,13 @@ sitemap: false
       letter-spacing: .5px;
       margin-bottom: 16px;
     }
-    .chart-wrap { position: relative; height: 220px; }
+    /* Chart.js sizes the canvas from its parent, but with no width constraint
+       of its own the canvas could still render wider than the card and push the
+       page sideways at 320px (canvas#chart-content-dist measured right=344px
+       against a 320px viewport). min-width:0 on .chart-card alone was not
+       enough — the wrapper and canvas need their own ceiling. */
+    .chart-wrap { position: relative; height: 220px; width: 100%; min-width: 0; }
+    .chart-wrap canvas { display: block; max-width: 100%; }
     /* ── Tables ─────────────────────────────────────────────── */
     /* Let wide data tables scroll inside their own box instead of pushing the
        whole page sideways on phones (Gap C, defect P3 #13). */

--- a/tests/playwright-agents/content-quality.spec.ts
+++ b/tests/playwright-agents/content-quality.spec.ts
@@ -17,7 +17,11 @@ test.use({ baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4000' }
 // each surface uses. Home mixes a hero excerpt with topic cards.
 const LISTING_SURFACES: { name: string; path: string; excerptSelector: string }[] = [
   { name: 'homepage', path: '/', excerptSelector: '.hero-post-excerpt, .topic-card-excerpt' },
-  { name: 'blog index', path: '/blog/', excerptSelector: '.econ-card-excerpt' },
+  // #1123 extracted the canonical post-card include, so /blog/ renders
+  // .topic-card-excerpt like every other listing surface. The old
+  // .econ-card-excerpt selector matched nothing, and the test failed on its own
+  // "expected at least one teaser card" guard rather than on teaser content.
+  { name: 'blog index', path: '/blog/', excerptSelector: '.topic-card-excerpt' },
   { name: 'security topic', path: '/security/', excerptSelector: '.topic-card-excerpt' },
   { name: 'software-engineering topic', path: '/software-engineering/', excerptSelector: '.topic-card-excerpt' },
   { name: 'test-automation topic', path: '/test-automation/', excerptSelector: '.topic-card-excerpt' },

--- a/tests/playwright-agents/navigation.spec.ts
+++ b/tests/playwright-agents/navigation.spec.ts
@@ -179,7 +179,11 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
     await expect(page.locator('.article-title')).toHaveCount(1);
     await expect(page.locator('.article-chart img')).toBeVisible();
     await expect(page.locator('.article-hero-image img')).toHaveAttribute('src', /understanding-qa-qc-quality-engineering-hero\.svg/);
-    await expect(page.locator('.article-hero-image .image-credit')).toContainText('ILLUSTRATION: WHEN QUALITY OWNERSHIP TANGLES');
+    // #1103 dropped the `| upcase` filter so hero captions render in the case
+    // the author wrote (the audit flagged all-caps captions as a P2 defect).
+    // Assert case-insensitively so this pins the caption text, not its casing.
+    await expect(page.locator('.article-hero-image .image-credit'))
+      .toContainText(/illustration: when quality ownership tangles/i);
 
     const articleHeadings = page.locator('article.economist-article h1');
     await expect(articleHeadings).toHaveCount(1);
@@ -397,14 +401,29 @@ test.describe('@navigation Post-page Taxonomy & Recommendations @REQ-NAV-01', ()
       if (href) hrefs.push(href);
     }
 
+    // Posts may carry several categories (the flaky-tests post is both Software
+    // Engineering and Quality Engineering), but the article page renders only
+    // the primary one. Asserting the rendered label equals the rail's category
+    // therefore fails on any legitimately multi-category post.
+    //
+    // The real invariant is membership: every post in the "More from Software
+    // Engineering" rail must appear on the Software Engineering category page.
+    // Check that instead — it survives multi-category posts and still catches a
+    // rail leaking genuinely unrelated content.
+    await page.goto('/software-engineering/');
+    await page.waitForLoadState('networkidle');
+    const categoryHrefs = await page
+      .locator('.topic-card a[href], article h3 a[href]')
+      .evaluateAll((links) =>
+        links.map((a) => new URL((a as HTMLAnchorElement).href).pathname)
+      );
+
     for (const href of hrefs) {
-      await page.goto(href);
-      await page.waitForLoadState('networkidle');
-      const sectionLink = page.locator('.article-section-line .section-link');
-      if (await sectionLink.count() > 0) {
-        const catText = (await sectionLink.first().textContent())?.trim();
-        expect(catText, `linked post at ${href} should be Software Engineering`).toBe('Software Engineering');
-      }
+      const path = new URL(href, 'http://localhost:4000').pathname;
+      expect(
+        categoryHrefs,
+        `post ${path} appears in the "More from Software Engineering" rail but not on /software-engineering/`
+      ).toContain(path);
     }
   });
 
@@ -419,7 +438,10 @@ test.describe('@navigation Mobile Navigation Specific Tests @REQ-NAV-01 @REQ-NAV
     await page.waitForLoadState('networkidle');
 
     // JS should have added js-nav-enabled class (progressive enhancement)
-    const hasJsClass = await page.evaluate(() => document.body.classList.contains('js-nav-enabled'));
+    // `js-nav-enabled` is set on the document element (see _layouts/default.html),
+    // not on <body> — the `.js-nav-enabled.nav-open` selector depends on both
+    // classes living on the same element.
+    const hasJsClass = await page.evaluate(() => document.documentElement.classList.contains('js-nav-enabled'));
     expect(hasJsClass).toBe(true);
 
     // Hamburger toggle button should be visible


### PR DESCRIPTION
Companion to the CI gate PR — **this should land first**. Making the Playwright shards blocking surfaced 5 distinct failures (each failing on all 3 Chromium projects). This PR greens them so the gate can actually be turned on.

Four are stale tests that drifted when the code they assert on was deliberately changed. One is a real product regression.

## Product regression: dashboard scrolls sideways at 320px

`canvas#chart-content-dist` measured **right=344px against a 320px viewport**.

PR 1122 added `min-width: 0` to `.chart-card`, but `.chart-wrap` had no width of its own and the canvas had no ceiling, so Chart.js could still size the canvas past the card. Added `width: 100%; min-width: 0` to `.chart-wrap` and `max-width: 100%` to its canvas.

This is the same defect the Phase-0 audit logged as **P3 #13**. It was fixed once and regressed unnoticed — which is exactly what a non-blocking gate buys you.

## Stale tests

| Test | Why it broke |
|---|---|
| `content-quality.spec.ts` | `/blog/` selector was `.econ-card-excerpt`. PR 1123 extracted the canonical post-card include and `/blog/` now renders `.topic-card-excerpt`. The locator matched nothing, so the test failed on its own "expected at least one teaser card" guard and **never reached the "Source:" assertion it exists to make**. |
| `navigation.spec.ts` hero caption | Asserted the literal all-caps `'ILLUSTRATION: WHEN QUALITY OWNERSHIP TANGLES'`. PR 1103 removed the `\| upcase` filter *because the audit flagged all-caps captions as a defect* — so the test was pinning the behaviour we had just fixed. Now case-insensitive: pins the text, not the casing. |
| `navigation.spec.ts` mobile nav | Checked `document.body.classList` for `js-nav-enabled`. `_layouts/default.html` sets it on the **document element** and says so — the `.js-nav-enabled.nav-open` selector needs both classes on one element. |
| `navigation.spec.ts` "More from" rail | Asserted the linked post's rendered section label equals `Software Engineering`. Posts can hold several categories (the flaky-tests post is Software Engineering **and** Quality Engineering) while the article page renders only the primary one, so any multi-category post failed. Replaced with the invariant that actually matters: every post in the rail must appear on `/software-engineering/`. |

Note the first two: the tests were asserting the *old, defective* behaviour that earlier audit PRs deliberately corrected. Because the gate was advisory, nothing forced them to be updated.

## Verification

Against a local dev server:

- The three affected specs on Desktop Chrome: **55 passed, 3 skipped, 0 failed**
- Full default suite across all three Chromium projects: **533 passed, 0 failed**

## Scope

`dashboard/agents.html` (CSS only) plus three spec files. No layout, include, or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)