### PR TITLE
docs: close out the session — commit project agent memory, record repo state

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -1,0 +1,4 @@
+- [Dead-CSS Deletion Review](review_dead_css_deletion.md) — verify with a compiled-CSS diff + generated `_site` grep, never a source grep alone
+- [Legacy Class Retention](review_legacy_class_retention.md) — a kept legacy class stacked on a modern one collides at equal specificity; source order decides
+- [Verify Defect Exists](feedback_verify_defect_exists.md) — confirm a "fix" branch's defect is actually on origin/main before crediting the diff; a test-only guard for an already-fixed bug is not a fix
+- [Responsive Image Include](pattern_responsive_image_include.md) — flag bare `<img src>` in page templates; should use responsive-image.html include for WebP + CLS handling

--- a/.claude/agent-memory/code-reviewer/feedback_verify_defect_exists.md
+++ b/.claude/agent-memory/code-reviewer/feedback_verify_defect_exists.md
@@ -1,0 +1,25 @@
+---
+name: verify-defect-exists
+description: Before crediting a "fix" branch, confirm the defect is actually present on origin/main — a test-only diff guarding an already-fixed bug is a regression guard, not a fix
+metadata:
+  type: feedback
+---
+
+When reviewing a branch framed as a single-defect fix, read the source on
+`origin/main` first and confirm the defect is actually present there before
+treating the diff as a fix.
+
+**Why:** A diff can look like a fix while resolving nothing. If the bug was
+already remediated on `main` (e.g. duplicate head SEO meta fixed by delegating
+title/description/canonical solely to `{% seo %}` in `_layouts/default.html`),
+a branch that adds only a guard test does NOT "fix the defect" — it is a forward
+regression guard. Such a test also will NOT fail on `origin/main` (it passes,
+because main is already clean), so it fails the "would fail on the old code"
+criterion for a fix-validating test even though it is otherwise a real,
+correctly-scoped guard (`toHaveCount(1)` without `.first()`).
+
+**How to apply:** For fix-branch reviews, separate two questions: (1) does the
+diff change behavior to resolve the bug? and (2) does any test demonstrate the
+bug pre-fix? A test-only diff against an already-clean main answers "no" to both.
+Approve it on its own merits as a regression guard if asked, but do not mark
+`fixes_defect` or treat a non-failing-on-old-code test as fix-validating.

--- a/.claude/agent-memory/code-reviewer/pattern_responsive_image_include.md
+++ b/.claude/agent-memory/code-reviewer/pattern_responsive_image_include.md
@@ -1,0 +1,12 @@
+---
+name: responsive-image-include
+description: New page/layout templates often emit raw <img src> instead of the responsive-image.html include, shipping multi-MB PNGs instead of WebP
+metadata:
+  type: feedback
+---
+
+When reviewing new or copied page templates / layouts that render post or hero images, check they route through `{% include responsive-image.html src=... alt=... %}` rather than a bare `<img src="{{ ... }}">`. The bare form bypasses the WebP `<source>` and the intrinsic width/height (CLS) handling, shipping multi-MB raw PNGs.
+
+**Why:** The include is the established precedent (used by `index.md`, `blog/index.html`, `_layouts/post.html`). Page templates authored independently (category/topic pages) drift back to raw `<img>` and silently regress page weight.
+
+**How to apply:** grep the diff for `<img src` in `.md`/`.html` page bodies; confirm a `.webp` sibling exists under `assets/images/` so the WebP `<source>` resolves; confirm the container CSS sizes the descendant `img` (e.g. `width:100%; object-fit:cover`) so the include's added intrinsic width/height attrs don't overflow. Related: [[verify-defect-exists]].

--- a/.claude/agent-memory/code-reviewer/review_dead_css_deletion.md
+++ b/.claude/agent-memory/code-reviewer/review_dead_css_deletion.md
@@ -1,0 +1,19 @@
+---
+name: review-dead-css-deletion
+description: How to verify a dead-CSS/dead-code deletion PR in this repo — compiled-CSS diff plus generated-_site grep, rather than trusting a source grep
+metadata:
+  type: feedback
+---
+
+For any PR that deletes "orphaned" CSS from `_sass/`, prove safety with **two build-based checks**, never a source-tree grep alone.
+
+**Why:** `_sass/` is Sass, not CSS — selectors can be composed via nesting, `@use`d across modules (`home-2026.scss` does `@use 'economist-theme' as theme`), and classes can be emitted by Liquid, includes, pagination, or kramdown attribute lists (`{: .foo}`) that a naive grep of `_layouts/` misses. A source grep also cannot tell you whether the *cascade* changed for rules that remain.
+
+**How to apply:**
+
+1. **Reachability** — `bundle exec jekyll build`, then grep the *generated* `_site/**/*.html` for each deleted class. This catches Liquid-generated and paginated markup. Note pagination multiplies a single source file into many outputs (`blog/index.html` → `_site/blog/page2..5/`), so a backlog note saying "used by one file" undercounts real usage.
+2. **Cascade** — build `main` and the branch, diff the two compiled `_site/assets/css/styles.css`. A **purely subtractive diff (lines removed, zero added or modified)** is proof that no surviving rule changed its properties, order, or media-query nesting. Any added/changed line means a rule was rehomed — e.g. a rule orphaned out of a media query that became empty.
+3. Also diff the compiled *selector sets* (`grep -oE '^[^{}]*\{'`, sort, `comm`) to confirm the removed set is exactly the intended dead families and nothing incidental.
+4. Remember there is a second stylesheet, `assets/css/custom.css`, outside the Sass pipeline — grep it too.
+
+Related: [[review-legacy-class-retention]]

--- a/.claude/agent-memory/code-reviewer/review_legacy_class_retention.md
+++ b/.claude/agent-memory/code-reviewer/review_legacy_class_retention.md
@@ -1,0 +1,18 @@
+---
+name: review-legacy-class-retention
+description: When a cleanup PR keeps one legacy class as an exception, check for equal-specificity source-order collisions with the modern component class on the same element
+metadata:
+  type: feedback
+---
+
+When a dead-code cleanup keeps **one** legacy class as a documented exception, always check whether that class sits on the *same element* as a modern component class, and diff their declaration blocks for overlapping properties.
+
+**Why:** In this repo, legacy and modern classes are routinely stacked on one element (e.g. `<nav class="econ-topic-browse home-intro-links">`). Two single-class selectors have **equal specificity (0,1,0)**, so source order alone decides the winner — and the legacy block usually sits *later* in `economist-theme.scss` because it was appended over time. A legacy `margin: 0` will therefore silently defeat the modern component's intended spacing. Retaining the class under a reassuring new band comment ("link styling for X") can bless that latent override as if it were deliberate design.
+
+**How to apply:**
+- List every rule targeting each class in the *compiled* CSS (`grep -n 'classA\|classB' styles.css`) and compare line numbers — later wins at equal specificity.
+- Flag any property declared in both blocks; ask whether the legacy value is intended or accidental.
+- Prefer folding the surviving declarations into the modern component class (or a real modifier) and dropping the legacy class from the markup, over keeping a historically-named class alive with an explanatory comment. A comment documents the confusion; it does not remove it.
+- Check the band comment actually describes *everything* the retained block does, not just the part the author cared about.
+
+Related: [[review-dead-css-deletion]]

--- a/.claude/agent-memory/security-auditor/MEMORY.md
+++ b/.claude/agent-memory/security-auditor/MEMORY.md
@@ -1,0 +1,2 @@
+- [Header Control Boundary](reference_header_control_boundary.md) — GitHub Pages hosting means CSP/HSTS findings are unfixable in-repo; don't report them as PR findings
+- [CSS Orphan Grep Antipattern](feedback_css_orphan_grep_antipattern.md) — prove a deleted class is dead via class-attribute matches in markup, not substring grep across docs

--- a/.claude/agent-memory/security-auditor/feedback_css_orphan_grep_antipattern.md
+++ b/.claude/agent-memory/security-auditor/feedback_css_orphan_grep_antipattern.md
@@ -1,0 +1,34 @@
+---
+name: css-orphan-grep-antipattern
+description: Verifying a deleted CSS class is orphaned requires matching class attributes in markup, not bare substring grep — repo prose is saturated with words like "homepage" and "scss"
+metadata:
+  type: feedback
+---
+
+When auditing a CSS/SCSS deletion, do not conclude "this class is still in use"
+from a bare substring grep of the class name across the repo.
+
+**Why:** This repo carries a very large docs/spec/tasks/skills surface
+(`docs/`, `specs/`, `tasks/archive/`, `.github/skills/`, `AGENTS.md`, plus a
+vendored `vendor/bundle/`). Generic tokens like `homepage`, `scss`, `main-content`
+match hundreds of lines of English prose, test *names*, and archived planning
+docs. During the PR #1203 audit a naive grep returned ~30 files for `homepage`
+and ~30 for `scss`, all prose, and one hit in `_includes/post-card.html` that
+turned out to be an HTML comment. This is the same shape as the substring-match
+label-grep antipattern closed by #987 — the failure mode recurs in new domains.
+
+**How to apply:**
+- Restrict to markup that can actually carry the class: `_layouts/`, `_includes/`,
+  `*.html`, and Liquid — and match the attribute form (`class="... foo ..."`),
+  not the bare token.
+- Exclude `_site/`, `vendor/`, `tasks/archive/`, and `docs/` from usage evidence;
+  they prove nothing about live rendering.
+- Check whether the deleted line was a *nested* rule or the standalone
+  definition. In #1203 `.meta-separator` appeared in the deleted hunk but only as
+  a rule nested inside a dead `.hero-post-meta` block; the real definition
+  survived and still styles `_layouts/post.html`. Grepping the deleted hunk alone
+  would have produced a false regression report.
+- Confirm the SCSS still brace-balances after a large deletion; an unbalanced
+  hunk is the one way a pure-deletion style PR can actually break the build.
+
+Related: [[header-control-boundary]]

--- a/.claude/agent-memory/security-auditor/reference_header_control_boundary.md
+++ b/.claude/agent-memory/security-auditor/reference_header_control_boundary.md
@@ -1,0 +1,28 @@
+---
+name: header-control-boundary
+description: Site is GitHub Pages (www.viney.ca) — no response-header control, so CSP/HSTS/X-Frame-Options findings are structurally unfixable in-repo; only meta-equiv CSP is available
+metadata:
+  type: reference
+---
+
+The blog deploys via `actions/deploy-pages` in `.github/workflows/jekyll.yml` to
+GitHub Pages, custom domain `www.viney.ca` (see `CNAME`).
+
+**Standing consequence:** GitHub Pages does not let you set custom HTTP response
+headers. There is no `_headers`, `netlify.toml`, `vercel.json`, or
+`staticwebapp.config.json` in this repo, and there never can be a useful one.
+As of the 2026-08-02 audit there is also no `<meta http-equiv="Content-Security-Policy">`
+anywhere in the layouts.
+
+**How to apply:**
+- Do NOT report "missing CSP / HSTS / X-Frame-Options / Referrer-Policy" as a
+  finding on ordinary PRs. It is a pre-existing platform boundary, not a
+  regression, and no PR touching content or styles can fix it. Reporting it
+  repeatedly is noise that trains the maintainer to skim audits.
+- The *only* in-repo lever is a `<meta http-equiv="Content-Security-Policy">` tag
+  in the head include. If a CSP is ever genuinely wanted, that is the one real
+  proposal to make — and it is a deliberate project, not an audit drive-by.
+- HSTS is served by GitHub Pages itself for custom domains with HTTPS enforced;
+  verify at the edge rather than looking for it in the repo.
+
+Related: [[css-orphan-grep-antipattern]]

--- a/.claude/agent-memory/test-engineer/MEMORY.md
+++ b/.claude/agent-memory/test-engineer/MEMORY.md
@@ -1,0 +1,4 @@
+# Test Engineer Memory
+
+- [Visual Gate Blind Spots](reference_visual_gate_blind_spots.md) — what "🖼️ 30/30 green" does not cover: the 769–1024px band, viewport-pinned listing pages, hidden `volatile` blocks
+- [Local Visual Verification Trap](reference_local_visual_verification_trap.md) — `_site` is shared; a second `jekyll serve` overwrites it and both ports serve the same build

--- a/.claude/agent-memory/test-engineer/reference_local_visual_verification_trap.md
+++ b/.claude/agent-memory/test-engineer/reference_local_visual_verification_trap.md
@@ -1,0 +1,27 @@
+---
+name: local-visual-verification-trap
+description: Jekyll's _site is shared across servers — a second `jekyll serve` on another port silently overwrites it, so an already-running server starts serving the new build
+metadata:
+  type: reference
+---
+
+`_site/` is a single shared build directory at the repo root. A `jekyll serve`
+on any port serves *that* directory and rebuilds into it.
+
+Consequence: if a server is already running on :4000 and you start a second one
+on :4010 to compare a branch against main, the second build overwrites `_site`
+and **:4000 immediately starts serving the branch too**. Both ports then return
+byte-identical CSS and the comparison silently reads as "no change".
+
+**Why:** hit this on 2026-08-02 comparing PR #1203's compiled `styles.css`
+against main. The two ports agreed perfectly — which looked like evidence and
+was actually the same file.
+
+**How to apply:** to compare two revisions' rendered output, build each in its
+own `git worktree` with an explicit `--destination` outside the repo, e.g.
+`git worktree add <tmp> origin/main` then
+`BUNDLE_GEMFILE=<repo>/Gemfile bundle exec jekyll build --destination <tmp>/_site_main`.
+Never rely on two ports off one checkout. Also rebuild `_site` at the end — a
+stray branch build left in place makes the next session's greps lie.
+
+Related: [[visual-gate-blind-spots]].

--- a/.claude/agent-memory/test-engineer/reference_visual_gate_blind_spots.md
+++ b/.claude/agent-memory/test-engineer/reference_visual_gate_blind_spots.md
@@ -1,0 +1,51 @@
+---
+name: visual-gate-blind-spots
+description: What the 30-capture Playwright visual-snapshot gate does NOT cover — pages, viewport bands, hidden selectors — measured 2026-08-02 against PR #1203
+metadata:
+  type: reference
+---
+
+The blocking pixel gate (`tests/playwright-agents/visual-snapshot.spec.ts`) is
+10 pages x 3 viewports = 30 captures. "🖼️ Visual Regression 30/30" is a much
+weaker signal than it reads as. Measured blind spots:
+
+**Viewport bands.** The three projects are Mobile 320x568, Tablet 768x1024,
+Desktop 1920x1080. So:
+- `≤600px` rules ARE exercised (Mobile is 320).
+- `769–1024px` rules are exercised by **nothing** — 768 falls below 769 and the
+  next project is 1920. Any `min-width: 769px` / `max-width: 1024px` band rule
+  has zero pixel coverage. (`bottom-nav.spec.ts` and `responsive.spec.ts` do use
+  1024x768, but as assertions, not snapshots.)
+- `1025–1919px` likewise has no pixel coverage.
+
+**Viewport-pinned pages.** 4 of the 10 pages carry `listing: true`
+(`blog-index`, and the three category pages), so they capture at viewport
+height, not full page — 12 of the 30 captures. Measured share of the page
+falling outside the capture: 45%–95%. Worst case `/test-automation/` at
+320x568 (12,429px tall, 95% uncovered); still 78% uncovered at 1920x1080.
+Footer, newsletter CTA and pagination controls on those four pages are never
+pixel-diffed.
+
+**Hidden-before-capture content.** `volatile` selectors are `display: none`-ed
+before the shot. On the homepage `.h26-news` removes 29–31% of the page at every
+viewport — the whole lead story and rail. Post pages hide `.related-list` and
+`.more-from-section`. Listing pages mask `.topic-grid`, so card interiors are
+never diffed.
+
+**Pages with zero pixel coverage at all** (they exist in the build and are
+served): `/blog/page2/`–`/blog/page5/` (which do carry live theme markup),
+`/dashboard/index.html`, `/dashboard/agents.html`, the two `/review/*` preview
+pages, and 23 of the 25 posts.
+
+**States with no coverage:** every `:hover`/`:focus`/`:active` rule (screenshots
+capture none), `/search/` with an actual query (results render client-side into
+a separate container; only the empty page is baselined), and the mobile nav in
+its open state. Print media is the exception — it *is* covered, by
+`interactive-elements.spec.ts` via `page.emulateMedia({ media: 'print' })`.
+
+**How to apply:** when asked whether CI green is enough for a CSS/layout change,
+check whether the change lands in one of these holes before answering. A theme
+change confined to a `769–1024px` band, a hover state, a listing page's
+below-the-fold region, or `.h26-news` can go green on all 30 captures while
+being visibly broken. See [[local-visual-verification-trap]] for how to render
+locally without fooling yourself.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -32,6 +32,36 @@ duplicate the queue.
 
 ---
 
+## Where to pick up (last updated 2026-08-09)
+
+Session closed to move machines. Nothing is in flight — working tree clean, no
+unpushed commits, no stashes.
+
+- **`main` is green and deployed.** Last deploy 2026-08-05 (#1235), production
+  smoke green. A GitHub Actions **major outage on 2026-08-06** (began 15:22 UTC,
+  Actions + Pages) cancelled every scheduled run at ~15 min while they sat queued
+  with no runner. Those failures are **not a repo regression** and self-healed —
+  all scheduled workflows green again as of 2026-08-09. Don't file defects for
+  that window.
+- **Open PRs:** four Dependabot bumps opened 2026-08-09 — [#1242](https://github.com/oviney/blog/pull/1242)
+  (jekyll-remote-theme 0.4.3→0.5.2, a **minor** bump, review before merging),
+  [#1243](https://github.com/oviney/blog/pull/1243) (json 2.20.0→2.21.2),
+  [#1244](https://github.com/oviney/blog/pull/1244) (@playwright/test 1.62.0→1.62.1),
+  [#1245](https://github.com/oviney/blog/pull/1245) (jekyll-include-cache 0.2.1→0.2.2).
+  Plus [#1232](https://github.com/oviney/blog/pull/1232) (dashboard data refresh,
+  automation) — `MERGEABLE` but **BEHIND**; needs a rebase.
+- **Issue noise is one problem, not 24.** 24 open `triage: stale skill file — *`
+  issues (P3, auto-filed 2026-08-03) plus P2 [#1206](https://github.com/oviney/blog/issues/1206)
+  are the same finding: skill files >90 days untouched. They will keep
+  regenerating until the files are refreshed or the audit's staleness threshold is
+  retuned. Decide which — don't work them one at a time.
+- **Top real P3s:** `tasks/` is publishing internal planning docs to production
+  (`viney.ca/tasks/…` returns 200) — needs an owner decision, `_config.yml` is
+  protected so no agent may fix it. Then `.featured-post` dead CSS and the
+  `.home-intro-links` margin collision.
+
+---
+
 ## Active (priority order)
 
 > **Epic — Agent evals & governance gap-closure** — **CLOSED 2026-06-13 at P1–P3.**


### PR DESCRIPTION
Session wrap-up so work can resume from a different machine. Two commits, split by concern.

## 1. Commit project-scoped subagent memory (recovering two lost files)

The three subagents configured with `memory: project` — code-reviewer, security-auditor, test-engineer — were writing to `.claude/agent-memory/`, which was **never tracked and never gitignored**. Project-scoped memory that lives in exactly one working copy isn't project-scoped; it evaporates on a machine switch.

Two code-reviewer memories existed **only** inside a June 28 stash (`stash@{0}`, untracked-files parent) and were one `git stash drop` from being lost:

- `feedback_verify_defect_exists.md` — confirm a "fix" branch's defect is actually present on `origin/main` before crediting the diff. A test-only guard for an already-fixed bug is a forward regression guard, not a fix, and won't fail on old code.
- `pattern_responsive_image_include.md` — flag bare `<img src>` in page templates; they bypass the `responsive-image.html` include's WebP `<source>` and intrinsic width/height (CLS) handling, shipping multi-MB raw PNGs.

Restored both and merged their pointers into the code-reviewer `MEMORY.md` index, which had drifted to list only the two later memories.

## 2. Record session state and the 2026-08-06 Actions outage

Adds a **"Where to pick up"** section to `docs/BACKLOG.md` so resume state lives in the repo rather than in one machine's local memory.

The headline entry: the wall of red scheduled-workflow runs on 2026-08-06 was a **GitHub Actions major outage** (began 15:22 UTC, hit Actions *and* Pages), **not a repo regression**. Jobs sat queued with `runner=null` and were cancelled at ~15 min without ever starting — which is precisely why they outran the orchestrator's own 10-minute `timeout-minutes`. Last green run was 15:31; the first failure was 16:13. All scheduled workflows are green again as of today. Documented so the next session doesn't re-diagnose it or file defects against that window.

Also captured: the four Dependabot PRs opened today (#1242 is a **minor** bump — jekyll-remote-theme 0.4.3→0.5.2 — so it wants a real look), #1232 needing a rebase, and the fact that the 24 `triage: stale skill file` issues plus P2 #1206 are **one recurring finding to decide once**, not 24 tasks.

## Verification

- `bundle exec jekyll build` green via the pre-commit hook.
- The 25 broken-internal-link warnings are **pre-existing and untouched by this PR** — they're already tracked as #1205.
- Scope: 12 files, under the 15-file cap. No protected or governance files touched. `.claude/` is a dotfile tree, so Jekyll excludes it from the published site by default — no production surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)