### PR TITLE
fix(ci): bind the orchestrator's duplicate-PR closer to closing keywords

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -124,6 +124,28 @@ jobs:
             // Track issues referenced by open PRs (for duplicate detection)
             const issueRefMap = {};   // issueNumber → [pr, ...]
 
+            // A PR "owns" an issue only when its body uses a GitHub closing
+            // keyword — `Closes #42`, `Fixes: #42`, `Resolved #42`. A bare
+            // `#42` in prose is a *mention* (context, cross-reference, "see
+            // also"), not a claim of ownership.
+            //
+            // This used to be /(?<![/\w])#(\d+)/g, which matched every bare
+            // `#NNN` anywhere in a body. Two unrelated PRs that merely cited
+            // the same issue looked like duplicates, and 1d auto-closed the
+            // one with fewer commits — it closed three PRs in a single session
+            // (see the P2 row in docs/BACKLOG.md).
+            //
+            // Anchoring on the keyword also fixes the two other consumers of
+            // this map: the stall handler (which re-opens and reassigns the
+            // "source" issues of a closed PR) and the dispatch guard (which
+            // treats an issue as already-worked). Both mean "the issue this PR
+            // is here to close", not "an issue this PR happens to name".
+            //
+            // Same-repo refs only: the keyword must be followed by whitespace
+            // and/or a colon and then `#`, so `Closes oviney/other-repo#42`
+            // does not match.
+            const CLOSING_REF_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]+#(\d+)\b/gi;
+
             // Known login formats for the Copilot coding agent
             // (e.g. 'copilot[bot]', 'Copilot', 'app/copilot-swe-agent')
             const COPILOT_LOGINS = new Set(['copilot[bot]', 'copilot', 'app/copilot-swe-agent']);
@@ -138,11 +160,13 @@ jobs:
                 activeCopilotDraftPRs++;
               }
 
-              // ── Build issue reference map (same-repo refs only) ─────────────
-              // Match bare #NNN references that are NOT preceded by a repo slug
-              // (e.g. "Closes #42" matches, "oviney/other-repo#42" does not).
-              const bodyIssueNums = [...(pr.body ?? '').matchAll(/(?<![/\w])#(\d+)/g)]
-                .map(m => parseInt(m[1], 10));
+              // ── Build issue reference map (closing refs only) ───────────────
+              // See CLOSING_REF_RE above: only `Closes #42`-style references
+              // count. Deduplicated so a body that repeats the same closing
+              // ref does not push the PR into issueRefMap twice.
+              const bodyIssueNums = [...new Set(
+                [...(pr.body ?? '').matchAll(CLOSING_REF_RE)].map(m => parseInt(m[1], 10))
+              )];
               for (const n of bodyIssueNums) {
                 if (!issueRefMap[n]) issueRefMap[n] = [];
                 issueRefMap[n].push(pr);


### PR DESCRIPTION
## Problem

`.github/workflows/orchestrator.yml` built its issue-reference map with
`/(?<![/\w])#(\d+)/g` — every bare `#NNN` anywhere in a PR body counted as an
issue reference. Two unrelated PRs that merely *cited* the same issue in prose
looked like duplicates, and step 1d auto-closed whichever had fewer commits.

It closed three PRs in one session (blog PRs 1171, 1172 and 1174). It is the
reason issue numbers currently have to be written as prose in PR bodies.

## Fix

Extraction is now anchored on GitHub's closing keywords:

```
/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]+#(\d+)\b/gi
```

`Closes #42`, `Fixes: #42`, `Resolved #42` bind. `See #42`, `Refs #42`,
`Part of epic #42`, `Related to #42` and a naked `#42` do not.

The tighter set is right for all three consumers of `issueRefMap`, not only
duplicate detection:

| Consumer | Meaning it needs |
|---|---|
| 1d — close duplicate PRs | the issue this PR exists to close |
| 2 — stall handler re-opens + reassigns "source" issues | the issue this PR exists to close |
| 3b — dispatch guard, "issue already has a PR" | the issue this PR exists to close |

None of them mean "an issue this PR happens to name."

Cross-repo refs (`Closes oviney/other-repo#42`) still do not match — the keyword
must be followed directly by `#`. Extracted numbers are now de-duplicated so a
body repeating the same closing ref cannot push its PR into the map twice.

## Verification

- `python3 -c "yaml.safe_load(...)"` + `node --check` on the extracted script — YAML parses, JS is syntactically valid.
- 29-case behaviour table run against the regex as extracted from the workflow file: every closing-keyword form matches, every prose-mention form does not, cross-repo and URL forms do not, repeated refs de-duplicate. All green.
- Post-merge: two throwaway PRs citing the same issue in prose, with the orchestrator dispatched against them — neither should be closed.

Carries `governance-update` — the change is under `.github/workflows/`.

Clears the P2 orchestrator row in `docs/BACKLOG.md`.