### PR TITLE
docs(instructions): forbid tests that cannot fail

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -85,6 +85,52 @@ expect(count).toBeGreaterThanOrEqual(1);
 
 Set assertion timeout via `playwright.config.ts` (`expect.timeout: 5000`); do not override per-assertion unless required.
 
+### Every test must be able to fail
+
+This is the one rule that outranks the rest of this file. A test that cannot
+report a failure is worse than no test: it consumes maintenance and buys false
+confidence. Before opening a PR, ask of each test — *what change to the site
+would turn this red?* If you cannot name one, the test is not finished.
+
+**Forbidden.** These are not style preferences; they are defects:
+
+```ts
+// A count is never negative — this passes on any rendering whatsoever.
+expect(items.length).toBeGreaterThanOrEqual(0);
+
+// A range so wide that no real regression falls outside it.
+expect(fontSize).toBeGreaterThanOrEqual(8);
+expect(fontSize).toBeLessThanOrEqual(50);
+
+// A `catch` that converts a genuine failure into a pass.
+try {
+  await expect(banner).toBeVisible();
+} catch {
+  validCount++;              // counts the error as a success
+}
+
+// A fallback that asserts something trivially true instead of the contract.
+} catch {
+  await expect(page.locator('body')).toBeVisible();
+}
+```
+
+**Bounds must be tight enough to catch a real regression.** Assert against the
+design token or the viewport, not against a range that any rendering satisfies:
+
+```ts
+// Good — fails if the element escapes the viewport.
+expect(box.width).toBeLessThanOrEqual(viewport.width + 1);
+
+// Good — fails if the 1040px listing token drifts.
+expect(Math.abs(wrapper.width - 1040)).toBeLessThanOrEqual(50);
+```
+
+**Never weaken an assertion to make a test pass.** If a test fails, either the
+product regressed (fix the product) or the test asserts something deliberately
+changed (retarget the test at the new contract). Widening the bound until the
+run goes green destroys the test's reason to exist.
+
 ## Network & Load State
 
 Wait for full page load before asserting:
@@ -99,10 +145,13 @@ Navigation links must have a touch target of at least 44 × 44 px:
 
 ```ts
 const box = await link.boundingBox();
-if (box) {
-  expect(Math.max(box.width, box.height)).toBeGreaterThanOrEqual(44);
-}
+expect(box, 'nav link has no layout box').not.toBeNull();
+expect(Math.max(box!.width, box!.height)).toBeGreaterThanOrEqual(44);
 ```
+
+Assert the box exists rather than wrapping the check in `if (box)`. A link that
+fails to lay out returns `null` here, and the `if` form silently passes on
+exactly the breakage the test is meant to catch.
 
 ## External Links
 
@@ -114,12 +163,64 @@ if (target === '_blank') {
 }
 ```
 
-## Defensive Patterns
+## Handling optional elements
 
-- Check `.count()` before interacting with optional elements
-- Use `try/catch` around interactions that may fail on certain pages
-- Log skipped steps with `console.log('reason for skip')` rather than throwing
-- Prefer `page.goBack()` over hardcoded back-navigation URLs when possible
+This section previously read "use `try/catch` around interactions that may fail"
+and "log skipped steps with `console.log` rather than throwing". That guidance
+produced a suite in which nine tests could not fail and eight more reported green
+when the element under test had vanished. It is replaced by the following.
+
+**First decide whether the element is genuinely optional.** Most are not. The
+primary nav, its Blog and category links, the related-reading section and the
+more-from rail all exist on every build of this site. Assert them:
+
+```ts
+const blogLink = nav.getByRole('link', { name: 'Blog' });
+await expect(blogLink).toBeVisible();
+```
+
+**Never make a test's own subject conditional.** This is the anti-pattern:
+
+```ts
+// WRONG — if navigation breaks, this reports success.
+if (await blogLink.count() === 0) {
+  test.skip(true, 'Blog link not found');
+  return;
+}
+```
+
+`test.skip()` is legitimate only for a condition external to the thing under
+test — a viewport that does not render the feature, or a documented pending
+defect with an issue reference. It is never legitimate as a response to the
+element under test being absent.
+
+**For genuinely optional content**, iterate over what is present and assert the
+contract on each, so an empty set is visible in the test name rather than hidden
+inside a passing test:
+
+```ts
+for (const { path, name } of pages) {
+  test(`${name} does not scroll horizontally at 320px`, async ({ page }) => {
+    // one test per case — a missing case is a missing test, not a silent skip
+  });
+}
+```
+
+**`try/catch` may never convert a failure into a pass.** If you need cleanup, use
+`finally`. If an interaction is genuinely best-effort, it does not belong in a
+gating test.
+
+**Prefer `page.goBack()`** over hardcoded back-navigation URLs where possible.
+
+## Making failures actionable
+
+A failing assertion should say what broke, not just that something did. Pass a
+message, and where a check scans many elements, name the offender:
+
+```ts
+expect(scrollWidth, `widest offender: ${offender}`).toBeLessThanOrEqual(clientWidth + 1);
+expect(undersized, `undersized nav touch targets: ${undersized.join(', ')}`).toHaveLength(0);
+```
 
 ## Running Tests
 


### PR DESCRIPTION
Part 2 of the test-gate restructure specced in `SPEC.md`. Docs only.

## Why this file

`.github/instructions/tests.instructions.md` applies to `tests/**/*.spec.ts`, so every agent that writes a Playwright test reads it. Its "Defensive Patterns" section said:

> - Use `try/catch` around interactions that may fail on certain pages
> - Log skipped steps with `console.log(...)` rather than throwing

Followed literally across many sessions, that guidance produced **nine tests incapable of reporting a failure** and **eight more that reported green when the element under test had vanished** — the defect #1194 cleans up. Deleting those tests without fixing this file just rebuilds them next time an agent touches the suite.

## Changes

**New rule: "Every test must be able to fail"**, stated as outranking the rest of the file, with the forbidden shapes shown as code rather than described:

- `expect(count).toBeGreaterThanOrEqual(0)` — never negative, passes on any rendering
- ranges so wide no real regression falls outside them (`fontSize` between 8 and 50)
- `catch` blocks that increment a pass counter
- fallbacks that assert `body` is visible instead of the actual contract

Plus the standing rule: a failing test is fixed by fixing the product or retargeting the assertion at the new contract — **never** by widening the bound until it goes green.

**"Defensive Patterns" → "Handling optional elements."** Starts from the point the old section missed: most elements treated as optional are not optional. The primary nav, its Blog and category links, related-reading and the more-from rail exist on every build. `test.skip()` is now confined to conditions *external* to the thing under test — a viewport that does not render the feature, or a documented pending defect with an issue reference — and the anti-pattern is shown explicitly so it is recognisable.

**Touch-target example** no longer wraps its assertion in `if (box)`. A link that fails to lay out returns `null` there, so the documented form passed on exactly the breakage it exists to catch.

**New "Making failures actionable" section** — assertion messages that name the offending element.

## Relationship to #1194

#1194 removes the tests; this removes the instruction that produced them. Either can merge first. This one changes no code and cannot affect CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)