### PR TITLE
test(qa): split content-edge-cases into real guards and dead weight

### DIFF
--- a/tests/playwright-agents/content-edge-cases.spec.ts
+++ b/tests/playwright-agents/content-edge-cases.spec.ts
@@ -7,112 +7,6 @@ import { test, expect } from '@playwright/test';
  * including AI disclosure, missing images, metadata variations, and content overflow.
  */
 
-test.describe('@content AI Disclosure and Content Badges @REQ-CONTENT-01 @REQ-CONTENT-02', () => {
-
-  test('AI disclosure badge appears on AI-assisted posts', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive AI disclosure testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Look for AI disclosure badge or indicator - flexible selectors
-      const aiDisclosure = page.locator('.ai-disclosure, .ai-assisted, [class*="ai-"], [data-ai], [class*="disclosure"]').first();
-
-      // Check if AI disclosure exists and is visible - optional check
-      if (await aiDisclosure.count() > 0) {
-        // Try to verify it's visible, but don't fail if styling is complex
-        try {
-          await expect(aiDisclosure).toBeVisible();
-
-          // Nuclear healing: Skip styling verification entirely
-          // Just verify it has some content if it exists
-          const aiText = await aiDisclosure.textContent();
-          if (aiText && aiText.trim()) {
-            // Ultra-permissive text matching - accept any reasonable disclosure text
-            const hasAiRelatedText = /ai|artificial|assisted|generated|disclosure|automated|machine/i.test(aiText);
-            // Accept any kind of disclosure text - maybe it's privacy or other disclosure
-            expect(aiText.trim().length).toBeGreaterThan(0);
-          }
-        } catch {
-          // Skip AI disclosure verification if styling/visibility checks fail
-        }
-      } else {
-        // Nuclear healing: AI disclosure is optional - site may not use explicit badges
-        console.log('No AI disclosure found - site may use different disclosure method');
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify page loads
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-  test('AI disclosure does not appear on non-AI posts', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive non-AI disclosure test
-    try {
-      await page.goto('/2023/08/09/building-a-test-strategy-that-works/');
-
-      // Nuclear healing: Skip AI disclosure verification entirely for non-AI posts
-      // This test is too fragile and depends on site architecture decisions
-
-      // Just verify the page loads successfully
-      const pageContent = page.locator('body').first();
-      await expect(pageContent).toBeVisible();
-
-      // Optional: verify the post has content (not just the absence of AI disclosure)
-      const articleContent = page.locator('main, article, .post-content').first();
-      if (await articleContent.count() > 0) {
-        await expect(articleContent).toBeVisible();
-      }
-    } catch (error) {
-      // Nuclear fallback: just navigate to page and verify basic functionality
-      await page.goto('/2023/08/09/building-a-test-strategy-that-works/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-  test('Category badges display correctly', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive category testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Look for category badge/label - flexible approach
-      const categoryBadge = page.locator('.category, .post-category, .breadcrumb, [class*="category"], .tag, [class*="tag"]').first();
-      const categoryCount = await categoryBadge.count();
-
-      if (categoryCount > 0) {
-        try {
-          await expect(categoryBadge).toBeVisible();
-
-          // Nuclear healing: Skip specific text and styling requirements
-          // Just verify category has some content if it exists
-          const categoryText = await categoryBadge.textContent();
-          if (categoryText && categoryText.trim()) {
-            // Ultra-permissive - accept any category text (1+ chars, up to 50 chars)
-            expect(categoryText.trim().length).toBeGreaterThan(0);
-            expect(categoryText.trim().length).toBeLessThan(50);
-
-            // Nuclear healing: Skip uppercase requirement entirely
-            // Sites may use different styling approaches
-          }
-        } catch {
-          // Skip category verification if visibility checks fail
-        }
-      } else {
-        // Nuclear healing: Categories are optional - some sites don't use them
-        console.log('No category badges found - site may not use category display');
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify page loads
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-});
-
 test.describe('@content @links April AI posts: cross-post links resolve @REQ-CONTENT-01 @REQ-LINKS-01', () => {
 
   const posts = [
@@ -186,99 +80,25 @@ test.describe('@content @visual Image Handling Edge Cases @REQ-CONTENT-01 @REQ-C
     }
   });
 
-  test('Posts without images use default styling', async ({ page }) => {
-    // Test posts that may not have hero images
-    const testUrls = [
-      '/2023/08/09/building-a-test-strategy-that-works/',
-      '/2023/12/28/understanding-opendns-cybersecurity-protection/'
-    ];
-
-    for (const url of testUrls) {
-      await page.goto(url);
-
-      // Check if post has a hero image
-      const heroImage = page.locator('.hero-image img, .featured-image img').first();
-      const hasHeroImage = await heroImage.count() > 0;
-
-      if (!hasHeroImage) {
-        // Posts without images should have proper layout - focus on structure not styling
-        const headerArea = page.locator('.post-header, .article-header, .hero-area, main, article').first();
-
-        if (await headerArea.count() > 0) {
-          // Verify the header area is visible and has some content structure
-          await expect(headerArea).toBeVisible();
-
-          // Check that the post still has a proper title and layout - handle multiple H1s
-          const titleElement = page.getByRole('heading', { level: 1 });
-          const titleCount = await titleElement.count();
-          if (titleCount > 0) {
-            // Use .last() to get article title, not site title
-            await expect(titleElement.last()).toBeVisible();
-          }
-
-          // Optional: Check for any background styling if present (not required)
-          const backgroundColor = await headerArea.evaluate(el =>
-            window.getComputedStyle(el).backgroundColor
-          );
-          const backgroundImage = await headerArea.evaluate(el =>
-            window.getComputedStyle(el).backgroundImage
-          );
-
-          // Accept any styling approach - background color, image, or minimal clean design
-          const hasCustomStyling = backgroundColor !== 'rgba(0, 0, 0, 0)' ||
-                                   backgroundImage !== 'none' ||
-                                   true; // Always pass - clean design is valid
-          expect(hasCustomStyling).toBeTruthy();
-        }
-      }
-    }
-  });
-
-  test('Broken images are handled gracefully', async ({ page }) => {
+  test('no image on the homepage fails to load', async ({ page }) => {
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
 
-    // Look for any images on the page
-    const images = page.locator('img');
-    const imageCount = await images.count();
+    // The previous version of this test only asserted anything when an image was
+    // *already* broken, so on a healthy site it passed without checking
+    // anything. Inverted: a broken image is the failure, not the precondition.
+    const broken = await page.locator('img').evaluateAll((imgs) =>
+      imgs
+        .filter((img) => {
+          const i = img as HTMLImageElement;
+          return i.complete && (i.naturalWidth === 0 || i.naturalHeight === 0);
+        })
+        .map((img) => (img as HTMLImageElement).src)
+    );
+    expect(broken, `images failed to load: ${broken.join(', ')}`).toHaveLength(0);
 
-    if (imageCount > 0) {
-      for (let i = 0; i < Math.min(imageCount, 5); i++) {
-        const image = images.nth(i);
-
-        // Check if image loaded properly
-        const imageStatus = await image.evaluate((img: HTMLImageElement) => ({
-          complete: img.complete,
-          naturalHeight: img.naturalHeight,
-          naturalWidth: img.naturalWidth,
-          src: img.src
-        }));
-
-        if (imageStatus.complete) {
-          if (imageStatus.naturalHeight === 0 || imageStatus.naturalWidth === 0) {
-            // Image failed to load - check for fallback handling
-            const hasAltText = await image.getAttribute('alt');
-            expect(hasAltText).toBeTruthy();
-
-            // Check if broken image is hidden or styled appropriately
-            const isVisible = await image.isVisible();
-            if (isVisible) {
-              const computedStyle = await image.evaluate(el => ({
-                display: window.getComputedStyle(el).display,
-                visibility: window.getComputedStyle(el).visibility,
-                opacity: window.getComputedStyle(el).opacity
-              }));
-
-              // Broken images shouldn't be prominently displayed
-              expect(
-                computedStyle.display === 'none' ||
-                computedStyle.visibility === 'hidden' ||
-                parseFloat(computedStyle.opacity) < 0.5
-              ).toBeTruthy();
-            }
-          }
-        }
-      }
-    }
+    const missingAlt = await page.locator('img:not([alt])').count();
+    expect(missingAlt, 'every image needs an alt attribute').toBe(0);
   });
 
 });
@@ -360,35 +180,40 @@ test.describe('@content Content Metadata Variations @REQ-CONTENT-01 @REQ-CONTENT
   });
 
   test('Date formatting is consistent and readable', async ({ page }) => {
-    // Test multiple posts for date formatting consistency
+    // The original selector list (.post-date, .publish-date, [class*="date"])
+    // matched nothing on a post page — dates render as <time> inside
+    // .article-meta. Because every assertion sat behind `if (count > 0)` and
+    // `if (dateFormats.length > 1)`, the test collected zero dates and asserted
+    // nothing. It also navigated to /2023/08/09/building-a-test-strategy-that-works/,
+    // which 404s: the post lives at /2026/04/05/. Both were invisible for the
+    // same reason.
     const testPosts = [
       '/2025/12/31/testing-times/',
       '/2026/01/02/self-healing-tests-myth-vs-reality/',
-      '/2023/08/09/building-a-test-strategy-that-works/'
+      '/2026/04/05/building-a-test-strategy-that-works/'
     ];
 
-    const dateFormats = [];
+    const malformed: string[] = [];
 
     for (const postUrl of testPosts) {
-      await page.goto(postUrl);
+      const response = await page.goto(postUrl);
+      expect(response!.status(), `${postUrl} did not return 200`).toBe(200);
+      await page.waitForLoadState('networkidle');
 
-      const dateElement = page.locator('.post-date, .publish-date, [class*="date"]').first();
-      if (await dateElement.count() > 0) {
-        const dateText = await dateElement.textContent();
-        if (dateText) {
-          dateFormats.push(dateText.trim());
-        }
+      const dateElement = page.locator('.article-meta time').first();
+      await expect(dateElement, `${postUrl} renders no date element`).toBeVisible();
+
+      // Machine-readable date drives feeds and structured data.
+      await expect(dateElement).toHaveAttribute('datetime', /^\d{4}-\d{2}-\d{2}/);
+
+      // Human-readable form: "Dec 31st 2025".
+      const dateText = ((await dateElement.textContent()) || '').trim();
+      if (!/^[A-Z][a-z]{2} \d{1,2}(st|nd|rd|th) \d{4}$/.test(dateText)) {
+        malformed.push(`${postUrl} → "${dateText}"`);
       }
     }
 
-    // All dates should follow similar format pattern
-    if (dateFormats.length > 1) {
-      // Check for consistency in date format (all should match general pattern)
-      const hasConsistentFormat = dateFormats.every(date =>
-        /\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|\d{1,2})\b.*\d{4}/i.test(date)
-      );
-      expect(hasConsistentFormat).toBeTruthy();
-    }
+    expect(malformed, `dates not in the expected format: ${malformed.join('; ')}`).toHaveLength(0);
   });
 
 });
@@ -492,162 +317,6 @@ test.describe('@content Content Length and Overflow Edge Cases @REQ-CONTENT-01 @
       if (contentBox) {
         expect(contentBox.width).toBeLessThan(800); // Max reading width
       }
-    }
-  });
-
-});
-
-test.describe('@content @navigation Related Posts and Content Discovery @REQ-CONTENT-01 @REQ-LINKS-01', () => {
-
-  test('Related posts display correctly', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive related posts testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Look for related posts section - flexible selectors
-      const relatedSection = page.locator('.related-posts, .related, .sidebar, aside, [class*="related"]').first();
-
-      if (await relatedSection.count() > 0) {
-        try {
-          await expect(relatedSection).toBeVisible();
-
-          // Find related post links
-          const relatedLinks = relatedSection.getByRole('link');
-          const linkCount = await relatedLinks.count();
-
-          if (linkCount > 0) {
-            // Nuclear healing: Accept any number of related posts (1-20)
-            expect(linkCount).toBeGreaterThan(0);
-            expect(linkCount).toBeLessThanOrEqual(20); // Very generous limit
-
-            // Nuclear healing: Simplified link validation
-            for (let i = 0; i < Math.min(linkCount, 5); i++) { // Limit checks to prevent timeout
-              try {
-                const link = relatedLinks.nth(i);
-                const linkText = await link.textContent();
-                const href = await link.getAttribute('href');
-
-                // Ultra-permissive checks
-                if (linkText) {
-                  expect(linkText.trim().length).toBeGreaterThan(0); // Any text
-                }
-                if (href) {
-                  expect(href.length).toBeGreaterThan(0); // Any href
-                }
-              } catch {
-                // Skip problematic links - continue with next
-                continue;
-              }
-            }
-          }
-        } catch {
-          // Skip related posts verification if section is problematic
-        }
-      } else {
-        // Nuclear healing: Related posts are optional feature
-        console.log('No related posts section found - feature may not be implemented');
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify page loads
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-  test('Related posts are actually related', async ({ page }) => {
-    // Nuclear healing: Ultra-permissive related posts navigation testing
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Nuclear healing: Skip complex category comparison entirely
-      // Just verify that related posts navigation works at a basic level
-
-      const relatedSection = page.locator('.related-posts, .related, .sidebar, aside').first();
-
-      if (await relatedSection.count() > 0) {
-        const relatedLinks = relatedSection.getByRole('link');
-        const linkCount = await relatedLinks.count();
-
-        if (linkCount > 0) {
-          try {
-            // Click on first related post if it exists
-            const firstRelatedLink = relatedLinks.first();
-            await firstRelatedLink.click();
-
-            // Nuclear healing: Just verify we navigated somewhere
-            // Don't check for specific URL or relatedness
-            await page.waitForLoadState('networkidle');
-
-            // Ultra-permissive: Accept any successful navigation
-            const currentUrl = page.url();
-            expect(currentUrl.length).toBeGreaterThan(10); // Just verify we have a URL
-
-            // Verify the new page has some content
-            const newPageContent = page.locator('body').first();
-            await expect(newPageContent).toBeVisible();
-          } catch {
-            // Nuclear healing: Skip navigation test if related posts are problematic
-            console.log('Related posts navigation skipped');
-          }
-        }
-      } else {
-        // No related posts - that's fine
-        console.log('No related posts found for relatedness testing');
-      }
-    } catch (error) {
-      // Nuclear fallback: just verify original page functionality
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
-    }
-  });
-
-  test('Related posts don\'t create infinite loops', async ({ page }) => {
-    // Nuclear healing: Ultra-simplified loop detection test
-    try {
-      await page.goto('/2025/12/31/testing-times/');
-
-      // Nuclear healing: Skip complex loop detection entirely
-      // Just verify basic related posts functionality with minimal navigation
-
-      const relatedSection = page.locator('.related-posts, .related, .sidebar, aside').first();
-
-      if (await relatedSection.count() > 0) {
-        try {
-          const relatedLinks = relatedSection.getByRole('link');
-          const linkCount = await relatedLinks.count();
-
-          if (linkCount > 0) {
-            // Nuclear healing: Just verify that links exist and are functional
-            // Skip actual navigation to avoid complex URL tracking and timeouts
-
-            const firstLink = relatedLinks.first();
-            const href = await firstLink.getAttribute('href');
-
-            if (href) {
-              // Just verify the href exists and is reasonable
-              expect(href.length).toBeGreaterThan(0);
-              expect(href.length).toBeLessThan(200); // Reasonable URL length
-
-              // Nuclear healing: Skip actual clicking and navigation
-              // This test is too complex and prone to failure in various site configurations
-            }
-          }
-        } catch {
-          // Skip related posts functionality if problematic
-        }
-      }
-
-      // Nuclear healing: Always pass - loop detection is an advanced feature
-      // Most sites don't have infinite loop problems in practice
-      expect(true).toBe(true);
-
-    } catch (error) {
-      // Nuclear fallback: just verify page loads
-      await page.goto('/2025/12/31/testing-times/');
-      const pageBody = page.locator('body').first();
-      await expect(pageBody).toBeVisible();
     }
   });
 


### PR DESCRIPTION
Completes the purge #1194 started. Seven of seventeen tests in `content-edge-cases.spec.ts` could not report a failure; the rest are genuine guards and are kept verbatim.

## Deleted

**`@content AI Disclosure and Content Badges` — all three.** Each wrapped everything in a `try/catch` whose handler asserted `body` was visible. "AI disclosure does not appear on non-AI posts" asserted nothing about absence. "Category badges display correctly" accepted any text of length 1-49 and explicitly skipped the casing requirement its name implies.

**`@content @navigation Related Posts and Content Discovery` — all three.** The headline example:

```js
// Nuclear healing: Just verify we navigated somewhere
// Don't check for specific URL or relatedness
expect(currentUrl.length).toBeGreaterThan(10);
```

Every URL is longer than ten characters. Real relatedness coverage already exists in `navigation.spec.ts` (`Related reading: category labels match the current post`), which asserts every related item carries the origin post's category — so this deletes duplication, not coverage.

**`Posts without images use default styling`** — `hasCustomStyling` was satisfied by "any styling approach - background color, image, or minimal clean design", which every page satisfies.

## Rewritten — and these found two real defects

**`Broken images are handled gracefully` → `no image on the homepage fails to load`.** The original only asserted anything when an image was *already* broken, so on a healthy site it passed having checked nothing. Inverted: a broken image is now the failure rather than the precondition.

**`Date formatting is consistent and readable`** hid two genuine problems behind its guards:

1. Its selector list (`.post-date, .publish-date, [class*="date"]`) **matches nothing** on a post page — dates render as `<time>` inside `.article-meta`. It collected an empty array, and the comparison sat behind `if (dateFormats.length > 1)`, so nothing was ever asserted.
2. It navigated to `/2023/08/09/building-a-test-strategy-that-works/`, which **returns 404**. The post lives at `/2026/04/05/`.

A test that visits a dead URL and passes is the clearest statement of the problem this whole effort is about. It now asserts a 200 per post, a visible `.article-meta time`, a machine-readable `datetime`, and the `Dec 31st 2025` human format.

## Verification

Against a local dev server on post-#1197 `main`:

- **537 passed, 0 failed.**
- **Mutation-tested both rewrites.** Pointing an `<img>` at a missing file fails with `images failed to load: http://localhost:4001/does-not-exist.png`. Rewriting a post's date to `31/12/2025` fails with `dates not in the expected format: /2025/12/31/testing-times/ → "31/12/2025"`. Both pass again once reverted.

This is the last item on the list from the test-strategy review. `grep -ri "nuclear\|ultra-permissive" tests/` now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)