### PR TITLE
fix(deps): clear the six npm advisories blocking the Security Audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5285,9 +5285,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## The repo is merge-blocked

`🔒 Security Audit` is one of the four **required** status checks, and it has been
failing on `main`'s dependency state. PR #1232 is already sitting at `BLOCKED`.
Every PR opened from here fails the same check until this lands.

The nightly went red on **2026-08-04 and 2026-08-05** on this alone — the
`🌙 Nightly Full Suite` job itself passed both nights.

## What changed

Two transitive bumps. `package.json` is untouched; the lockfile moves **6 lines**.

| Package | Path | Advisories |
|---|---|---|
| `ip-address` 10.2.0 → **10.4.0** | `@lhci/cli` → proxy-agent → socks-proxy-agent → socks | **[high]** [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) — Address4 decodes leading-zero octets as decimal while resolvers decode them as octal (SSRF / trust-boundary bypass), plus GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg |
| `undici` 6.27.0 → **6.28.0** | `pa11y-ci` → cheerio | [moderate] response desync via retry interceptor, CRLF injection via blob-like body `type`, cookie attribute injection |

**Both are dev-only CI tooling** — Lighthouse CI and pa11y. This is a static Jekyll
site; no npm code reaches production, so the practical exposure is to the CI runner,
not to readers.

No allowlist exception was needed, so `scripts/npm-audit-allowlist.json` stays empty
and nothing is deferred to a future review date.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run test:security` → *"No unreviewed advisories at or above moderate"*
- `npm run test:deps` → Puppeteer support floor still met
- **Both consumers exercised, not just version-checked.** A `--version` proves a
  package loads, not that its patched HTTP path works — so I ran `pa11y-ci` for real
  against a served build, which fetches and scans through the patched `undici`.

## One thing this PR does not fix

The nightly failed two nights running and **filed no issue**. The
"Open an issue on failure" step lives inside the `🌙 Nightly Full Suite` job with
`if: failure() && github.event_name == 'schedule'`, so it only fires when *that* job
fails — and it passed both nights. `🔒 Security Audit` broke in a sibling job the
notifier cannot see.

`test-quality.yml:347` states the intent in its own comment: *"A nightly failure
nobody sees is the same as no nightly."* The mechanism covers one job out of six.
**Follow-up PR, deliberately not bundled here** — this one should stay a revertable
lockfile bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)