### PR TITLE
fix(deps): clear the js-yaml quadratic-CPU advisory blocking the Security Audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3451,9 +3451,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## The problem

`npm audit` reports **1 high-severity vulnerability** on `main`:

> **GHSA-5p4m-2wfm-xmqj** (CVE-2026-59870) — quadratic CPU consumption in js-yaml's `!!omap` resolution. Affects **4.0.0 – 4.3.0**.

`🔒 Security Audit` is a **required** check, so this blocks **every merge in the repo**, not just one PR. It's the recurring npm-audit-drift pattern (#819, #974, #981, #1018, #1170, #1234) — a new advisory landed against an unchanged dependency tree, four days after #1234 cleared the last batch.

Surfaced when it failed the Security Audit on an unrelated docs-only PR (#1246), which touches no dependencies at all.

## The fix

js-yaml is transitive — `@lhci/cli → @lhci/utils` and `pa11y-ci → puppeteer → cosmiconfig` — but floor-pinned by the `js-yaml: ^4.2.0` override in `package.json`.

That range **already admits the fix**. 4.3.1 is the backported patch on the 4.x line, so only the lockfile was holding 4.3.0 back. Two consequences worth stating, since they're what keeps this diff to three lines:

- **No `package.json` change is needed.** The override doesn't need raising; `^4.2.0` resolves to 4.3.1 on any fresh install.
- **The override stays on 4.x.** js-yaml's latest is 5.2.3, but jumping a major to fix a patch-level advisory would be unforced risk across the Lighthouse and pa11y toolchains.

Lockfile-only, one package: **4.3.0 → 4.3.1**.

## Verification

```
$ npm audit --audit-level=moderate    # before
1 high severity vulnerability

$ npm audit --audit-level=moderate    # after
found 0 vulnerabilities
```

`bundle exec jekyll build` green via the pre-commit hook. The diff is three lines in `package-lock.json` (version, resolved, integrity) and touches no other package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)