### PR TITLE
docs(agents): retire the stale bare-#NNN warning in the Handoff Packet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Every cross-persona handoff must include at least these fields:
 |-------|------------------|
 | **Context** | One-line summary of the intent — what problem is being solved and why the handoff is happening now. |
 | **Work done** | Files touched and their outcomes (what changed, what passed, what was deliberately left alone). |
-| **Artifacts / PRs** | Links to the branch, PR, issue, failing CI job, or screenshot the next owner needs. Use `GH-<number>` or full URLs — never a bare `#<number>` (an orchestration bot misreads it as an issue ref). |
+| **Artifacts / PRs** | Links to the branch, PR, issue, failing CI job, or screenshot the next owner needs. `GH-<number>`, a bare `#<number>`, and full URLs are all safe — the orchestrator reads issue refs only from closing keywords (GH-1183). |
 | **Open questions** | The specific blocker, decision, or ambiguity that requires the receiving persona's expertise. |
 | **Next owner** | The target persona, consistent with this persona's `**Handoff triggers**:` row and the Mermaid graph above. |
 | **Acceptance checks** | The conditions that let the next owner confirm the handoff is resolved (e.g. `bundle exec jekyll build` passes, a specific test is green, contrast meets WCAG AA). |


### PR DESCRIPTION
## What

`AGENTS.md:159` told agents to write `GH-<number>` or full URLs and **never** a
bare `#<number>`, because "an orchestration bot misreads it as an issue ref".

GH-1183 bound the orchestrator's issue-ref extraction to closing keywords
(`/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]+#(\d+)\b/gi`), so a bare
`#NNN` in a PR body is inert. The line now teaches a workaround that no longer
applies — in the file agents read for handoff conventions.

## Why now

Found while planning the homepage visual-baseline decoupling (spec GH-1188,
plan GH-1189). Phase 0 of `tasks/todo.md`; independent of the rest of that work,
which is why it ships as its own PR.

## Scope

One line in `AGENTS.md`. Docs only — no site code, no tests, no baselines.

## Label

`protected-file-update` — `AGENTS.md` is protected, and that label is the
per-file bypass for exactly this case (deliberate, plan-driven `AGENTS.md`
edits). Not combined with `governance-update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)