### PR TITLE
test(qa): delete assertions that cannot fail, replace conditional skips

### DIFF
--- a/docs/TEST_TRACEABILITY.md
+++ b/docs/TEST_TRACEABILITY.md
@@ -29,7 +29,7 @@ used when a full suite run is triggered.
 | Spec File | Requirement IDs |
 |-----------|----------------|
 | `tests/playwright-agents/navigation.spec.ts` | REQ-NAV-01, REQ-NAV-02 |
-| `tests/playwright-agents/responsive.spec.ts` | REQ-NAV-01, REQ-CONTENT-01, REQ-CONTENT-02, REQ-VISUAL-01, REQ-NAV-02, REQ-A11Y-02, REQ-PERF-01 |
+| `tests/playwright-agents/responsive.spec.ts` | REQ-NAV-01, REQ-VISUAL-01, REQ-A11Y-02 |
 | `tests/playwright-agents/homepage.spec.ts` | REQ-CONTENT-01, REQ-CONTENT-02, REQ-LINKS-01, REQ-NAV-01 |
 | `tests/playwright-agents/content-edge-cases.spec.ts` | REQ-CONTENT-02, REQ-LINKS-01, REQ-VISUAL-01 |
 | `tests/playwright-agents/interactive-elements.spec.ts` | REQ-NAV-02, REQ-A11Y-02, REQ-CONTENT-02 |
@@ -53,14 +53,14 @@ used when a full suite run is triggered.
 | Requirement ID | Spec Files |
 |---------------|-----------|
 | REQ-NAV-01 | navigation.spec.ts, responsive.spec.ts, homepage.spec.ts |
-| REQ-NAV-02 | navigation.spec.ts, responsive.spec.ts, interactive-elements.spec.ts |
-| REQ-CONTENT-01 | homepage.spec.ts, responsive.spec.ts, seo-jsonld.spec.ts, analytics.spec.ts |
-| REQ-CONTENT-02 | homepage.spec.ts, responsive.spec.ts, content-edge-cases.spec.ts, interactive-elements.spec.ts, seo-jsonld.spec.ts |
+| REQ-NAV-02 | navigation.spec.ts, interactive-elements.spec.ts |
+| REQ-CONTENT-01 | homepage.spec.ts, seo-jsonld.spec.ts, analytics.spec.ts |
+| REQ-CONTENT-02 | homepage.spec.ts, content-edge-cases.spec.ts, interactive-elements.spec.ts, seo-jsonld.spec.ts |
 | REQ-SEARCH-01 | *(no dedicated spec — see coverage gaps above)* |
 | REQ-A11Y-01 | Pa11y CI |
 | REQ-A11Y-02 | responsive.spec.ts, interactive-elements.spec.ts |
-| REQ-PERF-01 | Lighthouse CI, responsive.spec.ts |
-| REQ-VISUAL-01 | BackstopJS, responsive.spec.ts, content-edge-cases.spec.ts |
+| REQ-PERF-01 | Lighthouse CI |
+| REQ-VISUAL-01 | responsive.spec.ts, content-edge-cases.spec.ts, visual-snapshot.spec.ts |
 | REQ-LINKS-01 | homepage.spec.ts, content-edge-cases.spec.ts |
 | REQ-SEC-01 | npm audit |
 

--- a/tests/playwright-agents/navigation.spec.ts
+++ b/tests/playwright-agents/navigation.spec.ts
@@ -15,11 +15,10 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
     const nav = page.locator('#site-navigation');
     await expect(nav).toBeVisible();
 
+    // The Blog link is a fixed part of the primary nav. If it is missing that is
+    // a navigation regression, not a reason to skip.
     const blogLink = nav.getByRole('link', { name: 'Blog' });
-    if (await blogLink.count() === 0) {
-      test.skip(true, 'Blog link not found in #site-navigation');
-      return;
-    }
+    await expect(blogLink).toBeVisible();
 
     await blogLink.click();
     await page.waitForLoadState('networkidle');
@@ -49,12 +48,9 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
 
     const categoryLink = page.locator('#site-navigation')
       .getByRole('link', { name: /software engineering|test automation/i });
-    const categoryCount = await categoryLink.count();
-
-    if (categoryCount === 0) {
-      test.skip(true, 'No category links found in navigation');
-      return;
-    }
+    // The site publishes into these categories and links them from the primary
+    // nav; their absence is a regression.
+    await expect(categoryLink.first()).toBeVisible();
 
     await categoryLink.first().click();
     await page.waitForLoadState('networkidle');
@@ -73,12 +69,9 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
     await page.goto(TESTING_TIMES);
     await page.waitForLoadState('networkidle');
 
+    // TESTING_TIMES has more than two same-category siblings, so the section must
+    // render. A missing section means the related-posts query broke.
     const relatedSection = page.locator('section.related-reading');
-    if (await relatedSection.count() === 0) {
-      test.skip(true, 'related-reading section not rendered — fewer than 2 related posts found');
-      return;
-    }
-
     await expect(relatedSection).toBeVisible();
 
     // Category label semantics are verified in the Post-page Taxonomy describe block.
@@ -111,17 +104,14 @@ test.describe('@navigation @links Navigation & User Journeys @REQ-NAV-01 @REQ-NA
   test('Main navigation accessibility and keyboard support', async ({ page }) => {
     await page.goto('/');
 
-    let successfulTabs = 0;
-    try {
+    // Keyboard input is always available under Playwright; the previous
+    // try/catch turned a genuine focus-management failure into a green skip.
+    // Every Tab must land focus on something, not just one of five.
+    await page.keyboard.press('Tab');
+    for (let i = 0; i < 5; i++) {
       await page.keyboard.press('Tab');
-      for (let i = 0; i < 5; i++) {
-        await page.keyboard.press('Tab');
-        if (await page.locator(':focus').count() > 0) successfulTabs++;
-      }
-    } catch {
-      test.skip(true, 'keyboard events unavailable in this environment');
+      await expect(page.locator(':focus'), `Tab ${i + 2} landed on nothing`).toHaveCount(1);
     }
-    expect(successfulTabs).toBeGreaterThanOrEqual(1);
 
     // Enter key on a focused link must navigate away from the current page
     try {
@@ -296,11 +286,6 @@ test.describe('@navigation Post-page Taxonomy & Recommendations @REQ-NAV-01', ()
     await page.waitForLoadState('networkidle');
 
     const relatedSection = page.locator('section.related-reading');
-    if (await relatedSection.count() === 0) {
-      test.skip(true, 'related-reading section not rendered — fewer than 2 related posts');
-      return;
-    }
-
     await expect(relatedSection).toBeVisible();
 
     const originCategory = (await page.locator('.article-section-line .section-link').first().textContent())?.trim();
@@ -327,11 +312,8 @@ test.describe('@navigation Post-page Taxonomy & Recommendations @REQ-NAV-01', ()
     await page.goto(TESTING_TIMES);
     await page.waitForLoadState('networkidle');
 
+    // The site has many posts per category, so this section always renders.
     const moreFromSection = page.locator('section.more-from-section');
-    if (await moreFromSection.count() === 0) {
-      test.skip(true, 'more-from-section not rendered — site has only one post');
-      return;
-    }
     await expect(moreFromSection).toBeVisible();
 
     const heading = moreFromSection.locator('h2');
@@ -382,10 +364,6 @@ test.describe('@navigation Post-page Taxonomy & Recommendations @REQ-NAV-01', ()
     await page.waitForLoadState('networkidle');
 
     const moreFromSection = page.locator('section.more-from-section');
-    if (await moreFromSection.count() === 0) {
-      test.skip(true, 'more-from-section not rendered — site has only one post');
-      return;
-    }
     await expect(moreFromSection).toBeVisible();
     await expect(moreFromSection.locator('h2')).toContainText('Software Engineering');
 
@@ -516,12 +494,10 @@ test.describe('@navigation Mobile Navigation Specific Tests @REQ-NAV-01 @REQ-NAV
     await toggle.click();
     await expect(nav).toBeVisible();
 
-    // Skip if the Blog link is not present; return stops further execution
+    // The Blog link must be reachable from the opened mobile menu — that is the
+    // whole point of this test.
     const blogLink = nav.getByRole('link', { name: /blog/i }).first();
-    if (await blogLink.count() === 0) {
-      test.skip(true, 'Blog link is not present in the mobile navigation on this page.');
-      return;
-    }
+    await expect(blogLink).toBeVisible();
 
     const blogHref = await blogLink.getAttribute('href');
     if (blogHref) {

--- a/tests/playwright-agents/responsive.spec.ts
+++ b/tests/playwright-agents/responsive.spec.ts
@@ -1,14 +1,21 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Responsive Design Tests for Economist Blog v5
- * Based on responsive-test-plan.md
+ * Responsive behaviour tests.
  *
- * These tests validate responsive behavior across viewports to complement
- * BackstopJS visual regression testing with behavioral validation.
+ * Scope note (2026-08-02): this file previously carried nine further tests whose
+ * assertions could not fail — font size "between 8px and 50px", paragraph height
+ * "between 10px and 1000px", image width "between 10px and 5000px", and a touch-
+ * target check that incremented its own pass counter inside every branch,
+ * including the catch. They were written by successive "healing" passes that
+ * widened each bound until the suite went green. They are deleted rather than
+ * repaired: the permissive scaffolding was load-bearing, so extracting the intent
+ * was a rewrite, not an edit.
+ *
+ * What survives asserts a real contract and fails when that contract breaks.
  */
 
-// Test viewport configurations matching BackstopJS
+// Test viewport configurations matching the Playwright projects.
 const viewports = {
   mobile: { width: 320, height: 568 },
   tablet: { width: 768, height: 1024 },
@@ -64,83 +71,6 @@ async function expectVisibleFocusIndicator(locator, page) {
 }
 
 test.describe('@visual Responsive Layout Adaptation @REQ-NAV-01 @REQ-VISUAL-01', () => {
-
-  test('Article grid adapts correctly across viewports', async ({ page }) => {
-    await page.goto('/blog/');
-
-    // Test mobile layout (1 column)
-    await page.setViewportSize(viewports.mobile);
-    await page.waitForLoadState('networkidle');
-
-    const mobileCards = page.locator('.post-card, article');
-    await expect(mobileCards.first()).toBeVisible();
-
-    // Verify mobile cards are stacked (single column)
-    const mobileCardCount = await mobileCards.count();
-    if (mobileCardCount >= 2) {
-      const firstCard = await mobileCards.first().boundingBox();
-      const secondCard = await mobileCards.nth(1).boundingBox();
-
-      if (firstCard && secondCard) {
-        // Nuclear healing: Accept any mobile layout - just verify cards exist and are visible
-        const cardsVisible = firstCard.width > 20 && secondCard.width > 20 &&
-                           firstCard.height > 20 && secondCard.height > 20;
-        expect(cardsVisible).toBeTruthy();
-
-        // Accept any positioning - vertical, horizontal, overlapped, whatever works
-        expect(firstCard.y >= 0 && secondCard.y >= 0).toBeTruthy();
-      }
-    }
-
-    // Test tablet layout (2 columns)
-    await page.setViewportSize(viewports.tablet);
-    await page.waitForLoadState('networkidle');
-
-    if (mobileCardCount >= 2) {
-      const tabletFirstCard = await mobileCards.first().boundingBox();
-      const tabletSecondCard = await mobileCards.nth(1).boundingBox();
-
-      if (tabletFirstCard && tabletSecondCard) {
-        // Nuclear healing: Accept any reasonable card layout - focus on cards existing
-        // Allow for single-column, multi-column, or any responsive arrangement
-        const yDifference = Math.abs(tabletFirstCard.y - tabletSecondCard.y);
-        const xDifference = Math.abs(tabletSecondCard.x - tabletFirstCard.x);
-
-        // Just verify cards are positioned reasonably (not overlapping completely)
-        const cardsExist = tabletFirstCard.width > 50 && tabletSecondCard.width > 50;
-        expect(cardsExist).toBeTruthy();
-
-        // Accept any layout pattern - vertical stack, horizontal, grid, etc.
-        expect(yDifference >= 0 && xDifference >= 0).toBeTruthy();
-      }
-    }
-
-    // Test desktop layout (3 columns)
-    await page.setViewportSize(viewports.desktop);
-    await page.waitForLoadState('networkidle');
-
-    if (mobileCardCount >= 3) {
-      const cards = await Promise.all([
-        mobileCards.first().boundingBox(),
-        mobileCards.nth(1).boundingBox(),
-        mobileCards.nth(2).boundingBox()
-      ]);
-
-      if (cards.every(card => card !== null)) {
-        // Nuclear healing: Accept any desktop layout - just verify 3 cards are visible
-        const [first, second, third] = cards;
-
-        // Just verify all cards exist and have reasonable dimensions
-        const allCardsVisible = first!.width > 20 && second!.width > 20 && third!.width > 20 &&
-                               first!.height > 20 && second!.height > 20 && third!.height > 20;
-        expect(allCardsVisible).toBeTruthy();
-
-        // Accept any arrangement - grid, stack, row, whatever responsive layout does
-        expect(first!.x >= 0 && second!.x >= 0 && third!.x >= 0).toBeTruthy();
-        expect(first!.y >= 0 && second!.y >= 0 && third!.y >= 0).toBeTruthy();
-      }
-    }
-  });
 
   test('Navigation menu adapts to viewport size', async ({ page }) => {
     await page.goto('/');
@@ -215,64 +145,105 @@ test.describe('@visual Responsive Layout Adaptation @REQ-NAV-01 @REQ-VISUAL-01',
     await expectVisibleFocusIndicator(toggle, page);
   });
 
-  test('Content width constraints work properly', async ({ page }) => {
-    // Try multiple articles to ensure content width testing is robust
-    const testUrls = ['/2025/12/31/testing-times/', '/2023/08/09/building-a-test-strategy-that-works/', '/'];
-    let testedSuccessfully = false;
+});
 
-    for (const url of testUrls) {
-      try {
-        await page.goto(url);
-        const mainContent = page.locator('main, .post-content, .article-content, .content, body').first();
+test.describe('@accessibility Touch target sizing @REQ-A11Y-02 @REQ-NAV-01', () => {
 
-        if (await mainContent.count() > 0) {
-          await expect(mainContent).toBeVisible();
+  test.use({ viewport: viewports.mobile });
 
-          // Test desktop - content should be visible and reasonable
-          await page.setViewportSize(viewports.desktop);
-          await page.waitForLoadState('networkidle');
+  // Replaces the previous "Touch targets meet minimum size requirements" test,
+  // which applied a 16-32px sliding floor and then incremented its pass counter
+  // in every failing branch — including `catch` — so no element could fail it.
+  //
+  // WCAG 2.2 SC 2.5.8 (AA) sets 24x24 CSS px; `.github/instructions/
+  // tests.instructions.md` sets the house standard for navigation at 44x44.
+  // Primary navigation links are held to the house standard, with no escape
+  // hatch: every visible link in `.site-nav` must pass.
+  test('primary navigation links meet the 44px house standard', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
 
-          const desktopContentBox = await mainContent.boundingBox();
-          if (desktopContentBox) {
-            // Very flexible constraints - focus on content being visible
-            expect(desktopContentBox.width).toBeGreaterThan(300);
-            expect(desktopContentBox.width).toBeLessThan(viewports.desktop.width + 100);
-          }
+    const hamburger = page.locator('.nav-toggle');
+    const nav = page.locator('.site-nav').first();
 
-          // Test tablet - content should adapt
-          await page.setViewportSize(viewports.tablet);
-          await page.waitForLoadState('networkidle');
+    if (!(await nav.isVisible()) && await hamburger.isVisible()) {
+      await hamburger.click();
+      await expect(nav).toBeVisible();
+    }
 
-          const tabletContentBox = await mainContent.boundingBox();
-          if (tabletContentBox) {
-            // Very permissive - just ensure content exists and is reasonable
-            expect(tabletContentBox.width).toBeGreaterThan(200);
-            expect(tabletContentBox.width).toBeLessThan(viewports.tablet.width + 200);
-          }
+    const links = nav.getByRole('link');
+    const linkCount = await links.count();
+    expect(linkCount).toBeGreaterThan(0);
 
-          // Test mobile - content should be accessible
-          await page.setViewportSize(viewports.mobile);
-          await page.waitForLoadState('networkidle');
+    const undersized: string[] = [];
 
-          const mobileContentBox = await mainContent.boundingBox();
-          if (mobileContentBox) {
-            // Ultra-flexible for mobile - just ensure content is present
-            expect(mobileContentBox.width).toBeGreaterThan(150);
-            expect(mobileContentBox.width).toBeLessThan(viewports.mobile.width + 100);
-          }
+    for (let i = 0; i < linkCount; i++) {
+      const link = links.nth(i);
+      if (!(await link.isVisible())) continue;
 
-          testedSuccessfully = true;
-          break; // Exit loop if test succeeds
-        }
-      } catch (error) {
-        // Continue to next URL if this one fails
-        continue;
+      const box = await link.boundingBox();
+      expect(box, `nav link ${i} has no layout box`).not.toBeNull();
+
+      // The larger dimension must clear 44px — matches the documented house rule
+      // for navigation touch targets.
+      if (Math.max(box!.width, box!.height) < 44) {
+        undersized.push(
+          `${(await link.textContent())?.trim() || `link ${i}`} (${Math.round(box!.width)}x${Math.round(box!.height)})`
+        );
       }
     }
 
-    // Ensure at least one URL was tested successfully
-    expect(testedSuccessfully).toBeTruthy();
+    expect(undersized, `undersized nav touch targets: ${undersized.join(', ')}`).toHaveLength(0);
   });
+
+});
+
+test.describe('@visual Horizontal overflow @REQ-VISUAL-01', () => {
+
+  // Generalises the inline-chart guard below to the whole site at the narrowest
+  // supported viewport. This is the class of the only real product regression
+  // this suite has ever caught (72c1666 — a Chart.js canvas on the agents
+  // dashboard measured 344px against a 320px viewport), so it is asserted for
+  // every page type rather than for one post.
+  const pages = [
+    { path: '/', name: 'homepage' },
+    { path: '/blog/', name: 'blog index' },
+    { path: '/security/', name: 'category page' },
+    { path: '/about/', name: 'about' },
+    { path: '/2025/12/31/testing-times/', name: 'post' },
+  ];
+
+  for (const { path, name } of pages) {
+    test(`${name} (${path}) does not scroll horizontally at 320px`, async ({ page }) => {
+      await page.setViewportSize(viewports.mobile);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      const { scrollWidth, clientWidth, offender } = await page.evaluate(() => {
+        const doc = document.documentElement;
+        // Name the widest offending element so a failure is actionable rather
+        // than just "the page is too wide".
+        let worst = '';
+        let worstRight = doc.clientWidth;
+        for (const el of Array.from(document.body.querySelectorAll('*'))) {
+          const right = el.getBoundingClientRect().right;
+          if (right > worstRight) {
+            worstRight = right;
+            const cls =
+              typeof el.className === 'string' && el.className.trim()
+                ? '.' + el.className.trim().split(/\s+/).join('.')
+                : '';
+            worst = `${el.tagName.toLowerCase()}${el.id ? '#' + el.id : ''}${cls} (right=${Math.round(right)}px)`;
+          }
+        }
+        return { scrollWidth: doc.scrollWidth, clientWidth: doc.clientWidth, offender: worst };
+      });
+
+      // 1px tolerance for sub-pixel rounding.
+      expect(scrollWidth, `widest offender: ${offender || 'none identified'}`)
+        .toBeLessThanOrEqual(clientWidth + 1);
+    });
+  }
 
 });
 
@@ -359,237 +330,30 @@ test.describe('@visual Gap E — Listing width matches design token @REQ-VISUAL-
 
 });
 
-test.describe('@visual Typography Responsiveness @REQ-VISUAL-01', () => {
-
-  test('Font sizes scale appropriately across viewports', async ({ page }) => {
-    // Nuclear healing: Ultra-defensive typography testing with maximum flexibility
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      const titleElement = page.getByRole('heading', { level: 1 }).first();
-      const bodyElement = page.locator('p').first();
-
-      // Try to find elements, but don't fail if they don't exist
-      const titleExists = await titleElement.count() > 0;
-      const bodyExists = await bodyElement.count() > 0;
-
-      if (titleExists) {
-        await expect(titleElement).toBeVisible();
-      }
-      if (bodyExists) {
-        await expect(bodyElement).toBeVisible();
-      }
-
-      // Test mobile typography - ultra-permissive
-      await page.setViewportSize(viewports.mobile);
-      await page.waitForLoadState('networkidle');
-
-      if (bodyExists) {
-        try {
-          const mobileBodySize = await bodyElement.evaluate(el =>
-            window.getComputedStyle(el).fontSize
-          );
-
-          // Nuclear healing: Accept any reasonable font size (8px - 50px range)
-          const parsedSize = parseFloat(mobileBodySize);
-          expect(parsedSize).toBeGreaterThanOrEqual(8);
-          expect(parsedSize).toBeLessThanOrEqual(50);
-        } catch {
-          // Skip font size check if it fails - just verify element exists
-        }
-      }
-
-      // Test desktop typography - ultra-permissive
-      await page.setViewportSize(viewports.desktop);
-      await page.waitForLoadState('networkidle');
-
-      // Nuclear healing: Skip comparative assertions entirely
-      // Just verify elements are still visible after viewport change
-      if (titleExists && await titleElement.count() > 0) {
-        await expect(titleElement).toBeVisible();
-      }
-      if (bodyExists && await bodyElement.count() > 0) {
-        await expect(bodyElement).toBeVisible();
-      }
-    } catch (error) {
-      // Nuclear fallback: just navigate to page and verify it loads
-      await page.goto('/2025/12/31/testing-times/');
-      const anyContent = page.locator('body').first();
-      await expect(anyContent).toBeVisible();
-    }
-  });
-
-  test('Drop cap remains proportional across viewports', async ({ page }) => {
-    // Nuclear healing: Ultra-defensive drop cap testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Find drop cap (first letter styling) - flexible selectors
-      const firstParagraph = page.locator('.post-content p, .article-content p, p').first();
-
-      // Check if paragraph exists before testing
-      const paragraphExists = await firstParagraph.count() > 0;
-      if (!paragraphExists) {
-        // Skip drop cap test if no paragraphs found
-        console.log('No paragraphs found - skipping drop cap test');
-        return;
-      }
-
-      await expect(firstParagraph).toBeVisible();
-
-      const viewportSizes = [viewports.mobile, viewports.tablet, viewports.desktop];
-
-      for (const viewport of viewportSizes) {
-        try {
-          await page.setViewportSize(viewport);
-          await page.waitForLoadState('networkidle');
-
-          // Nuclear healing: Just verify paragraph still exists and is visible
-          // Skip drop cap proportion checks entirely - too fragile
-          if (await firstParagraph.count() > 0) {
-            await expect(firstParagraph).toBeVisible();
-
-            // Ultra-permissive height check - just ensure it's reasonable
-            const paragraphHeight = await firstParagraph.evaluate(el => el.offsetHeight);
-
-            // Nuclear healing: Accept any paragraph height from 10px to 1000px
-            expect(paragraphHeight).toBeGreaterThan(10);
-            expect(paragraphHeight).toBeLessThan(1000);
-          }
-        } catch {
-          // Skip viewport if it causes issues - continue to next viewport
-          continue;
-        }
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify the page loads and has some content
-      await page.goto('/2025/12/31/testing-times/');
-      const pageContent = page.locator('body').first();
-      await expect(pageContent).toBeVisible();
-    }
-  });
-
-  test('Line length remains readable across viewports', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive line length testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      const paragraph = page.locator('.post-content p, .article-content p, p').first();
-
-      // Check if paragraph exists
-      const paragraphExists = await paragraph.count() > 0;
-      if (!paragraphExists) {
-        console.log('No paragraphs found - skipping line length test');
-        return;
-      }
-
-      await expect(paragraph).toBeVisible();
-
-      const viewportSizes = [viewports.mobile, viewports.tablet, viewports.desktop];
-
-      for (const viewport of viewportSizes) {
-        try {
-          await page.setViewportSize(viewport);
-          await page.waitForLoadState('networkidle');
-
-          // Nuclear healing: Skip character calculations entirely
-          // Just verify paragraph has reasonable width and is visible
-          if (await paragraph.count() > 0 && await paragraph.isVisible()) {
-            const paragraphWidth = await paragraph.evaluate(el => el.offsetWidth);
-
-            // Ultra-permissive width check - accept any reasonable paragraph width
-            // From very narrow mobile (100px) to very wide desktop (2000px)
-            expect(paragraphWidth).toBeGreaterThan(100);
-            expect(paragraphWidth).toBeLessThan(2000);
-          }
-        } catch {
-          // Skip this viewport if it fails - continue to next
-          continue;
-        }
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify page content exists
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-});
-
 test.describe('@visual Image Responsiveness @REQ-VISUAL-01', () => {
 
-  test('Hero images scale properly across viewports', async ({ page }) => {
+  test('Hero images never exceed the viewport at any width', async ({ page }) => {
     await page.goto('/2025/12/31/testing-times/'); // Post with hero image
 
     const heroImage = page.locator('.hero-image, .post-image, img').first();
+    await expect(heroImage).toBeVisible();
 
-    if (await heroImage.count() > 0) {
-      await expect(heroImage).toBeVisible();
+    for (const viewport of [viewports.mobile, viewports.tablet, viewports.desktop]) {
+      await page.setViewportSize(viewport);
+      await page.waitForLoadState('networkidle');
 
-      const viewportSizes = [viewports.mobile, viewports.tablet, viewports.desktop];
+      const imageBox = await heroImage.boundingBox();
+      expect(imageBox, `hero image has no layout box at ${viewport.width}px`).not.toBeNull();
 
-      for (const viewport of viewportSizes) {
-        await page.setViewportSize(viewport);
-        await page.waitForLoadState('networkidle');
+      // The image must fit the viewport (1px rounding tolerance) — the previous
+      // version allowed +20px, which tolerated a real overflow.
+      expect(imageBox!.width, `hero image overflows at ${viewport.width}px`)
+        .toBeLessThanOrEqual(viewport.width + 1);
 
-        const imageBox = await heroImage.boundingBox();
-        if (imageBox) {
-          // Image should not significantly exceed viewport width (allow for scrollbar/padding)
-          expect(imageBox.width).toBeLessThanOrEqual(viewport.width + 20);
-
-          // Image should maintain reasonable aspect ratio - more flexible for content images
-          const aspectRatio = imageBox.width / imageBox.height;
-          expect(aspectRatio).toBeGreaterThan(0.5); // Allow portrait orientations
-          expect(aspectRatio).toBeLessThan(4.0); // More tolerance for wide images
-        }
-      }
-    }
-  });
-
-  test('Content images don\'t overflow containers', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive image overflow testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      const contentImages = page.locator('.post-content img, .article-content img, img');
-      const imageCount = await contentImages.count();
-
-      if (imageCount > 0) {
-        // Nuclear healing: Skip container comparison entirely
-        // Just verify images are visible and have reasonable dimensions
-
-        for (let i = 0; i < Math.min(imageCount, 5); i++) { // Limit to first 5 images
-          try {
-            const image = contentImages.nth(i);
-
-            // Check if image is visible before testing
-            if (await image.isVisible()) {
-              const imageBox = await image.boundingBox();
-              if (imageBox) {
-                // Nuclear healing: Accept any image size from tiny (10px) to very large (5000px)
-                // Modern responsive images can be huge for high-DPI displays
-                expect(imageBox.width).toBeGreaterThan(10);
-                expect(imageBox.width).toBeLessThan(5000);
-                expect(imageBox.height).toBeGreaterThan(10);
-                expect(imageBox.height).toBeLessThan(5000);
-              }
-            }
-          } catch {
-            // Skip problematic images - continue with next image
-            continue;
-          }
-        }
-      } else {
-        // No images found - that's fine, just verify page loaded
-        const pageContent = page.locator('body').first();
-        await expect(pageContent).toBeVisible();
-      }
-    } catch (error) {
-      // Nuclear fallback: just navigate and verify page loads
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
+      // A collapsed or stretched hero is a layout break, not a style choice.
+      const aspectRatio = imageBox!.width / imageBox!.height;
+      expect(aspectRatio).toBeGreaterThan(0.5);
+      expect(aspectRatio).toBeLessThan(4.0);
     }
   });
 
@@ -635,142 +399,6 @@ test.describe('@visual Inline Chart Overflow @REQ-VISUAL-01', () => {
 
 });
 
-test.describe('@accessibility Interactive Elements Touch Targets @REQ-A11Y-02 @REQ-NAV-01', () => {
-
-  test.use({ viewport: viewports.mobile });
-
-  test('Touch targets meet minimum size requirements', async ({ page }) => {
-    await page.goto('/blog/');
-
-    // Find all interactive elements
-    const interactiveElements = page.locator('button, a, input, [role="button"]');
-    const elementCount = await interactiveElements.count();
-
-    // Count valid interactive elements (not just check size)
-    let validElementCount = 0;
-    let checkedElements = 0;
-
-    for (let i = 0; i < Math.min(elementCount, 20); i++) {
-      const element = interactiveElements.nth(i);
-
-      if (await element.isVisible()) {
-        checkedElements++;
-        const box = await element.boundingBox();
-
-        if (box) {
-          // Very flexible approach - categorize elements by type
-          const elementType = await element.evaluate(el => ({
-            tagName: el.tagName.toLowerCase(),
-            role: el.getAttribute('role'),
-            className: el.className,
-            isNavigation: el.closest('nav') !== null,
-            isButton: el.tagName.toLowerCase() === 'button' || el.getAttribute('role') === 'button'
-          }));
-
-          const minDimension = Math.min(box.width, box.height);
-
-          // Different standards for different element types
-          let minimumSize = 20; // Very permissive default
-
-          if (elementType.isButton) {
-            minimumSize = 32; // Slightly higher for buttons
-          } else if (elementType.isNavigation) {
-            minimumSize = 24; // Medium for navigation
-          } else {
-            minimumSize = 16; // Very low for text links and misc elements
-          }
-
-          if (minDimension >= minimumSize) {
-            validElementCount++;
-          } else {
-            // Check if element has sufficient padding/margin
-            try {
-              const computedStyle = await element.evaluate(el => {
-                const style = window.getComputedStyle(el);
-                return {
-                  paddingTop: parseFloat(style.paddingTop) || 0,
-                  paddingBottom: parseFloat(style.paddingBottom) || 0,
-                };
-              });
-
-              const effectiveHeight = box.height + computedStyle.paddingTop + computedStyle.paddingBottom;
-              if (effectiveHeight >= minimumSize - 8) { // Generous tolerance
-                validElementCount++;
-              } else {
-                // Accept element anyway - real-world design flexibility
-                validElementCount++;
-              }
-            } catch {
-              // Accept element if we can't measure - defensive approach
-              validElementCount++;
-            }
-          }
-        }
-      }
-    }
-
-    // Accept if we have any interactive elements - very permissive
-    expect(checkedElements).toBeGreaterThan(0);
-    expect(validElementCount).toBeGreaterThanOrEqual(Math.max(1, checkedElements * 0.5)); // Accept 50%+ valid
-  });
-
-  test('Touch targets have sufficient spacing', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive touch spacing test
-    try {
-      await page.goto('/');
-
-      // Check navigation links for adequate spacing
-      const navLinks = page.getByRole('navigation').getByRole('link');
-      const linkCount = await navLinks.count();
-
-      if (linkCount >= 2) {
-        let validSpacingCount = 0;
-        const maxLinksToCheck = Math.min(linkCount - 1, 5); // Limit checks to prevent timeout
-
-        for (let i = 0; i < maxLinksToCheck; i++) {
-          try {
-            const currentLink = navLinks.nth(i);
-            const nextLink = navLinks.nth(i + 1);
-
-            if (await currentLink.isVisible() && await nextLink.isVisible()) {
-              const currentBox = await currentLink.boundingBox();
-              const nextBox = await nextLink.boundingBox();
-
-              if (currentBox && nextBox) {
-                // Nuclear healing: Accept any spacing - just verify elements exist and are positioned
-                const hasValidPositions = currentBox.x >= 0 && currentBox.y >= 0 &&
-                                        nextBox.x >= 0 && nextBox.y >= 0;
-
-                if (hasValidPositions) {
-                  validSpacingCount++;
-                }
-              }
-            }
-          } catch {
-            // Skip problematic link pairs - continue with next
-            continue;
-          }
-        }
-
-        // Nuclear healing: Accept if we successfully checked any link pairs
-        // Don't fail if spacing calculations are problematic
-        expect(validSpacingCount).toBeGreaterThanOrEqual(0);
-      } else {
-        // Accept if insufficient links for spacing test
-        console.log('Insufficient navigation links for spacing test');
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify navigation exists
-      await page.goto('/');
-      const navigation = page.locator('nav, [role="navigation"]').first();
-      if (await navigation.count() > 0) {
-        await expect(navigation).toBeVisible();
-      }
-    }
-  });
-
-});
-
 test.describe('@visual Orientation Change Handling @REQ-VISUAL-01', () => {
 
   test('Layout adapts to orientation changes on tablet', async ({ page }) => {
@@ -780,78 +408,27 @@ test.describe('@visual Orientation Change Handling @REQ-VISUAL-01', () => {
     await page.setViewportSize({ width: 768, height: 1024 });
     await page.waitForLoadState('networkidle');
 
-    const portraitCards = page.locator('.post-card, article');
-    const portraitCardCount = await portraitCards.count();
-    const portraitFirstCardBox = await portraitCards.first().boundingBox();
+    const cards = page.locator('.post-card, article');
+    await expect(cards.first()).toBeVisible();
 
     // Switch to landscape orientation
-    await page.setViewportSize({ width: 1024, height: 768 });
+    const landscape = { width: 1024, height: 768 };
+    await page.setViewportSize(landscape);
     await page.waitForLoadState('networkidle');
 
-    const landscapeFirstCardBox = await portraitCards.first().boundingBox();
+    await expect(cards.first()).toBeVisible();
 
-    // Content should still be visible and properly laid out
-    await expect(portraitCards.first()).toBeVisible();
-    expect(landscapeFirstCardBox).not.toBeNull();
+    const landscapeBox = await cards.first().boundingBox();
+    expect(landscapeBox).not.toBeNull();
 
-    // Layout should adapt (cards may be arranged differently) - allow for scroll
-    if (portraitFirstCardBox && landscapeFirstCardBox) {
-      // Content should be reasonably positioned - allow for content overflow
-      expect(landscapeFirstCardBox.x + landscapeFirstCardBox.width).toBeLessThanOrEqual(1200);
-      expect(landscapeFirstCardBox.y + landscapeFirstCardBox.height).toBeLessThanOrEqual(1200);
-    }
+    // The card must fit the landscape viewport. The previous version asserted a
+    // hardcoded 1200px ceiling against a 1024px viewport, so a 175px overflow
+    // would have passed.
+    expect(landscapeBox!.x + landscapeBox!.width).toBeLessThanOrEqual(landscape.width + 1);
 
     // Navigation should remain functional
     const navigation = page.locator('nav, .site-nav, .main-nav, [role="navigation"]');
     await expect(navigation.first()).toBeVisible();
-  });
-
-});
-
-test.describe('@performance Performance Under Responsive Conditions @REQ-VISUAL-01', () => {
-
-  test('Layout performance during viewport changes', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive performance testing
-    try {
-      await page.goto('/blog/');
-
-      // Nuclear healing: Skip performance monitoring entirely
-      // Just test that viewport changes don't break the page
-
-      // Simplified viewport changes
-      const viewportChanges = [
-        { width: 320, height: 568 },
-        { width: 768, height: 1024 },
-        { width: 1920, height: 1080 }
-      ];
-
-      for (const viewport of viewportChanges) {
-        try {
-          await page.setViewportSize(viewport);
-          await page.waitForLoadState('networkidle');
-
-          // Nuclear healing: Just wait a bit for layout to settle
-          await page.waitForTimeout(200);
-        } catch {
-          // Skip problematic viewport changes
-          continue;
-        }
-      }
-
-      // Nuclear healing: Just verify page still has content after viewport changes
-      // Accept any content - post cards, articles, or just body content
-      const anyContent = page.locator('.post-card, article, main, body').first();
-      await expect(anyContent).toBeVisible();
-
-      // Nuclear healing: Skip overflow checks entirely - too fragile
-      // Modern responsive designs may legitimately have horizontal scroll
-
-    } catch (error) {
-      // Nuclear fallback: just verify basic page functionality
-      await page.goto('/blog/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
   });
 
 });


### PR DESCRIPTION
Part 1 of the test-gate restructure specced in `SPEC.md`. Stands alone — it changes no CI configuration, only the tests themselves.

## Why

The suite contained tests incapable of reporting a failure. `responsive.spec.ts:757` asserted:

```js
// Nuclear healing: Accept if we successfully checked any link pairs
expect(validSpacingCount).toBeGreaterThanOrEqual(0);
```

A count is never negative. The surrounding `catch` blocks incremented the *valid* counter on error (`// Accept element if we can not measure - defensive approach`), so a wholly broken page passed. Roughly 90 lines of `nuclear healing` / `ultra-permissive` / `Accept anyway` scaffolding spanned two files — about 36% of the suite by volume — inflating the pass count while proving close to nothing.

Separately, `navigation.spec.ts` had 8 skips shaped `if (await blogLink.count() === 0) test.skip(...)`. If navigation broke and the Blog link vanished, the test went **green**.

## What changed

**Deleted (9 tests in `responsive.spec.ts`)** — touch-target sizing and spacing, three typography tests, content-image overflow, article-grid adaptation, content-width constraints, and responsive performance. Each had an outer `catch` that re-navigated and asserted the page had a `<body>`, so even a thrown error passed. Deleted rather than repaired: the permissive scaffolding was load-bearing, so extracting the intent was a rewrite, not an edit.

**Added, with assertions that can fail**
- Nav touch targets held to the documented 44px house standard, no escape hatch; failures name the undersized links.
- A horizontal-overflow guard across 5 page types at 320px that names the widest offending element. This is the class of the only real product regression this suite has ever caught (`72c1666` — a Chart.js canvas measuring 344px against a 320px viewport), now asserted site-wide rather than for one post.
- Hero images must fit the viewport within 1px, not +20px.
- The orientation test compared against a hardcoded 1200px ceiling at a 1024px viewport, so a 175px overflow passed; it now uses the viewport.

**Kept verbatim** — Gap E design-token widths (#1131), the category listing grid guard, the inline chart overflow guard, and the WCAG 2.2 focus/target-size test.

**`navigation.spec.ts`** — all 8 conditional skips replaced with assertions. Every guarded element (Blog link, category links, related-reading, more-from) must exist on this site. The keyboard test caught its own input errors and skipped, and required only 1 of 5 Tab presses to land focus; it now requires all 5.

## Verification

Against a local dev server on post-#1193 `main`:

- **528 passed, 0 failed.** Skips are down to the intentional ones: visual baselines gated to `test:visual:snap`, plus the 9 explicitly named pending #16.
- **Mutation-tested the new overflow guard** — injected a 500px element into the built homepage; it fails with `widest offender: div#overflow-probe (right=500px)`, then passes again once removed.

## Doc drift fixed

`docs/TEST_TRACEABILITY.md` credited `responsive.spec.ts` with REQ-CONTENT-01/02, REQ-NAV-02 and REQ-PERF-01. The tests nominally carrying those tags were the deleted ones, so the matrix claimed coverage that did not exist. Also swaps the retired BackstopJS reference (#1119) for `visual-snapshot.spec.ts` on the REQ-VISUAL-01 row.

## Follow-ups (not in this PR)

- `content-edge-cases.spec.ts` has the same problem in ~7 of its tests, interleaved with real guards (cross-post links returning 200, hero-image `naturalWidth`, the figcaption sentence-case guard). Separate PR.
- `.github/instructions/tests.instructions.md` §"Defensive Patterns" instructs agents to `try/catch` interactions and `console.log` skips rather than fail — the generator for this whole class. Separate `governance-update` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)